### PR TITLE
Run nightly workflow on pull requests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: "0 6 * * *" # Daily at 06:00 UTC
   workflow_dispatch:
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
Adds the `pull_request:` trigger to `.github/workflows/nightly.yml` so the nightly toolchain is exercised on every PR, alongside the existing daily schedule and `workflow_dispatch`.

## Why
PR #118 was the motivating case: a `deprecated → use to_owned` warning from local nightly led to a fix whose replacement method (`StringView::to_owned`) didn't yet exist on the stable channel CI installs. The PR went red and there was no way to discover the toolchain mismatch from CI alone — you had to either wait for the daily nightly run or manually dispatch. Auto-running nightly on PRs closes that gap.

This PR itself will be the first end-to-end validation: when CI runs, you should see the `nightly` workflow appear alongside `check` and `bench`.

## Test plan
- [ ] Confirm three workflows fire on this PR: `check`, `bench`, `nightly`
- [ ] Confirm `nightly` runs `moon version --all` and reports a nightly-channel version
- [ ] Confirm `moon check`/`moon test` pass on nightly for current `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbit-community/cmark.mbt/pull/120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
