### PR TITLE
Add nightly CI workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,62 @@
+name: nightly
+
+on:
+  schedule:
+    - cron: "0 6 * * *" # Daily at 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - name: ubuntu-latest
+          - name: macos-latest
+          - name: windows-latest
+
+    runs-on: ${{ matrix.os.name }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install nightly
+        if: ${{ matrix.os.name != 'windows-latest' }}
+        run: |
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s nightly
+          echo "$HOME/.moon/bin" >> $GITHUB_PATH
+
+      - name: install nightly on windows
+        if: ${{ matrix.os.name == 'windows-latest' }}
+        run: |
+          $env:MOONBIT_INSTALL_VERSION = "nightly"
+          Set-ExecutionPolicy RemoteSigned -Scope CurrentUser; irm https://cli.moonbitlang.com/install/powershell.ps1 | iex
+          "C:\Users\runneradmin\.moon\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
+
+      - name: moon version
+        run: |
+          moon version --all
+          moonrun --version
+
+      - name: moon check
+        run: |
+          moon update
+          moon check
+
+      - name: moon info and moon fmt
+        run: |
+          moon info
+          moon fmt
+          git diff --exit-code
+
+      - name: moon test
+        env:
+          OCAMLRUNPARAM: b
+        run: |
+          moon test --target wasm
+          moon test --target wasm --release
+          moon test --target wasm-gc
+          moon test --target wasm-gc --release
+          moon test --target js
+          moon test --target js --release
+          moon test --target native
+          moon test --target native --release


### PR DESCRIPTION
## Summary
Adds `.github/workflows/nightly.yml` running `moon check`, `moon fmt`, and `moon test` against the **nightly** MoonBit toolchain on Linux/macOS/Windows.

- Trigger: daily at 06:00 UTC + manual `workflow_dispatch`
- Does *not* run on `push`/`pull_request` so it cannot block normal contributions
- The existing `check.yml` continues using the default (stable) channel

### Why
Without this, regressions and deprecations in nightly only get noticed when someone tries to fix the warnings locally and then CI breaks (e.g. PR #118 ran into `Type StringView has no method to_owned` because the deprecation warning was emitted by a newer compiler than CI's stable). A daily nightly run gives early warning.

### How the version is selected
- `unix.sh nightly` — install script's positional arg
- `MOONBIT_INSTALL_VERSION=nightly` — same script's env var (used on Windows because `iex` doesn't take args)

## Test plan
- [ ] Manually trigger the workflow once via `gh workflow run nightly.yml` after merge to validate it runs end-to-end
- [ ] Verify `moon version --all` step prints a nightly-channel version

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbit-community/cmark.mbt/pull/119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
