### PR TITLE
Fix unused variable and deprecated loop warnings

### DIFF
--- a/src/cmark_html/html.mbt
+++ b/src/cmark_html/html.mbt
@@ -777,7 +777,7 @@ fn table(c : Context, t : @cmark.Table) -> Unit raise {
         cols(c, tag, [][:], count - 1, cs)
       }
       ([], []) =>
-        for i in 0..<count {
+        for _ in 0..<count {
           start(c, None, tag)
           close(c, tag)
         }


### PR DESCRIPTION
## Summary
- Fix unused variable `i` → `_` in `html.mbt`
- Follows #113 (deprecated loop syntax fixes)

## Note on `derive(Show)` warnings (77 remaining)

The `derive(Show) → derive(Debug)` migration is **not trivially fixable** because:
1. `derive(Debug)` does **not** provide the `Show` trait — they are separate traits
2. `inspect()` (used in 414 test calls) requires `Show`
3. Manual `impl Show for Meta/Tokens/Tight` depend on derived `Show` of field types
4. `Node[T]` lacks a `Debug` impl, so `derive(Debug)` fails on types containing `Node`

A proper migration requires either:
- Adding `impl Debug for Node[T]` and migrating `inspect()` calls to `@json.inspect()`
- Or waiting for upstream tooling to bridge `Debug` → `Show` automatically

## Test plan
- [x] `moon check` — 0 errors, 97 warnings (77 derive(Show) + 20 unused_try)
- [x] All 370 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbit-community/cmark.mbt/pull/114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
