### PR TITLE
Fix deprecated loop syntax to for loops

### DIFF
--- a/src/cmark/block.mbt
+++ b/src/cmark/block.mbt
@@ -468,18 +468,23 @@ pub fn Table::new(
 fn Table::parse_sep_row(
   cs : ArrayView[(Inline, TableCellLayout)],
 ) -> Array[Node[TableSep]]? {
-  loop ([], cs) {
-    (acc, []) => Some(acc)
-    (acc, [(Text({ v, meta }), TableCellLayout(("", ""))), .. cs]) => {
-      guard !v.is_empty() else { None }
-      let max = v.length() - 1
-      let first_colon = v.code_unit_at(0) == ':'
-      let last_colon = v.code_unit_at(max) == ':'
-      let first = if first_colon { 1 } else { 0 }
-      let last = if last_colon { max - 1 } else { max }
-      for i in first..<=last {
-        guard v.code_unit_at(i) == '-' else { break None }
-      } nobreak {
+  let acc : Array[_] = []
+  for cs = cs {
+    match cs {
+      [] => break Some(acc)
+      [(Text({ v, meta }), TableCellLayout(("", ""))), .. cs] => {
+        guard !v.is_empty() else { break None }
+        let max = v.length() - 1
+        let first_colon = v.code_unit_at(0) == ':'
+        let last_colon = v.code_unit_at(max) == ':'
+        let first = if first_colon { 1 } else { 0 }
+        let last = if last_colon { max - 1 } else { max }
+        let all_dashes = for i in first..<=last {
+          guard v.code_unit_at(i) == '-' else { break false }
+        } nobreak {
+          true
+        }
+        guard all_dashes else { break None }
         let count = last - first + 1
         let sep = match (first_colon, last_colon) {
           (false, false) => None
@@ -488,9 +493,9 @@ fn Table::parse_sep_row(
           (false, true) => Some(Right)
         }
         acc.push({ v: (sep, count), meta })
-        continue (acc, cs)
+        continue cs
       }
+      _ => break None
     }
-    _ => None
   }
 }

--- a/src/cmark/block_struct.mbt
+++ b/src/cmark/block_struct.mbt
@@ -1572,24 +1572,27 @@ fn Parser::block_struct_to_table(
   rows : Array[(LineSpan, LineSpan)],
 ) -> Block {
   guard rows.last() is Some((last, _))
-  let (first, col_count, rows) = loop (0, false, [], rows[:]) {
-    (col_count, last_was_sep, acc, [.. rs, (row, blanks)]) => {
-      let meta = self.meta(self.text_loc_of_span(row))
-      let row1 = { ..row, first: row.first + 1, last: row.last }
-      let cols = self.parse_table_row(row1)
-      let col_count = @cmp.maximum(col_count, cols.length())
-      let (r, last_was_sep) = match Table::parse_sep_row(cols[:]) {
-        Some(seps) => ({ v: Sep(seps), meta }, true)
-        None => {
-          let v = if last_was_sep { Header(cols) } else { Data(cols) }
-          ({ v, meta }, false)
+  let acc : Array[_] = []
+  let (first, col_count, rows) = for col_count = 0, last_was_sep = false, rs = rows[:] {
+    match rs {
+      [.. rs, (row, blanks)] => {
+        let meta = self.meta(self.text_loc_of_span(row))
+        let row1 = { ..row, first: row.first + 1, last: row.last }
+        let cols = self.parse_table_row(row1)
+        let col_count = @cmp.maximum(col_count, cols.length())
+        let (r, last_was_sep) = match Table::parse_sep_row(cols[:]) {
+          Some(seps) => ({ v: Sep(seps), meta }, true)
+          None => {
+            let v = if last_was_sep { Header(cols) } else { Data(cols) }
+            ({ v, meta }, false)
+          }
         }
+        acc.push((r, self.layout_clean_raw_span1(blanks)))
+        guard rs.length() != 0 else { break (row, col_count, acc) }
+        continue col_count, last_was_sep, rs
       }
-      acc.push((r, self.layout_clean_raw_span1(blanks)))
-      guard rs.length() != 0 else { break (row, col_count, acc) }
-      continue (col_count, last_was_sep, acc, rs)
+      [] => abort("unreachable")
     }
-    (_, _, _, []) => abort("unreachable")
   }
   rows.rev_in_place()
   let meta = self.meta_of_spans(first~, last~)
@@ -1663,30 +1666,27 @@ fn Parser::block_struct_to_list_item(
   i : ListItemStruct,
 ) -> (Node[ListItem], Bool) {
   fn go(bstate : BState, tight, acc : Array[_], bs : ArrayView[BlockStruct]) {
-    loop (bstate, tight, acc, bs) {
-      (bstate, tight, acc, [BlankLine(_) as bl, .. bs]) => {
-        let bstate = if bstate == TrailBlank { TrailBlank } else { Blank }
-        acc.push(self.block_struct_to_block(bl))
-        continue (bstate, tight, acc, bs)
-      }
-      (
-        bstate,
-        _,
-        acc,
+    for bstate = bstate, tight = tight, bs = bs {
+      match bs {
+        [BlankLine(_) as bl, .. bs] => {
+          let bstate = if bstate == TrailBlank { TrailBlank } else { Blank }
+          acc.push(self.block_struct_to_block(bl))
+          continue bstate, tight, bs
+        }
         [
           List({ items: [.., { blocks: [.., BlankLine(_)], .. }], .. }) as l,
           .. bs,
-        ],
-      ) => {
-        acc.push(self.block_struct_to_block(l))
-        continue (bstate, false, acc, bs)
+        ] => {
+          acc.push(self.block_struct_to_block(l))
+          continue bstate, false, bs
+        }
+        [b, .. bs] => {
+          let tight = tight && bstate != Blank
+          acc.push(self.block_struct_to_block(b))
+          continue NonBlank, tight, bs
+        }
+        [] => break (tight, acc)
       }
-      (bstate, tight, acc, [b, .. bs]) => {
-        let tight = tight && bstate != Blank
-        acc.push(self.block_struct_to_block(b))
-        continue (NonBlank, tight, acc, bs)
-      }
-      (_, tight, acc, []) => (tight, acc)
     }
   }
 
@@ -1728,19 +1728,19 @@ fn Parser::block_struct_to_list_item(
 fn Parser::block_struct_to_list(self : Parser, list : ListBlockStruct) -> Block {
   let items = list.items
   let (first, tight) = self.block_struct_to_list_item(items[0])
-  let (tight, items) = loop (!list.loose && tight, [first], items[1:]) {
-    (tight, acc, []) => (tight, acc)
-    (tight, acc, [item, .. items]) => {
-      let (item, item_tight) = self.block_struct_to_list_item(item)
-      acc.push(item)
-      continue (tight && item_tight, acc, items)
+  let acc = [first]
+  let tight = for tight = !list.loose && tight, items = items[1:] {
+    match items {
+      [] => break tight
+      [item, .. items] => {
+        let (item, item_tight) = self.block_struct_to_list_item(item)
+        acc.push(item)
+        continue tight && item_tight, items
+      }
     }
   }
-  let meta = self.meta_of_metas(
-    first=first.meta,
-    last=items.last().unwrap().meta,
-  )
-  List({ v: { ty: list.list_type, tight, items }, meta })
+  let meta = self.meta_of_metas(first=first.meta, last=acc.last().unwrap().meta)
+  List({ v: { ty: list.list_type, tight, items: acc }, meta })
 }
 
 ///|

--- a/src/cmark_html/html.mbt
+++ b/src/cmark_html/html.mbt
@@ -616,21 +616,22 @@ fn item_block(tight~ : Bool, c : Context, b : @cmark.Block) -> Unit raise {
     (BlankLine(_), _) => ()
     (Paragraph({ v, .. }), true) => c.inline(v.inline)
     (Blocks({ v, .. }), _) =>
-      loop (c, true, v.to_array()[:], tight) {
-        (c, add_nl, [BlankLine(_), .. bs], tight) =>
-          continue (c, add_nl, bs, tight)
-        (c, _, [Paragraph({ v, .. }), .. bs], true as tight) => {
-          c.inline(v.inline)
-          continue (c, true, bs, tight)
-        }
-        (c, add_nl, [b, .. bs], tight) => {
-          if add_nl {
-            c.b.write_char('\n')
+      for add_nl = true, bs = v.to_array()[:] {
+        match (bs, tight) {
+          ([BlankLine(_), .. bs], _) => continue add_nl, bs
+          ([Paragraph({ v, .. }), .. bs], true) => {
+            c.inline(v.inline)
+            continue true, bs
           }
-          c.block(b)
-          continue (c, false, bs, tight)
+          ([b, .. bs], _) => {
+            if add_nl {
+              c.b.write_char('\n')
+            }
+            c.block(b)
+            continue false, bs
+          }
+          _ => break
         }
-        _ => ()
       }
     _ => {
       c.b.write_char('\n')


### PR DESCRIPTION
## Summary
- Convert 5 deprecated `loop (x, y) { ... }` constructs to the new `for x = ..., y = ... { match ... }` syntax
- Hoist mutable array accumulators out of loop state to avoid `unused_loop_variable` warnings
- Warnings reduced from 102 to 98 (0 errors, all 370 tests pass)

## Remaining warnings (98 total)

| Code | Count | Category | Trivially fixable? |
|------|-------|----------|--------------------|
| 27 | 77 | `derive(Show)` deprecated → `derive(Debug)` | **No** — changes public API surface (`.mbti` files), may break downstream consumers relying on `Show` impls |
| 23 | 20 | `unused_try`: try expression body never raises | **Yes** — remove redundant `try`/`catch` wrappers |
| 2 | 1 | Unused variable `i` in `html.mbt` | **Yes** — rename to `_` |

## Test plan
- [x] `moon check` — 0 errors, no `loop` syntax or `unused_loop_variable` warnings remain
- [x] `moon test` — all 370 tests pass
- [x] `moon fmt` and `moon info` produce no further changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbit-community/cmark.mbt/pull/113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
