### PR TITLE
Fix to_owned deprecation warnings on StringView slices

### DIFF
--- a/src/char/text.mbt
+++ b/src/char/text.mbt
@@ -125,7 +125,7 @@ pub fn utf_16_clean_raw(
   fn check(last, first, k) {
     for k = k {
       break if k > last {
-        s[first:last + 1].to_string()
+        s[first:last + 1].to_owned()
       } else if s.code_unit_at(k) == '\u{0}' {
         buf.reset()
         clean(last, first, k)
@@ -273,7 +273,7 @@ fn _utf_16_clean_unesc_unref(
       }
       match s.code_unit_at(k) {
         ';' => {
-          let name = s[name_start:k].to_string()
+          let name = s[name_start:k].to_owned()
           match html_named_entity(name) {
             None => return resolve(last, start, k + 1)
             Some(e) => {
@@ -372,7 +372,7 @@ fn _utf_16_clean_unesc_unref(
   let last = @cmp.minimum(last, max)
   let first = @cmp.maximum(first, 0)
   for k = first {
-    guard k <= last else { break s[first:last + 1].to_string() }
+    guard k <= last else { break s[first:last + 1].to_owned() }
     match (s.code_unit_at(k), do_unesc) {
       ('\\', true) | ('&', _) | ('\u{0}', _) => {
         buf.reset()

--- a/src/cmark/block.mbt
+++ b/src/cmark/block.mbt
@@ -206,9 +206,9 @@ pub fn CodeBlock::language_of_info_string(s : String) -> (String, String)? {
     }
   }
   let rem_first = @cmark_base.first_non_blank(s, last=max, start=white)
-  let lang = s[0:white].to_string()
+  let lang = s[0:white].to_owned()
   guard !lang.is_empty() else { None }
-  Some((lang, s[rem_first:max + 1].to_string()))
+  Some((lang, s[rem_first:max + 1].to_owned()))
 }
 
 ///|

--- a/src/cmark/block_line.mbt
+++ b/src/cmark/block_line.mbt
@@ -81,12 +81,12 @@ fn BlockLine::flush_tight(
   }
   // On the first line the blanks are legit 
   if acc.is_empty() {
-    acc.push({ blanks: "", node: { meta, v: s[start:last + 1].to_string() } })
+    acc.push({ blanks: "", node: { meta, v: s[start:last + 1].to_owned() } })
     return
   }
   let nb = @cmark_base.first_non_blank(s, last~, start~)
   acc.push({
-    blanks: s[start:nb].to_string(),
-    node: { meta, v: s[nb:last + 1].to_string() },
+    blanks: s[start:nb].to_owned(),
+    node: { meta, v: s[nb:last + 1].to_owned() },
   })
 }

--- a/src/cmark/inline.mbt
+++ b/src/cmark/inline.mbt
@@ -333,7 +333,7 @@ pub fn InlineCodeSpan::code(self : InlineCodeSpan) -> String {
   let s = self.code_layout.iter().map(Tight::to_string).to_array().join(" ")
   guard s != "" else { "" }
   if s is [' ', .. mid, ' '] && !mid.iter().all(fn(it) { it == ' ' }) {
-    return s[1:s.length() - 1].to_string()
+    return s[1:s.length() - 1].to_owned()
   }
   s
 }
@@ -431,7 +431,7 @@ pub fn InlineLink::is_unsafe(l : String) -> Bool {
       None => j
     }
     let allowed = ["image/gif", "image/png", "image/jpeg", "image/webp"]
-    allowed.contains(l[5:@cmp.minimum(j, k)].to_string())
+    allowed.contains(l[5:@cmp.minimum(j, k)].to_owned())
   }
   let lower = @casefold.casefold(l)
   lower.has_prefix("javascript:") ||

--- a/src/cmark_base/leaf_blocks.mbt
+++ b/src/cmark_base/leaf_blocks.mbt
@@ -410,7 +410,7 @@ pub fn LineType::html_block_start(
         }
         continue i + 1
       }
-      let tag = s[tag_first:tag_last + 1].to_string().to_lower()
+      let tag = s[tag_first:tag_last + 1].to_owned().to_lower()
       let is_open_end = {
         let n = tag_last + 1
         n > last ||


### PR DESCRIPTION
## Summary
- Replaces 11 deprecated `.to_string()` calls on `StringView` slices with `.to_owned()`, per the compiler's migration guidance: *"Use \`to_owned\` to allocate an owned String from a StringView; use \`Show::to_string\` or format strings for display."*
- No behavior change — pure rename of the allocation method.

Files touched:
- `src/char/text.mbt` (3 sites)
- `src/cmark/block.mbt` (2 sites)
- `src/cmark/block_line.mbt` (3 sites)
- `src/cmark/inline.mbt` (2 sites)
- `src/cmark_base/leaf_blocks.mbt` (1 site)

## Test plan
- [x] `moon check` — 0 `to_owned` deprecation warnings remain (down from 11; total 169 warnings, was 180)
- [x] `moon test` — all 370 tests pass
- [x] `moon fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbit-community/cmark.mbt/pull/118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
