### PR TITLE
Fix unused_try warnings across codebase

### DIFF
--- a/src/char/text.mbt
+++ b/src/char/text.mbt
@@ -89,7 +89,7 @@ pub fn utf_16_clean_raw(
   fn clean(last, first, dirty) {
     let flush = fn(last, start, k) {
       if start <= last {
-        buf.write_view(s[start:k] catch { _ => panic() })
+        buf.write_view(s[start:k])
       }
     }
     flush(last, first, dirty)
@@ -125,9 +125,7 @@ pub fn utf_16_clean_raw(
   fn check(last, first, k) {
     for k = k {
       break if k > last {
-        s[first:last + 1].to_string() catch {
-          _ => panic()
-        }
+        s[first:last + 1].to_string()
       } else if s.code_unit_at(k) == '\u{0}' {
         buf.reset()
         clean(last, first, k)
@@ -196,7 +194,7 @@ fn flush(
   k : Int,
 ) -> Unit {
   if start <= last {
-    buf.write_view(s[start:k] catch { _ => panic() })
+    buf.write_view(s[start:k])
   }
 }
 
@@ -275,7 +273,7 @@ fn _utf_16_clean_unesc_unref(
       }
       match s.code_unit_at(k) {
         ';' => {
-          let name = s[name_start:k].to_string() catch { _ => panic() }
+          let name = s[name_start:k].to_string()
           match html_named_entity(name) {
             None => return resolve(last, start, k + 1)
             Some(e) => {
@@ -374,9 +372,7 @@ fn _utf_16_clean_unesc_unref(
   let last = @cmp.minimum(last, max)
   let first = @cmp.maximum(first, 0)
   for k = first {
-    guard k <= last else {
-      break s[first:last + 1].to_string() catch { _ => panic() }
-    }
+    guard k <= last else { break s[first:last + 1].to_string() }
     match (s.code_unit_at(k), do_unesc) {
       ('\\', true) | ('&', _) | ('\u{0}', _) => {
         buf.reset()

--- a/src/cmark/block.mbt
+++ b/src/cmark/block.mbt
@@ -206,9 +206,9 @@ pub fn CodeBlock::language_of_info_string(s : String) -> (String, String)? {
     }
   }
   let rem_first = @cmark_base.first_non_blank(s, last=max, start=white)
-  let lang = s[0:white].to_string() catch { _ => panic() }
+  let lang = s[0:white].to_string()
   guard !lang.is_empty() else { None }
-  Some((lang, s[rem_first:max + 1].to_string() catch { _ => panic() }))
+  Some((lang, s[rem_first:max + 1].to_string()))
 }
 
 ///|

--- a/src/cmark/block_line.mbt
+++ b/src/cmark/block_line.mbt
@@ -81,17 +81,12 @@ fn BlockLine::flush_tight(
   }
   // On the first line the blanks are legit 
   if acc.is_empty() {
-    acc.push({
-      blanks: "",
-      node: { meta, v: s[start:last + 1].to_string() catch { _ => panic() } },
-    })
+    acc.push({ blanks: "", node: { meta, v: s[start:last + 1].to_string() } })
     return
   }
   let nb = @cmark_base.first_non_blank(s, last~, start~)
   acc.push({
-    blanks: s[start:nb].to_string() catch {
-      _ => panic()
-    },
-    node: { meta, v: s[nb:last + 1].to_string() catch { _ => panic() } },
+    blanks: s[start:nb].to_string(),
+    node: { meta, v: s[nb:last + 1].to_string() },
   })
 }

--- a/src/cmark/inline.mbt
+++ b/src/cmark/inline.mbt
@@ -333,7 +333,7 @@ pub fn InlineCodeSpan::code(self : InlineCodeSpan) -> String {
   let s = self.code_layout.iter().map(Tight::to_string).to_array().join(" ")
   guard s != "" else { "" }
   if s is [' ', .. mid, ' '] && !mid.iter().all(fn(it) { it == ' ' }) {
-    return s[1:s.length() - 1].to_string() catch { _ => panic() }
+    return s[1:s.length() - 1].to_string()
   }
   s
 }
@@ -431,7 +431,7 @@ pub fn InlineLink::is_unsafe(l : String) -> Bool {
       None => j
     }
     let allowed = ["image/gif", "image/png", "image/jpeg", "image/webp"]
-    allowed.contains(l[5:@cmp.minimum(j, k)].to_string() catch { _ => panic() })
+    allowed.contains(l[5:@cmp.minimum(j, k)].to_string())
   }
   let lower = @casefold.casefold(l)
   lower.has_prefix("javascript:") ||

--- a/src/cmark_base/leaf_blocks.mbt
+++ b/src/cmark_base/leaf_blocks.mbt
@@ -314,7 +314,7 @@ fn LineType::html_block_start_5(
 ) -> LineType {
   let next = start + 3 // 3 first chars checked
   let sub = "CDATA["
-  if start + 8 > last || !(s[next:].has_prefix(sub) catch { _ => panic() }) {
+  if start + 8 > last || !s[next:].has_prefix(sub) {
     return Nomatch
   }
   HtmlBlockLine(EndStr("]]>"))
@@ -410,9 +410,7 @@ pub fn LineType::html_block_start(
         }
         continue i + 1
       }
-      let tag = s[tag_first:tag_last + 1].to_string().to_lower() catch {
-          _ => panic()
-        }
+      let tag = s[tag_first:tag_last + 1].to_string().to_lower()
       let is_open_end = {
         let n = tag_last + 1
         n > last ||
@@ -422,10 +420,8 @@ pub fn LineType::html_block_start(
         // ' ' | '\t' | '>'
         | 62)
       }
-      let is_open_close_end = (is_open_end ||
-      (tag_last + 2 <= last && s[tag_last + 1:tag_last + 3] == "/>")) catch {
-        _ => panic()
-      }
+      let is_open_close_end = is_open_end ||
+        (tag_last + 2 <= last && s[tag_last + 1:tag_last + 3] == "/>")
       if c != '/' {
         if html_start_cond_1_set.contains(tag) && is_open_end {
           LineType::HtmlBlockLine(EndCond1) // 1
@@ -458,7 +454,7 @@ fn LineType::html_block_end_cond_1(
     }
     let next = k + 2
     let is_end_tag = {
-      let lower_s_sub = lower_s[next:] catch { _ => panic() }
+      let lower_s_sub = lower_s[next:]
       match s.code_unit_at(next) {
         'p' => lower_s_sub.has_prefix("pre>")
         's' =>

--- a/src/cmark_base/raw_html.mbt
+++ b/src/cmark_base/raw_html.mbt
@@ -305,7 +305,7 @@ fn[A] cdata_section(
   if start + 8 > line.last {
     return None
   }
-  if !(s[start + 3:].has_prefix("CDATA[") catch { _ => panic() }) {
+  if !s[start + 3:].has_prefix("CDATA[") {
     return None
   }
   let acc = []

--- a/src/cmark_html/html.mbt
+++ b/src/cmark_html/html.mbt
@@ -100,7 +100,7 @@ fn uid(c : Context, id : String) -> String {
 fn footnote_id(l : String) -> String {
   let res = StringBuilder::new()
   res.write_string("fn-")
-  let l = l[1:] catch { _ => panic() }
+  let l = l[1:]
   for c in l {
     res.write_char(
       match c {
@@ -174,7 +174,7 @@ fn buffer_add_html_escaped_string(b : StringBuilder, s : String) -> Unit {
   let max_idx = len - 1
   fn flush(b : StringBuilder, start : Int, i : Int) {
     if start < len {
-      b.write_view(s[start:i] catch { _ => panic() })
+      b.write_view(s[start:i])
     }
   }
 
@@ -257,7 +257,7 @@ fn buffer_add_pct_encoded_string(b : StringBuilder, s : String) -> Unit { // Per
 
   let flush = fn(b : StringBuilder, max : Int, start : Int, i : Int) -> Unit {
     if start <= max {
-      b.write_view(s[start:i] catch { _ => panic() })
+      b.write_view(s[start:i])
     }
   }
   let max = s.length() - 1


### PR DESCRIPTION
## Summary
- Removed 20 unused `catch { _ => panic() }` clauses across 7 files where the wrapped expressions (`s[a:b]`, `.to_string()`, `.has_prefix(...)`, etc.) no longer raise errors.
- No behavior changes — purely warning cleanup.

Files touched:
- `src/char/text.mbt` (5 sites)
- `src/cmark/block.mbt` (2 sites)
- `src/cmark/block_line.mbt` (3 sites)
- `src/cmark/inline.mbt` (2 sites)
- `src/cmark_base/leaf_blocks.mbt` (4 sites)
- `src/cmark_base/raw_html.mbt` (1 site)
- `src/cmark_html/html.mbt` (3 sites)

## Test plan
- [x] `moon check` — 0 `unused_try` warnings remain (down from 20)
- [x] `moon test` — all 370 tests pass
- [x] `moon fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbit-community/cmark.mbt/pull/116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
