### PR TITLE
Migrate Show to Debug for debugging-only types

### DIFF
--- a/src/char/README.mbt.md
+++ b/src/char/README.mbt.md
@@ -9,9 +9,9 @@ Test if a character belongs to certain ASCII categories:
 ```mbt check
 ///|
 test "ascii classification" {
-  inspect(@char.is_ascii_whitespace(' '), content="true")
-  inspect(@char.is_ascii_punctuation('.'), content="true")
-  inspect(@char.is_ascii_control('\u{0}'), content="true")
+  debug_inspect(@char.is_ascii_whitespace(' '), content="true")
+  debug_inspect(@char.is_ascii_punctuation('.'), content="true")
+  debug_inspect(@char.is_ascii_control('\u{0}'), content="true")
 }
 ```
 
@@ -23,13 +23,23 @@ Convert between ASCII cases and get numeric values from ASCII digits:
 ///|
 test "ascii conversion" {
   // Case conversion
-  inspect(@char.to_ascii_upper('a'), content="A")
-  inspect(@char.to_ascii_lower('Z'), content="z")
+  debug_inspect(
+    @char.to_ascii_upper('a'),
+    content=(
+      #|'A'
+    ),
+  )
+  debug_inspect(
+    @char.to_ascii_lower('Z'),
+    content=(
+      #|'z'
+    ),
+  )
 
   // Numeric conversion
-  inspect(@char.ascii_digit_to_int('5'), content="5")
-  inspect(@char.ascii_hexdigit_to_int('A'), content="10")
-  inspect(@char.ascii_octdigit_to_int('7'), content="7")
+  debug_inspect(@char.ascii_digit_to_int('5'), content="5")
+  debug_inspect(@char.ascii_hexdigit_to_int('A'), content="10")
+  debug_inspect(@char.ascii_octdigit_to_int('7'), content="7")
 }
 ```
 
@@ -43,8 +53,8 @@ test "string char access" {
   let s = "Hello, 🐰"
 
   // Safe checked access
-  inspect(@char.at_checked(s, 0), content="Ok('H')")
-  inspect(@char.at_checked(s, 7), content="Ok('🐰')")
+  debug_inspect(@char.at_checked(s, 0), content="Ok('H')")
+  debug_inspect(@char.at_checked(s, 7), content="Ok('🐰')")
 }
 ```
 
@@ -58,10 +68,20 @@ test "string navigation" {
   let s = "Hello, 世界"
 
   // Navigate to next character
-  inspect(@char.next_char(s, last=0, after=7), content=" ")
+  debug_inspect(
+    @char.next_char(s, last=0, after=7),
+    content=(
+      #|' '
+    ),
+  )
 
   // Navigate to previous character
-  inspect(@char.prev_char(s, first=7, before=9), content="世")
+  debug_inspect(
+    @char.prev_char(s, first=7, before=9),
+    content=(
+      #|'世'
+    ),
+  )
 }
 ```
 
@@ -74,9 +94,9 @@ Query Unicode properties of characters:
 test "unicode properties" {
   // UTF encoding lengths
   let c = '🐰'.to_int()
-  inspect(@char.length_utf8(c), content="4")
-  inspect(@char.length_utf16(c), content="2")
-  inspect(@char.length_utf32(c), content="1")
+  debug_inspect(@char.length_utf8(c), content="4")
+  debug_inspect(@char.length_utf16(c), content="2")
+  debug_inspect(@char.length_utf32(c), content="1")
 }
 ```
 
@@ -89,7 +109,7 @@ Utilities for string manipulation and character handling:
 test "string processing" {
   // Substring inclusion check
   let text = "Hello, World!"
-  inspect(
+  debug_inspect(
     @char.sub_includes(affix="World", text, first=0, last=13),
     content="true",
   )
@@ -98,9 +118,19 @@ test "string processing" {
   let s = "&#xcab;&#XD800;"
   let buf = StringBuilder::new()
   let cleaned = @char.utf_16_clean_unref(buf, s, first=0, last=6)
-  inspect(cleaned, content="ಫ")
+  debug_inspect(
+    cleaned,
+    content=(
+      #|"ಫ"
+    ),
+  )
   let cleaned = @char.utf_16_clean_unref(buf, s, first=7, last=14)
-  inspect(cleaned, content="�")
+  debug_inspect(
+    cleaned,
+    content=(
+      #|"�"
+    ),
+  )
 }
 ```
 

--- a/src/char/ascii_test.mbt
+++ b/src/char/ascii_test.mbt
@@ -1,51 +1,91 @@
 ///|
 test "to_ascii_lower uppercase to lowercase" {
-  inspect(@char.to_ascii_lower('A'), content="a")
-  inspect(@char.to_ascii_lower('Z'), content="z")
-  inspect(@char.to_ascii_lower('M'), content="m")
+  debug_inspect(
+    @char.to_ascii_lower('A'),
+    content=(
+      #|'a'
+    ),
+  )
+  debug_inspect(
+    @char.to_ascii_lower('Z'),
+    content=(
+      #|'z'
+    ),
+  )
+  debug_inspect(
+    @char.to_ascii_lower('M'),
+    content=(
+      #|'m'
+    ),
+  )
 }
 
 ///|
 test "to_ascii_upper: convert lowercase to uppercase" {
-  inspect(@char.to_ascii_upper('a'), content="A")
-  inspect(@char.to_ascii_upper('z'), content="Z")
+  debug_inspect(
+    @char.to_ascii_upper('a'),
+    content=(
+      #|'A'
+    ),
+  )
+  debug_inspect(
+    @char.to_ascii_upper('z'),
+    content=(
+      #|'Z'
+    ),
+  )
 }
 
 ///|
 test "to_ascii_upper: keep uppercase unchanged" {
-  inspect(@char.to_ascii_upper('A'), content="A")
+  debug_inspect(
+    @char.to_ascii_upper('A'),
+    content=(
+      #|'A'
+    ),
+  )
 }
 
 ///|
 test "to_ascii_upper: keep non-letters unchanged" {
-  inspect(@char.to_ascii_upper('1'), content="1")
-  inspect(@char.to_ascii_upper('@'), content="@")
+  debug_inspect(
+    @char.to_ascii_upper('1'),
+    content=(
+      #|'1'
+    ),
+  )
+  debug_inspect(
+    @char.to_ascii_upper('@'),
+    content=(
+      #|'@'
+    ),
+  )
 }
 
 ///|
 test "is_ascii_graphic with graphic chars" {
   // Test with exclamation mark (first graphic char)
-  inspect(@char.is_ascii_graphic('!'), content="true")
+  debug_inspect(@char.is_ascii_graphic('!'), content="true")
   // Test with tilde (last graphic char)
-  inspect(@char.is_ascii_graphic('~'), content="true")
+  debug_inspect(@char.is_ascii_graphic('~'), content="true")
   // Test with some middle graphic chars
-  inspect(@char.is_ascii_graphic('A'), content="true")
-  inspect(@char.is_ascii_graphic('5'), content="true")
+  debug_inspect(@char.is_ascii_graphic('A'), content="true")
+  debug_inspect(@char.is_ascii_graphic('5'), content="true")
 }
 
 ///|
 test "is_ascii_graphic with non-graphic chars" {
   // Test with chars before '!'
-  inspect(@char.is_ascii_graphic(' '), content="false")
+  debug_inspect(@char.is_ascii_graphic(' '), content="false")
   // Test with chars after '~'
-  inspect(@char.is_ascii_graphic('\u007F'), content="false")
+  debug_inspect(@char.is_ascii_graphic('\u007F'), content="false")
 }
 
 ///|
 test "ascii_octdigit_to_int normal cases" {
-  inspect(@char.ascii_octdigit_to_int('0'), content="0")
-  inspect(@char.ascii_octdigit_to_int('3'), content="3")
-  inspect(@char.ascii_octdigit_to_int('7'), content="7")
+  debug_inspect(@char.ascii_octdigit_to_int('0'), content="0")
+  debug_inspect(@char.ascii_octdigit_to_int('3'), content="3")
+  debug_inspect(@char.ascii_octdigit_to_int('7'), content="7")
 }
 
 ///|

--- a/src/char/rune_test.mbt
+++ b/src/char/rune_test.mbt
@@ -1,16 +1,16 @@
 ///|
 test "length_utf8 with multibyte char 1" {
-  inspect(@char.length_utf8('¢'), content="2")
+  debug_inspect(@char.length_utf8('¢'), content="2")
 }
 
 ///|
 test "length_utf8 with multibyte char 2" {
-  inspect(@char.length_utf8('€'), content="3")
+  debug_inspect(@char.length_utf8('€'), content="3")
 }
 
 ///|
 test "length_utf8 with multibyte char 3" {
-  inspect(@char.length_utf8('🌍'), content="4")
+  debug_inspect(@char.length_utf8('🌍'), content="4")
 }
 
 ///|
@@ -21,5 +21,5 @@ test "panic length_utf8 with invalid char" {
 
 ///|
 test "length_utf32 returns 1" {
-  inspect(@char.length_utf32('A'), content="1")
+  debug_inspect(@char.length_utf32('A'), content="1")
 }

--- a/src/char/text_test.mbt
+++ b/src/char/text_test.mbt
@@ -2,9 +2,11 @@
 test "utf_16_clean_raw with padding" {
   let buf = StringBuilder::new()
   let s = "hello"
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_raw(pad=2, buf, s, first=0, last=4),
-    content="  hello",
+    content=(
+      #|"  hello"
+    ),
   )
 }
 
@@ -12,9 +14,11 @@ test "utf_16_clean_raw with padding" {
 test "utf_16_clean_raw without padding" {
   let buf = StringBuilder::new()
   let s = "hello"
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_raw(pad=0, buf, s, first=0, last=4),
-    content="hello",
+    content=(
+      #|"hello"
+    ),
   )
 }
 
@@ -22,25 +26,47 @@ test "utf_16_clean_raw without padding" {
 test "utf_16_clean_raw with empty string" {
   let buf = StringBuilder::new()
   let s = ""
-  inspect(@char.utf_16_clean_raw(pad=2, buf, s, first=0, last=0), content="  ")
-  inspect(@char.utf_16_clean_raw(pad=0, buf, s, first=0, last=0), content="")
+  debug_inspect(
+    @char.utf_16_clean_raw(pad=2, buf, s, first=0, last=0),
+    content=(
+      #|"  "
+    ),
+  )
+  debug_inspect(
+    @char.utf_16_clean_raw(pad=0, buf, s, first=0, last=0),
+    content=(
+      #|""
+    ),
+  )
 }
 
 ///|
 test "utf_16_clean_raw with invalid range" {
   let buf = StringBuilder::new()
   let s = "hello"
-  inspect(@char.utf_16_clean_raw(pad=0, buf, s, first=5, last=2), content="")
-  inspect(@char.utf_16_clean_raw(pad=2, buf, s, first=5, last=2), content="  ")
+  debug_inspect(
+    @char.utf_16_clean_raw(pad=0, buf, s, first=5, last=2),
+    content=(
+      #|""
+    ),
+  )
+  debug_inspect(
+    @char.utf_16_clean_raw(pad=2, buf, s, first=5, last=2),
+    content=(
+      #|"  "
+    ),
+  )
 }
 
 ///|
 test "utf_16_clean_raw with null character" {
   let buf = StringBuilder::new()
   let s = "hel\u{0}lo"
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_raw(pad=0, buf, s, first=0, last=5),
-    content="hel�lo",
+    content=(
+      #|"hel�lo"
+    ),
   )
 }
 
@@ -50,44 +76,62 @@ test "utf_16_clean_unref vs utf_16_clean_unesc_unref" {
   let buf = StringBuilder::new()
   let s = "a\\*b"
   // utf_16_clean_unref should not unescape
-  inspect(@char.utf_16_clean_unref(buf, s, first=0, last=3), content="a\\*b")
+  debug_inspect(
+    @char.utf_16_clean_unref(buf, s, first=0, last=3),
+    content=(
+      #|"a\\*b"
+    ),
+  )
   // utf_16_clean_unesc_unref should unescape
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, s, first=0, last=3),
-    content="a*b",
+    content=(
+      #|"a*b"
+    ),
   )
 }
 
 ///|
 test "try_entity_hex invalid" {
   let buf = StringBuilder::new(size_hint=0)
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, "&#xqq;", first=0, last=5),
-    content="&#xqq;",
+    content=(
+      #|"&#xqq;"
+    ),
   )
 }
 
 ///|
 test "try_entity_named empty" {
   let buf = StringBuilder::new(size_hint=0)
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, "&;", first=0, last=1),
-    content="&;",
+    content=(
+      #|"&;"
+    ),
   )
 }
 
 ///|
 test "resolve empty" {
   let buf = StringBuilder::new(size_hint=0)
-  inspect(@char.utf_16_clean_unesc_unref(buf, "", first=1, last=0), content="")
+  debug_inspect(
+    @char.utf_16_clean_unesc_unref(buf, "", first=1, last=0),
+    content=(
+      #|""
+    ),
+  )
 }
 
 ///|
 test "resolve escaped chars" {
   let buf = StringBuilder::new(size_hint=0)
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, "\\", first=0, last=0),
-    content="\\",
+    content=(
+      #|"\\"
+    ),
   )
 }
 
@@ -95,9 +139,11 @@ test "resolve escaped chars" {
 test "try_entity_named with incomplete entity" {
   let buf = StringBuilder::new(size_hint=0)
   let s = "&abc"
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, s, first=0, last=3),
-    content="&abc",
+    content=(
+      #|"&abc"
+    ),
   )
 }
 
@@ -105,9 +151,11 @@ test "try_entity_named with incomplete entity" {
 test "handling null character and non-ascii chars" {
   let buf = StringBuilder::new(size_hint=0)
   let s = "\u{0}\u{FF}"
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, s, first=0, last=1),
-    content="�ÿ",
+    content=(
+      #|"�ÿ"
+    ),
   )
 }
 
@@ -115,9 +163,11 @@ test "handling null character and non-ascii chars" {
 test "handling escape with non-punctuation" {
   let buf = StringBuilder::new(size_hint=0)
   let s = "\\a"
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, s, first=0, last=1),
-    content="\\a",
+    content=(
+      #|"\\a"
+    ),
   )
 }
 
@@ -125,9 +175,11 @@ test "handling escape with non-punctuation" {
 test "hex entity with invalid length" {
   let buf = StringBuilder::new()
   let s = "&#x123456789;" // Too long hex entity
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, s, first=0, last=11),
-    content="&#x123456789",
+    content=(
+      #|"&#x123456789"
+    ),
   )
 }
 
@@ -135,9 +187,11 @@ test "hex entity with invalid length" {
 test "hex entity with null char" {
   let buf = StringBuilder::new()
   let s = "&#x0;" // Represents null character
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, s, first=0, last=4),
-    content="�",
+    content=(
+      #|"�"
+    ),
   )
 }
 
@@ -146,9 +200,11 @@ test "non-ASCII valid UTF-16 sequence" {
   let buf = StringBuilder::new()
   // Valid UTF-16 sequence for a non-ASCII character
   let s = "a😀b"
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, s, first=0, last=3),
-    content="a😀b",
+    content=(
+      #|"a😀b"
+    ),
   )
 }
 
@@ -156,16 +212,23 @@ test "non-ASCII valid UTF-16 sequence" {
 test "decimal entity reference" {
   let buf = StringBuilder::new()
   let s = "&#65;" // Decimal for 'A'
-  inspect(@char.utf_16_clean_unesc_unref(buf, s, first=0, last=4), content="A")
+  debug_inspect(
+    @char.utf_16_clean_unesc_unref(buf, s, first=0, last=4),
+    content=(
+      #|"A"
+    ),
+  )
 }
 
 ///|
 test "invalid decimal entity reference" {
   let buf = StringBuilder::new()
   let s = "&#a;" // Not a valid decimal
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, s, first=0, last=3),
-    content="&#a;",
+    content=(
+      #|"&#a;"
+    ),
   )
 }
 
@@ -173,9 +236,11 @@ test "invalid decimal entity reference" {
 test "empty decimal entity reference" {
   let buf = StringBuilder::new()
   let s = "&#;" // Empty decimal reference
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, s, first=0, last=2),
-    content="&#;",
+    content=(
+      #|"&#;"
+    ),
   )
 }
 
@@ -183,9 +248,11 @@ test "empty decimal entity reference" {
 test "decimal entity reference too long" {
   let buf = StringBuilder::new()
   let s = "&#12345678;" // Too long decimal entity
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, s, first=0, last=10),
-    content="&#12345678;",
+    content=(
+      #|"&#12345678;"
+    ),
   )
 }
 
@@ -193,16 +260,23 @@ test "decimal entity reference too long" {
 test "try_entity_named with valid entity" {
   let buf = StringBuilder::new()
   let s = "&amp;" // HTML entity for '&'
-  inspect(@char.utf_16_clean_unesc_unref(buf, s, first=0, last=4), content="&")
+  debug_inspect(
+    @char.utf_16_clean_unesc_unref(buf, s, first=0, last=4),
+    content=(
+      #|"&"
+    ),
+  )
 }
 
 ///|
 test "try_entity_named with non-alphabetic character" {
   let buf = StringBuilder::new()
   let s = "&123;"
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, s, first=0, last=4),
-    content="&123;",
+    content=(
+      #|"&123;"
+    ),
   )
 }
 
@@ -210,8 +284,14 @@ test "try_entity_named with non-alphabetic character" {
 test "at_checked valid character" {
   let s = "hello"
   match @char.at_checked(s, 0) {
-    Ok(c) => inspect(c.to_string(), content="h")
-    Err(_) => inspect("Should not reach here", content="")
+    Ok(c) =>
+      debug_inspect(
+        c.to_string(),
+        content=(
+          #|"h"
+        ),
+      )
+    Err(_) => debug_inspect("Should not reach here", content="")
   }
 }
 
@@ -220,15 +300,21 @@ test "at_checked with boundary" {
   let s = "hello"
   // Check if it handles index at the boundary correctly
   match @char.at_checked(s, 4) {
-    Ok(c) => inspect(c.to_string(), content="o")
-    Err(_) => inspect("Should not reach here", content="")
+    Ok(c) =>
+      debug_inspect(
+        c.to_string(),
+        content=(
+          #|"o"
+        ),
+      )
+    Err(_) => debug_inspect("Should not reach here", content="")
   }
 }
 
 ///|
 test "at_checked with invalid utf16 surrogate" {
   let s = "👋"
-  inspect(@char.at_checked(s, 1), content="Err(56395)")
+  debug_inspect(@char.at_checked(s, 1), content="Err(56395)")
 }
 
 ///|
@@ -236,9 +322,11 @@ test "entity_decimal with invalid continuation" {
   let buf = StringBuilder::new()
   // Test a decimal entity that has a non-digit character after '&#'
   let s = "&#a123;"
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, s, first=0, last=6),
-    content="&#a123;",
+    content=(
+      #|"&#a123;"
+    ),
   )
 }
 
@@ -247,9 +335,11 @@ test "entity_decimal with empty reference" {
   let buf = StringBuilder::new()
   // Test an empty decimal entity reference
   let s = "&#;"
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, s, first=0, last=2),
-    content="&#;",
+    content=(
+      #|"&#;"
+    ),
   )
 }
 
@@ -260,15 +350,17 @@ test "clean_unesc_unref with invalid utf16 sequence" {
 
   // Instead of trying to create an invalid UTF-16 character directly,
   // let's test the handling of the replacement character
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, "a\u{fffd}b", first=0, last=2),
-    content="a\u{fffd}b",
+    content=(
+      #|"a�b"
+    ),
   )
 }
 
 ///|
 test "sub_includes with matching at end" {
-  inspect(
+  debug_inspect(
     @char.sub_includes(affix="abc", "xxxabc", first=3, last=5),
     content="true",
   )
@@ -278,9 +370,11 @@ test "sub_includes with matching at end" {
 test "empty decimal entity reference (2)" {
   let buf = StringBuilder::new()
   let s = "&#;"
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, s, first=0, last=2),
-    content="&#;",
+    content=(
+      #|"&#;"
+    ),
   )
 }
 
@@ -288,9 +382,11 @@ test "empty decimal entity reference (2)" {
 test "non-digit in decimal entity reference" {
   let buf = StringBuilder::new()
   let s = "&#A;"
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, s, first=0, last=3),
-    content="&#A;",
+    content=(
+      #|"&#A;"
+    ),
   )
 }
 
@@ -298,16 +394,22 @@ test "non-digit in decimal entity reference" {
 test "at_checked valid character (2)" {
   let s = "hello"
   match @char.at_checked(s, 0) {
-    Ok(c) => inspect(c.to_string(), content="h")
-    Err(_) => inspect("Should not reach here", content="")
+    Ok(c) =>
+      debug_inspect(
+        c.to_string(),
+        content=(
+          #|"h"
+        ),
+      )
+    Err(_) => debug_inspect("Should not reach here", content="")
   }
 }
 
 ///|
 test "at_checked invalid character" {
   let s = "🌞"
-  inspect(@char.at_checked(s, 0), content="Ok('🌞')")
-  inspect(@char.at_checked(s, 1), content="Err(57118)")
+  debug_inspect(@char.at_checked(s, 0), content="Ok('🌞')")
+  debug_inspect(@char.at_checked(s, 1), content="Err(57118)")
 }
 
 ///|
@@ -316,11 +418,18 @@ test "utf_16_clean_unref vs utf_16_clean_unesc_unref (2)" {
   let buf = StringBuilder::new()
   let s = "a\\*b"
   // utf_16_clean_unref should not unescape
-  inspect(@char.utf_16_clean_unref(buf, s, first=0, last=3), content="a\\*b")
+  debug_inspect(
+    @char.utf_16_clean_unref(buf, s, first=0, last=3),
+    content=(
+      #|"a\\*b"
+    ),
+  )
   // utf_16_clean_unesc_unref should unescape
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, s, first=0, last=3),
-    content="a*b",
+    content=(
+      #|"a*b"
+    ),
   )
 }
 
@@ -328,16 +437,23 @@ test "utf_16_clean_unref vs utf_16_clean_unesc_unref (2)" {
 test "decimal entity reference (2)" {
   let buf = StringBuilder::new()
   let s = "&#65;" // Decimal for 'A'
-  inspect(@char.utf_16_clean_unesc_unref(buf, s, first=0, last=4), content="A")
+  debug_inspect(
+    @char.utf_16_clean_unesc_unref(buf, s, first=0, last=4),
+    content=(
+      #|"A"
+    ),
+  )
 }
 
 ///|
 test "invalid decimal entity reference (2)" {
   let buf = StringBuilder::new()
   let s = "&#a;" // Not a valid decimal
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, s, first=0, last=3),
-    content="&#a;",
+    content=(
+      #|"&#a;"
+    ),
   )
 }
 
@@ -345,9 +461,11 @@ test "invalid decimal entity reference (2)" {
 test "empty decimal entity reference (3)" {
   let buf = StringBuilder::new()
   let s = "&#;" // Empty decimal reference
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, s, first=0, last=2),
-    content="&#;",
+    content=(
+      #|"&#;"
+    ),
   )
 }
 
@@ -355,42 +473,55 @@ test "empty decimal entity reference (3)" {
 test "decimal entity reference too long (2)" {
   let buf = StringBuilder::new()
   let s = "&#12345678;" // Too long decimal entity
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, s, first=0, last=10),
-    content="&#12345678;",
+    content=(
+      #|"&#12345678;"
+    ),
   )
 }
 
 ///|
 test "try_entity_hex invalid (2)" {
   let buf = StringBuilder::new(size_hint=0)
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, "&#xqq;", first=0, last=5),
-    content="&#xqq;",
+    content=(
+      #|"&#xqq;"
+    ),
   )
 }
 
 ///|
 test "try_entity_named empty (2)" {
   let buf = StringBuilder::new(size_hint=0)
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, "&;", first=0, last=1),
-    content="&;",
+    content=(
+      #|"&;"
+    ),
   )
 }
 
 ///|
 test "resolve empty (2)" {
   let buf = StringBuilder::new(size_hint=0)
-  inspect(@char.utf_16_clean_unesc_unref(buf, "", first=1, last=0), content="")
+  debug_inspect(
+    @char.utf_16_clean_unesc_unref(buf, "", first=1, last=0),
+    content=(
+      #|""
+    ),
+  )
 }
 
 ///|
 test "resolve escaped chars (2)" {
   let buf = StringBuilder::new(size_hint=0)
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, "\\", first=0, last=0),
-    content="\\",
+    content=(
+      #|"\\"
+    ),
   )
 }
 
@@ -398,9 +529,11 @@ test "resolve escaped chars (2)" {
 test "try_entity_named with incomplete entity (2)" {
   let buf = StringBuilder::new(size_hint=0)
   let s = "&abc"
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, s, first=0, last=3),
-    content="&abc",
+    content=(
+      #|"&abc"
+    ),
   )
 }
 
@@ -408,9 +541,11 @@ test "try_entity_named with incomplete entity (2)" {
 test "handling null character and non-ascii chars (2)" {
   let buf = StringBuilder::new(size_hint=0)
   let s = "\u0000\u00FF"
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, s, first=0, last=1),
-    content="�ÿ",
+    content=(
+      #|"�ÿ"
+    ),
   )
 }
 
@@ -418,9 +553,11 @@ test "handling null character and non-ascii chars (2)" {
 test "handling escape with non-punctuation (2)" {
   let buf = StringBuilder::new(size_hint=0)
   let s = "\\a"
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, s, first=0, last=1),
-    content="\\a",
+    content=(
+      #|"\\a"
+    ),
   )
 }
 
@@ -428,9 +565,11 @@ test "handling escape with non-punctuation (2)" {
 test "hex entity with invalid length (2)" {
   let buf = StringBuilder::new()
   let s = "&#x123456789;" // Too long hex entity
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, s, first=0, last=11),
-    content="&#x123456789",
+    content=(
+      #|"&#x123456789"
+    ),
   )
 }
 
@@ -438,9 +577,11 @@ test "hex entity with invalid length (2)" {
 test "hex entity with null char (2)" {
   let buf = StringBuilder::new()
   let s = "&#x0;" // Represents null character
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, s, first=0, last=4),
-    content="�",
+    content=(
+      #|"�"
+    ),
   )
 }
 
@@ -449,9 +590,11 @@ test "non-ASCII valid UTF-16 sequence (2)" {
   let buf = StringBuilder::new()
   // Valid UTF-16 sequence for a non-ASCII character
   let s = "a😀b"
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, s, first=0, last=3),
-    content="a😀b",
+    content=(
+      #|"a😀b"
+    ),
   )
 }
 
@@ -459,27 +602,37 @@ test "non-ASCII valid UTF-16 sequence (2)" {
 test "try_entity_named with valid entity (2)" {
   let buf = StringBuilder::new()
   let s = "&amp;" // HTML entity for '&'
-  inspect(@char.utf_16_clean_unesc_unref(buf, s, first=0, last=4), content="&")
+  debug_inspect(
+    @char.utf_16_clean_unesc_unref(buf, s, first=0, last=4),
+    content=(
+      #|"&"
+    ),
+  )
 }
 
 ///|
 test "try_entity_named with non-alphabetic character (2)" {
   let buf = StringBuilder::new()
   let s = "&123;"
-  inspect(
+  debug_inspect(
     @char.utf_16_clean_unesc_unref(buf, s, first=0, last=4),
-    content="&123;",
+    content=(
+      #|"&123;"
+    ),
   )
 }
 
 ///|
 test "sub_includes empty string returns false" {
-  inspect(@char.sub_includes(affix="abc", "", first=0, last=0), content="false")
+  debug_inspect(
+    @char.sub_includes(affix="abc", "", first=0, last=0),
+    content="false",
+  )
 }
 
 ///|
 test "sub_includes longer affix returns false" {
-  inspect(
+  debug_inspect(
     @char.sub_includes(affix="abcdef", "abc", first=0, last=2),
     content="false",
   )
@@ -487,7 +640,7 @@ test "sub_includes longer affix returns false" {
 
 ///|
 test "sub_includes full match" {
-  inspect(
+  debug_inspect(
     @char.sub_includes(affix="abc", "zabc", first=1, last=4),
     content="true",
   )
@@ -495,7 +648,7 @@ test "sub_includes full match" {
 
 ///|
 test "sub_includes partial match" {
-  inspect(
+  debug_inspect(
     @char.sub_includes(affix="abc", "zabxc", first=1, last=5),
     content="false",
   )
@@ -503,7 +656,7 @@ test "sub_includes partial match" {
 
 ///|
 test "sub_includes no match" {
-  inspect(
+  debug_inspect(
     @char.sub_includes(affix="abc", "xyz", first=0, last=2),
     content="false",
   )
@@ -512,7 +665,7 @@ test "sub_includes no match" {
 ///|
 test "sub_includes repeated pattern match" {
   // Test the case where a partial match is found and then restarting from next position
-  inspect(
+  debug_inspect(
     @char.sub_includes(affix="abc", "abababc", first=0, last=6),
     content="true",
   )

--- a/src/cmark/alias.mbt
+++ b/src/cmark/alias.mbt
@@ -26,12 +26,7 @@ using @cmark_base {type Span}
 using @cmark_base {type LineSpan}
 
 ///|
-priv struct Tokens(@deque.Deque[Token])
-
-///|
-impl @debug.Debug for Tokens with to_repr(self) {
-  @debug.to_repr(self.0)
-}
+priv struct Tokens(@deque.Deque[Token]) derive(Debug)
 
 ///|
 impl ToJson for Tokens with to_json(self) {
@@ -55,12 +50,7 @@ fn Tokens::push(self : Tokens, t : Token) -> Unit {
 // }
 
 ///|
-priv struct RevTokens(@deque.Deque[Token])
-
-///|
-impl @debug.Debug for RevTokens with to_repr(self) {
-  @debug.to_repr(self.0)
-}
+priv struct RevTokens(@deque.Deque[Token]) derive(Debug)
 
 ///|
 impl ToJson for RevTokens with to_json(self) {

--- a/src/cmark/alias.mbt
+++ b/src/cmark/alias.mbt
@@ -29,8 +29,8 @@ using @cmark_base {type LineSpan}
 priv struct Tokens(@deque.Deque[Token])
 
 ///|
-impl Show for Tokens with output(self, logger) {
-  logger.write_object(self.0)
+impl @debug.Debug for Tokens with to_repr(self) {
+  @debug.to_repr(self.0)
 }
 
 ///|
@@ -40,8 +40,8 @@ impl ToJson for Tokens with to_json(self) {
 
 ///|
 test {
-  // Prevent warning about unused Show and ToJson
-  (fn(t : Tokens) { t.to_string() }) |> ignore()
+  // Prevent warning about unused Debug and ToJson
+  (fn(t : Tokens) { @debug.to_string(t) }) |> ignore()
   (fn(t : Tokens) { t.to_json() }) |> ignore()
 }
 
@@ -58,8 +58,8 @@ fn Tokens::push(self : Tokens, t : Token) -> Unit {
 priv struct RevTokens(@deque.Deque[Token])
 
 ///|
-impl Show for RevTokens with output(self, logger) {
-  logger.write_object(self.0)
+impl @debug.Debug for RevTokens with to_repr(self) {
+  @debug.to_repr(self.0)
 }
 
 ///|
@@ -69,8 +69,8 @@ impl ToJson for RevTokens with to_json(self) {
 
 ///|
 test {
-  // Prevent warning about unused Show and ToJson
-  (fn(t : RevTokens) { t.to_string() }) |> ignore()
+  // Prevent warning about unused Debug and ToJson
+  (fn(t : RevTokens) { @debug.to_string(t) }) |> ignore()
   (fn(t : RevTokens) { t.to_json() }) |> ignore()
 }
 

--- a/src/cmark/block.mbt
+++ b/src/cmark/block.mbt
@@ -14,7 +14,7 @@ pub(all) enum Block {
   ExtMathBlock(Node[CodeBlock])
   ExtTable(Node[Table])
   ExtFootnoteDefinition(Node[Footnote])
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 pub fn Block::empty() -> Block {
@@ -110,7 +110,7 @@ pub(all) struct BlockQuote {
   indent : Indent
   /// The quoted block.
   block : Block
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 pub fn BlockQuote::new(indent? : Int = 0, block : Block) -> BlockQuote {
@@ -137,20 +137,20 @@ pub(all) struct CodeBlock {
   layout : CodeBlockLayout
   info_string : StringNode?
   code : Seq[StringNode]
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 pub(all) enum CodeBlockLayout {
   Indented
   Fenced(CodeBlockFencedLayout)
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 pub(all) struct CodeBlockFencedLayout {
   indent : Indent
   opening_fence : StringNode
   closing_fence : StringNode?
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 pub fn CodeBlockFencedLayout::default() -> CodeBlockFencedLayout {
@@ -225,20 +225,20 @@ pub(all) struct BlockHeading {
   level : Int
   inline : Inline
   id : BlockHeadingId?
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 pub(all) enum BlockHeadingLayout {
   Atx(BlockHeadingAtxLayout)
   Setext(BlockHeadingSetextLayout)
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 pub(all) struct BlockHeadingAtxLayout {
   indent : Indent
   after_opening : Blanks
   closing : String
-} derive(Show, FromJson, ToJson)
+} derive(Debug, FromJson, ToJson)
 
 ///|
 pub fn BlockHeadingAtxLayout::default() -> BlockHeadingAtxLayout {
@@ -252,13 +252,13 @@ pub(all) struct BlockHeadingSetextLayout {
   underline_indent : Indent
   underline_count : Node[Count]
   underline_blanks : Blanks
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 pub(all) enum BlockHeadingId {
   Auto(String)
   Id(String)
-} derive(Show, FromJson, ToJson)
+} derive(Debug, FromJson, ToJson)
 
 ///|
 pub fn BlockHeading::new(
@@ -272,7 +272,7 @@ pub fn BlockHeading::new(
 
 ///|
 /// The type for [HTML blocks](https://spec.commonmark.org/0.30/#html-blocks).
-pub(all) struct HtmlBlock(Seq[StringNode]) derive(Show, ToJson)
+pub(all) struct HtmlBlock(Seq[StringNode]) derive(Debug, ToJson)
 
 ///|
 pub(all) struct ListItem {
@@ -281,7 +281,7 @@ pub(all) struct ListItem {
   after_marker : Indent
   block : Block
   ext_task_marker : Node[Char]?
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 pub type ListItemBlock = ListItem
@@ -331,7 +331,7 @@ pub(all) struct BlockList {
   ty : ListType
   tight : Bool
   items : Seq[Node[ListItem]]
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 pub fn BlockList::map_items(
@@ -352,7 +352,7 @@ pub(all) struct BlockParagraph {
   leading_indent : Indent
   inline : Inline
   trailing_blanks : Blanks
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 pub fn BlockParagraph::new(
@@ -368,7 +368,7 @@ pub fn BlockParagraph::new(
 pub(all) struct BlockThematicBreak {
   indent : Indent
   layout : String
-} derive(Show, FromJson, ToJson)
+} derive(Debug, FromJson, ToJson)
 
 ///|
 pub fn BlockThematicBreak::new(
@@ -386,7 +386,7 @@ pub(all) struct Footnote {
   label : Label
   defined_label : Label?
   block : Block
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 pub fn Footnote::new(
@@ -421,28 +421,28 @@ pub(all) struct Table {
   indent : Indent
   col_count : Count
   rows : Seq[(Node[TableRow], Blanks)]
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 pub(all) enum TableAlign {
   Left
   Center
   Right
-} derive(Show, FromJson, ToJson)
+} derive(Debug, FromJson, ToJson)
 
 ///|
 pub(all) enum TableRow {
   Header(Seq[(Inline, TableCellLayout)])
   Sep(Seq[Node[TableSep]])
   Data(Seq[(Inline, TableCellLayout)])
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
-pub(all) struct TableSep((TableAlign?, Count)) derive(Show, ToJson)
+pub(all) struct TableSep((TableAlign?, Count)) derive(Debug, ToJson)
 
 ///|
 pub(all) struct TableCellLayout((Blanks, Blanks)) derive (
-  Show,
+  Debug,
   ToJson,
   Eq,
   Compare,

--- a/src/cmark/block_line.mbt
+++ b/src/cmark/block_line.mbt
@@ -30,16 +30,11 @@ pub fn BlockLine::list_text_loc(ls : Seq[BlockLine]) -> TextLoc {
 pub(all) struct Tight {
   blanks : Blanks
   node : StringNode
-} derive(Eq, ToJson)
+} derive(Eq, Debug, ToJson)
 
 ///|
 pub fn Tight::empty(meta? : Meta = Meta::none()) -> Tight {
   { blanks: "", node: StringNode::empty(meta~) }
-}
-
-///|
-pub impl @debug.Debug for Tight with to_repr(self) {
-  @debug.to_repr(self.node.v)
 }
 
 ///|

--- a/src/cmark/block_line.mbt
+++ b/src/cmark/block_line.mbt
@@ -38,8 +38,8 @@ pub fn Tight::empty(meta? : Meta = Meta::none()) -> Tight {
 }
 
 ///|
-pub impl Show for Tight with output(self, logger) {
-  logger.write_object(self.node.v)
+pub impl @debug.Debug for Tight with to_repr(self) {
+  @debug.to_repr(self.node.v)
 }
 
 ///|

--- a/src/cmark/block_line_test.mbt
+++ b/src/cmark/block_line_test.mbt
@@ -1,7 +1,12 @@
 ///|
 test "Show for Tight outputs the node content" {
   let tight = @cmark.Tight::empty()
-  inspect(Show::to_string(tight), content="\"\"")
+  debug_inspect(
+    @debug.to_string(tight),
+    content=(
+      #|"\"\""
+    ),
+  )
 }
 
 ///|
@@ -9,16 +14,27 @@ test "BlockLine::to_string extracts the string value" {
   let meta = @cmark_base.Meta::none()
   let block_line : @cmark.BlockLine = { v: "Test string", meta }
   let result = block_line.to_string()
-  inspect(result, content="Test string")
+  debug_inspect(
+    result,
+    content=(
+      #|"Test string"
+    ),
+  )
 }
 
 ///|
 test "BlockLine::list_text_loc handles empty sequence" {
   let empty_seq = @cmark.Seq::empty()
-  inspect(
+  debug_inspect(
     @cmark.BlockLine::list_text_loc(empty_seq),
     content=(
-      #|{file: "-", first_ccode: -1, last_ccode: -1, first_line: LinePos(-1, -1), last_line: LinePos(-1, -1)}
+      #|{
+      #|  file: "-",
+      #|  first_ccode: -1,
+      #|  last_ccode: -1,
+      #|  first_line: LinePos(-1, -1),
+      #|  last_line: LinePos(-1, -1),
+      #|}
     ),
   )
 }
@@ -36,10 +52,16 @@ test "BlockLine::list_text_loc handles single element sequence" {
   let single_node : @cmark.BlockLine = { v: "hello", meta }
   let single_seq = @cmark.Seq::from_array([single_node])
   let result = @cmark.BlockLine::list_text_loc(single_seq)
-  inspect(
+  debug_inspect(
     result,
     content=(
-      #|{file: "-", first_ccode: 0, last_ccode: 5, first_line: LinePos(1, 0), last_line: LinePos(1, 5)}
+      #|{
+      #|  file: "-",
+      #|  first_ccode: 0,
+      #|  last_ccode: 5,
+      #|  first_line: LinePos(1, 0),
+      #|  last_line: LinePos(1, 5),
+      #|}
     ),
   )
 }
@@ -71,10 +93,16 @@ test "BlockLine::list_text_loc handles multiple element sequence" {
   let result = @cmark.BlockLine::list_text_loc(multi_seq)
 
   // Should span from first_ccode of first node to last_ccode of last node
-  inspect(
+  debug_inspect(
     result,
     content=(
-      #|{file: "-", first_ccode: 0, last_ccode: 11, first_line: LinePos(1, 0), last_line: LinePos(2, 5)}
+      #|{
+      #|  file: "-",
+      #|  first_ccode: 0,
+      #|  last_ccode: 11,
+      #|  first_line: LinePos(1, 0),
+      #|  last_line: LinePos(2, 5),
+      #|}
     ),
   )
 }
@@ -82,10 +110,16 @@ test "BlockLine::list_text_loc handles multiple element sequence" {
 ///|
 test "Tight::list_text_loc handles empty sequence" {
   let empty_seq = @cmark.Seq::empty()
-  inspect(
+  debug_inspect(
     @cmark.Tight::list_text_loc(empty_seq),
     content=(
-      #|{file: "-", first_ccode: -1, last_ccode: -1, first_line: LinePos(-1, -1), last_line: LinePos(-1, -1)}
+      #|{
+      #|  file: "-",
+      #|  first_ccode: -1,
+      #|  last_ccode: -1,
+      #|  first_line: LinePos(-1, -1),
+      #|  last_line: LinePos(-1, -1),
+      #|}
     ),
   )
 }
@@ -103,10 +137,16 @@ test "Tight::list_text_loc handles single element sequence" {
   let node : @cmark.StringNode = { v: "hello", meta }
   let t : @cmark.Tight = { blanks: "", node }
   let seq = @cmark.Seq::from_array([t])
-  inspect(
+  debug_inspect(
     @cmark.Tight::list_text_loc(seq),
     content=(
-      #|{file: "-", first_ccode: 0, last_ccode: 5, first_line: LinePos(1, 0), last_line: LinePos(1, 5)}
+      #|{
+      #|  file: "-",
+      #|  first_ccode: 0,
+      #|  last_ccode: 5,
+      #|  first_line: LinePos(1, 0),
+      #|  last_line: LinePos(1, 5),
+      #|}
     ),
   )
 }
@@ -137,10 +177,16 @@ test "Tight::list_text_loc handles multiple element sequence" {
   let node2 : @cmark.StringNode = { v: "world", meta: meta2 }
   let t2 : @cmark.Tight = { blanks: "  ", node: node2 }
   let seq = @cmark.Seq::from_array([t1, t2])
-  inspect(
+  debug_inspect(
     @cmark.Tight::list_text_loc(seq),
     content=(
-      #|{file: "-", first_ccode: 0, last_ccode: 11, first_line: LinePos(1, 0), last_line: LinePos(2, 5)}
+      #|{
+      #|  file: "-",
+      #|  first_ccode: 0,
+      #|  last_ccode: 11,
+      #|  first_line: LinePos(1, 0),
+      #|  last_line: LinePos(2, 5),
+      #|}
     ),
   )
 }

--- a/src/cmark/block_line_test.mbt
+++ b/src/cmark/block_line_test.mbt
@@ -4,7 +4,7 @@ test "Show for Tight outputs the node content" {
   debug_inspect(
     @debug.to_string(tight),
     content=(
-      #|"\"\""
+      #|"{\n  blanks: \"\",\n  node: {\n    v: \"\",\n    meta: {\n      id: 0,\n      loc: {\n        file: \"-\",\n        first_ccode: -1,\n        last_ccode: -1,\n        first_line: LinePos(-1, -1),\n        last_line: LinePos(-1, -1),\n      },\n      extra: None,\n    },\n  },\n}"
     ),
   )
 }

--- a/src/cmark/block_struct.mbt
+++ b/src/cmark/block_struct.mbt
@@ -135,7 +135,7 @@ priv struct IndentedCodeLine {
   pad : SpacePad
   code : LineSpan
   is_blank : Bool
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 priv struct Fence {
@@ -144,19 +144,19 @@ priv struct Fence {
   fence : (Char, Int) // Fence length
   info_string : LineSpan? // We drop the trailing blanks
   closing_fence : LineSpan?
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 priv struct FenceCodeBlockStruct {
   fence : Fence
   code : Array[(SpacePad, LineSpan)]
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 priv enum CodeBlockStruct {
   Indented(Array[IndentedCodeLine])
   Fenced(FenceCodeBlockStruct)
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 priv struct Atx {
@@ -165,7 +165,7 @@ priv struct Atx {
   after_open : CharCodePos
   heading : LineSpan
   layout_after : LineSpan
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 priv struct Setext {
@@ -173,25 +173,25 @@ priv struct Setext {
   heading_lines : Array[LineSpan]
   /// Indent, underline char count, blanks
   underline : (Indent, LineSpan, LineSpan)
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 priv enum Heading {
   Atx(Atx)
   Setext(Setext)
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 priv struct HtmlBlockStruct {
   end_cond : HtmlBlockEndCond?
   html : Array[LineSpan]
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 priv struct Paragraph {
   maybe_ref : Bool
   lines : Array[LineSpan]
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 priv enum BlockStruct {
@@ -206,7 +206,7 @@ priv enum BlockStruct {
   ThematicBreak(Indent, LineSpan) // Including trailing blanks
   ExtTable(Indent, Array[(LineSpan, LineSpan)]) // The second `LineSpan` is for trailing blanks
   ExtFootnote(Indent, (Label, Label?), Array[BlockStruct])
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 priv struct ListItemStruct {
@@ -215,7 +215,7 @@ priv struct ListItemStruct {
   after_marker : Indent
   ext_task_marker : (Char, LineSpan)?
   blocks : Array[BlockStruct]
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 priv struct ListBlockStruct {
@@ -224,7 +224,7 @@ priv struct ListBlockStruct {
   item_min_indent : Indent // Last item minimal indent
   list_type : ListType
   items : Array[ListItemStruct]
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 fn BlockStruct::is_blank_line(self : BlockStruct) -> Bool {

--- a/src/cmark/block_struct_test.mbt
+++ b/src/cmark/block_struct_test.mbt
@@ -2,5 +2,10 @@
 test "get_first_line with CRLF" {
   let line = "hello\r\nworld"
   let doc = @cmark.Doc::from_string(line)
-  inspect(doc.nl, content="\r\n")
+  debug_inspect(
+    doc.nl,
+    content=(
+      #|"\r\n"
+    ),
+  )
 }

--- a/src/cmark/block_test.mbt
+++ b/src/cmark/block_test.mbt
@@ -1,26 +1,31 @@
 ///|
 test "normalize other block types" {
   let block = @cmark.Block::BlankLine(@cmark.Node::empty())
-  inspect(block.normalize(), content="BlankLine(Node::new(\"\"))")
+  debug_inspect(block.normalize(), content="BlankLine(Node::new(\"\"))")
 
   // Test BlockQuote normalization
   let quote_block = @cmark.Block::BlockQuote(
     @cmark.Node::new(@cmark.BlockQuote::new(@cmark.Block::empty())),
   )
-  inspect(
+  debug_inspect(
     quote_block.normalize(),
-    content="BlockQuote(Node::new({indent: 0, block: Blocks(Node::new(Seq([])))}))",
+    content=(
+      #|BlockQuote(Node::new({ indent: 0, block: Blocks(Node::new(Seq([]))) }))
+    ),
   )
 }
 
 ///|
 test "language_of_info_string with empty string" {
-  inspect(@cmark.CodeBlock::language_of_info_string(""), content="None")
+  debug_inspect(@cmark.CodeBlock::language_of_info_string(""), content="None")
 }
 
 ///|
 test "language_of_info_string with only whitespace in language" {
-  inspect(@cmark.CodeBlock::language_of_info_string("   "), content="None")
+  debug_inspect(
+    @cmark.CodeBlock::language_of_info_string("   "),
+    content="None",
+  )
 }
 
 ///|
@@ -30,8 +35,14 @@ test "code block new with info string" {
   let info = @cmark.Node::new("info")
   let codeBlock = @cmark.CodeBlock::new(info_string=Some(info), code)
   match codeBlock.info_string {
-    Some(info_node) => inspect(info_node.v, content="info")
-    None => inspect(false, content="true")
+    Some(info_node) =>
+      debug_inspect(
+        info_node.v,
+        content=(
+          #|"info"
+        ),
+      )
+    None => debug_inspect(false, content="true")
   }
 }
 
@@ -48,10 +59,10 @@ test "code block with indented layout and info string" {
   )
   match codeBlock.layout {
     @cmark.CodeBlockLayout::Fenced(layout) => {
-      inspect(layout.indent, content="0")
-      inspect(true, content="true")
+      debug_inspect(layout.indent, content="0")
+      debug_inspect(true, content="true")
     }
-    @cmark.CodeBlockLayout::Indented => inspect(false, content="true")
+    @cmark.CodeBlockLayout::Indented => debug_inspect(false, content="true")
   }
 }
 
@@ -63,16 +74,26 @@ test "code block make fence" {
   let code = @cmark.Seq::from_array([node])
   let codeBlock = @cmark.CodeBlock::new(code)
   let (char, count) = codeBlock.make_fence()
-  inspect(char, content="`")
-  inspect(count, content="3")
+  debug_inspect(
+    char,
+    content=(
+      #|'`'
+    ),
+  )
+  debug_inspect(count, content="3")
 
   // Test with backticks in code
   let node_with_backticks = @cmark.Node::new("```Example with backticks```")
   let code_with_backticks = @cmark.Seq::from_array([node_with_backticks])
   let codeBlock_with_backticks = @cmark.CodeBlock::new(code_with_backticks)
   let (char2, count2) = codeBlock_with_backticks.make_fence()
-  inspect(char2, content="`")
-  inspect(count2, content="4")
+  debug_inspect(
+    char2,
+    content=(
+      #|'`'
+    ),
+  )
+  debug_inspect(count2, content="4")
 }
 
 ///|
@@ -80,9 +101,11 @@ test "code block make fence" {
 test "block normalize with block quote" {
   let blockQuote = @cmark.BlockQuote::new(@cmark.Block::empty())
   let normalized = @cmark.Block::BlockQuote(@cmark.Node::new(blockQuote)).normalize()
-  inspect(
+  debug_inspect(
     normalized,
-    content="BlockQuote(Node::new({indent: 0, block: Blocks(Node::new(Seq([])))}))",
+    content=(
+      #|BlockQuote(Node::new({ indent: 0, block: Blocks(Node::new(Seq([]))) }))
+    ),
   )
 }
 
@@ -96,9 +119,11 @@ test "block normalize with list using Seq.empty" {
     items,
   }
   let normalized = @cmark.Block::List(@cmark.Node::new(list)).normalize()
-  inspect(
+  debug_inspect(
     normalized,
-    content="List(Node::new({ty: Unordered('*'), tight: true, items: Seq([])}))",
+    content=(
+      #|List(Node::new({ ty: Unordered('*'), tight: true, items: Seq([]) }))
+    ),
   )
 }
 
@@ -106,14 +131,19 @@ test "block normalize with list using Seq.empty" {
 /// Tests to improve coverage for the block.mbt file
 test "code block fenced layout default" {
   let layout = @cmark.CodeBlockFencedLayout::default()
-  inspect(layout.indent, content="0")
+  debug_inspect(layout.indent, content="0")
 }
 
 ///|
 test "thematic break new" {
   let tb = @cmark.BlockThematicBreak::new(indent=2, layout="***")
-  inspect(tb.indent, content="2")
-  inspect(tb.layout, content="***")
+  debug_inspect(tb.indent, content="2")
+  debug_inspect(
+    tb.layout,
+    content=(
+      #|"***"
+    ),
+  )
 }
 
 ///|
@@ -126,22 +156,22 @@ test "create new list item" {
     ext_task_marker=None,
     block,
   )
-  inspect(item.before_marker, content="2")
-  inspect(item.after_marker, content="1")
+  debug_inspect(item.before_marker, content="2")
+  debug_inspect(item.after_marker, content="1")
 
   // Test ListItem::map_block and ListItem::normalize_block
   let new_block = @cmark.Block::BlankLine(@cmark.Node::new(""))
   let mapped_item = item.map_block(fn(_) { new_block })
-  inspect(mapped_item.block, content="BlankLine(Node::new(\"\"))")
+  debug_inspect(mapped_item.block, content="BlankLine(Node::new(\"\"))")
   let normalized_item = item.normalize_block()
-  inspect(normalized_item.before_marker, content="2")
+  debug_inspect(normalized_item.before_marker, content="2")
 }
 
 ///|
 test "block quote normalize_block" {
   let quote = @cmark.BlockQuote::new(@cmark.Block::empty())
   let normalized_quote = quote.normalize_block()
-  inspect(normalized_quote.indent, content="0")
+  debug_inspect(normalized_quote.indent, content="0")
 }
 
 ///|
@@ -149,8 +179,14 @@ test "block quote normalize_block" {
 test "list task status from marker with custom marker" {
   let status = @cmark.ListTaskStatus::from_marker('?')
   match status {
-    Other(c) => inspect(c, content="?")
-    _ => inspect(false, content="true")
+    Other(c) =>
+      debug_inspect(
+        c,
+        content=(
+          #|'?'
+        ),
+      )
+    _ => debug_inspect(false, content="true")
   }
 }
 
@@ -162,20 +198,25 @@ test "paragraph new" {
     trailing_blanks="  ",
     inline,
   )
-  inspect(para.leading_indent, content="2")
-  inspect(para.trailing_blanks, content="  ")
+  debug_inspect(para.leading_indent, content="2")
+  debug_inspect(
+    para.trailing_blanks,
+    content=(
+      #|"  "
+    ),
+  )
 }
 
 ///|
 test "heading new" {
   let inline = @cmark.Inline::Text(@cmark.Node::new("heading"))
   let heading = @cmark.BlockHeading::new(level=2, inline)
-  inspect(heading.level, content="2")
+  debug_inspect(heading.level, content="2")
 }
 
 ///|
 test "block normalize" {
   let block = @cmark.Block::BlankLine(@cmark.Node::new(""))
   let normalized = block.normalize()
-  inspect(normalized, content="BlankLine(Node::new(\"\"))")
+  debug_inspect(normalized, content="BlankLine(Node::new(\"\"))")
 }

--- a/src/cmark/block_test.mbt
+++ b/src/cmark/block_test.mbt
@@ -1,7 +1,27 @@
 ///|
 test "normalize other block types" {
   let block = @cmark.Block::BlankLine(@cmark.Node::empty())
-  debug_inspect(block.normalize(), content="BlankLine(Node::new(\"\"))")
+  debug_inspect(
+    block.normalize(),
+    content=(
+      #|BlankLine(
+      #|  {
+      #|    v: "",
+      #|    meta: {
+      #|      id: 0,
+      #|      loc: {
+      #|        file: "-",
+      #|        first_ccode: -1,
+      #|        last_ccode: -1,
+      #|        first_line: LinePos(-1, -1),
+      #|        last_line: LinePos(-1, -1),
+      #|      },
+      #|      extra: None,
+      #|    },
+      #|  },
+      #|)
+    ),
+  )
 
   // Test BlockQuote normalization
   let quote_block = @cmark.Block::BlockQuote(
@@ -10,7 +30,40 @@ test "normalize other block types" {
   debug_inspect(
     quote_block.normalize(),
     content=(
-      #|BlockQuote(Node::new({ indent: 0, block: Blocks(Node::new(Seq([]))) }))
+      #|BlockQuote(
+      #|  {
+      #|    v: {
+      #|      indent: 0,
+      #|      block: Blocks(
+      #|        {
+      #|          v: Seq([]),
+      #|          meta: {
+      #|            id: 0,
+      #|            loc: {
+      #|              file: "-",
+      #|              first_ccode: -1,
+      #|              last_ccode: -1,
+      #|              first_line: LinePos(-1, -1),
+      #|              last_line: LinePos(-1, -1),
+      #|            },
+      #|            extra: None,
+      #|          },
+      #|        },
+      #|      ),
+      #|    },
+      #|    meta: {
+      #|      id: 0,
+      #|      loc: {
+      #|        file: "-",
+      #|        first_ccode: -1,
+      #|        last_ccode: -1,
+      #|        first_line: LinePos(-1, -1),
+      #|        last_line: LinePos(-1, -1),
+      #|      },
+      #|      extra: None,
+      #|    },
+      #|  },
+      #|)
     ),
   )
 }
@@ -104,7 +157,40 @@ test "block normalize with block quote" {
   debug_inspect(
     normalized,
     content=(
-      #|BlockQuote(Node::new({ indent: 0, block: Blocks(Node::new(Seq([]))) }))
+      #|BlockQuote(
+      #|  {
+      #|    v: {
+      #|      indent: 0,
+      #|      block: Blocks(
+      #|        {
+      #|          v: Seq([]),
+      #|          meta: {
+      #|            id: 0,
+      #|            loc: {
+      #|              file: "-",
+      #|              first_ccode: -1,
+      #|              last_ccode: -1,
+      #|              first_line: LinePos(-1, -1),
+      #|              last_line: LinePos(-1, -1),
+      #|            },
+      #|            extra: None,
+      #|          },
+      #|        },
+      #|      ),
+      #|    },
+      #|    meta: {
+      #|      id: 0,
+      #|      loc: {
+      #|        file: "-",
+      #|        first_ccode: -1,
+      #|        last_ccode: -1,
+      #|        first_line: LinePos(-1, -1),
+      #|        last_line: LinePos(-1, -1),
+      #|      },
+      #|      extra: None,
+      #|    },
+      #|  },
+      #|)
     ),
   )
 }
@@ -122,7 +208,22 @@ test "block normalize with list using Seq.empty" {
   debug_inspect(
     normalized,
     content=(
-      #|List(Node::new({ ty: Unordered('*'), tight: true, items: Seq([]) }))
+      #|List(
+      #|  {
+      #|    v: { ty: Unordered('*'), tight: true, items: Seq([]) },
+      #|    meta: {
+      #|      id: 0,
+      #|      loc: {
+      #|        file: "-",
+      #|        first_ccode: -1,
+      #|        last_ccode: -1,
+      #|        first_line: LinePos(-1, -1),
+      #|        last_line: LinePos(-1, -1),
+      #|      },
+      #|      extra: None,
+      #|    },
+      #|  },
+      #|)
     ),
   )
 }
@@ -162,7 +263,27 @@ test "create new list item" {
   // Test ListItem::map_block and ListItem::normalize_block
   let new_block = @cmark.Block::BlankLine(@cmark.Node::new(""))
   let mapped_item = item.map_block(fn(_) { new_block })
-  debug_inspect(mapped_item.block, content="BlankLine(Node::new(\"\"))")
+  debug_inspect(
+    mapped_item.block,
+    content=(
+      #|BlankLine(
+      #|  {
+      #|    v: "",
+      #|    meta: {
+      #|      id: 0,
+      #|      loc: {
+      #|        file: "-",
+      #|        first_ccode: -1,
+      #|        last_ccode: -1,
+      #|        first_line: LinePos(-1, -1),
+      #|        last_line: LinePos(-1, -1),
+      #|      },
+      #|      extra: None,
+      #|    },
+      #|  },
+      #|)
+    ),
+  )
   let normalized_item = item.normalize_block()
   debug_inspect(normalized_item.before_marker, content="2")
 }
@@ -218,5 +339,25 @@ test "heading new" {
 test "block normalize" {
   let block = @cmark.Block::BlankLine(@cmark.Node::new(""))
   let normalized = block.normalize()
-  debug_inspect(normalized, content="BlankLine(Node::new(\"\"))")
+  debug_inspect(
+    normalized,
+    content=(
+      #|BlankLine(
+      #|  {
+      #|    v: "",
+      #|    meta: {
+      #|      id: 0,
+      #|      loc: {
+      #|        file: "-",
+      #|        first_ccode: -1,
+      #|        last_ccode: -1,
+      #|        first_line: LinePos(-1, -1),
+      #|        last_line: LinePos(-1, -1),
+      #|      },
+      #|      extra: None,
+      #|    },
+      #|  },
+      #|)
+    ),
+  )
 }

--- a/src/cmark/closer.mbt
+++ b/src/cmark/closer.mbt
@@ -35,6 +35,7 @@ type PosSet = Set[Int]
 priv struct CloserIndex(Map[Closer, PosSet]) derive(ToJson)
 
 ///|
+// Set[Int] does not implement Debug yet; manually walk the Map.
 impl @debug.Debug for CloserIndex with to_repr(self) {
   let entries = self.0
     .iter()

--- a/src/cmark/closer.mbt
+++ b/src/cmark/closer.mbt
@@ -12,12 +12,19 @@ priv enum Closer {
   EmphasisMarks(Char)
   StrikethroughMarks
   MathSpanMarks(Int)
-} derive(Eq, Hash, Show, ToJson)
+} derive(Eq, Hash, Debug, ToJson)
+
+///|
+// Manual Show impl bridges Closer's Debug output through Map's ToJson,
+// which requires Show on the key type.
+impl Show for Closer with output(self, logger) {
+  logger.write_string(@debug.to_string(self))
+}
 
 ///|
 test {
-  // Prevent warning about unused Show and ToJson
-  (fn(c : Closer) { c.to_string() }) |> ignore()
+  // Prevent warning about unused Debug and ToJson
+  (fn(c : Closer) { @debug.to_string(c) }) |> ignore()
   (fn(c : Closer) { c.to_json() }) |> ignore()
 }
 
@@ -25,12 +32,24 @@ test {
 type PosSet = Set[Int]
 
 ///|
-priv struct CloserIndex(Map[Closer, PosSet]) derive(Show, ToJson)
+priv struct CloserIndex(Map[Closer, PosSet]) derive(ToJson)
+
+///|
+impl @debug.Debug for CloserIndex with to_repr(self) {
+  let entries = self.0
+    .iter()
+    .map(fn(kv) {
+      let (k, v) = kv
+      (@debug.to_repr(k), @debug.to_repr(v.iter().to_array()))
+    })
+    .to_array()
+  @debug.Repr::map(entries)
+}
 
 ///|
 test {
-  // Prevent warning about unused Show and ToJson
-  (fn(c : CloserIndex) { c.to_string() }) |> ignore()
+  // Prevent warning about unused Debug and ToJson
+  (fn(c : CloserIndex) { @debug.to_string(c) }) |> ignore()
   (fn(c : CloserIndex) { c.to_json() }) |> ignore()
 }
 

--- a/src/cmark/doc.mbt
+++ b/src/cmark/doc.mbt
@@ -4,7 +4,7 @@ pub(all) struct Doc {
   nl : String
   block : Block
   defs : LabelDefs
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 pub fn Doc::new(

--- a/src/cmark/error.mbt
+++ b/src/cmark/error.mbt
@@ -1,9 +1,9 @@
 ///|
 pub(all) suberror FolderError {
   FolderError(String)
-} derive(Show)
+} derive(Debug)
 
 ///|
 pub(all) suberror MapperError {
   MapperError(String)
-} derive(Show)
+} derive(Debug)

--- a/src/cmark/folder.mbt
+++ b/src/cmark/folder.mbt
@@ -18,7 +18,7 @@ pub(all) struct FolderFn[A, B]((Folder[B], B, A) -> FolderResult[B])
 pub(all) enum FolderResult[A] {
   Default
   Fold(A)
-} derive(Eq, Show, ToJson)
+} derive(Eq, Debug, ToJson)
 
 ///|
 pub impl[A] Default for FolderResult[A] with default() {

--- a/src/cmark/folder_test.mbt
+++ b/src/cmark/folder_test.mbt
@@ -1,14 +1,14 @@
 ///|
 test "folder_none" {
   let folder = @cmark.Folder::new()
-  inspect(@cmark.Folder::none(folder, 1, "test"), content="Default")
+  debug_inspect(@cmark.Folder::none(folder, 1, "test"), content="Default")
 }
 
 ///|
 test "fold_block with blank line" {
   let folder = @cmark.Folder::new()
   let block = @cmark.Block::BlankLine(@cmark.Node::new(""))
-  inspect(folder.fold_block(0, block), content="0")
+  debug_inspect(folder.fold_block(0, block), content="0")
 }
 
 ///|
@@ -21,7 +21,7 @@ test "fold_block with paragraph" {
       trailing_blanks: "",
     }),
   )
-  inspect(folder.fold_block(0, block), content="0")
+  debug_inspect(folder.fold_block(0, block), content="0")
 }
 
 ///|
@@ -37,7 +37,7 @@ test "fold_block with heading" {
       id: None,
     }),
   )
-  inspect(folder.fold_block(0, heading), content="0")
+  debug_inspect(folder.fold_block(0, heading), content="0")
 }
 
 ///|
@@ -55,7 +55,7 @@ test "fold_block with blockquote" {
       ),
     }),
   )
-  inspect(folder.fold_block(0, quote), content="0")
+  debug_inspect(folder.fold_block(0, quote), content="0")
 }
 
 ///|
@@ -81,7 +81,7 @@ test "fold_block with blocks" {
       ]),
     ),
   )
-  inspect(folder.fold_block(0, blocks), content="0")
+  debug_inspect(folder.fold_block(0, blocks), content="0")
 }
 
 ///|
@@ -146,7 +146,7 @@ test "folder block with table" {
     }),
   )
   let result = folder.fold_block(0, table)
-  inspect(result, content="0")
+  debug_inspect(result, content="0")
 }
 
 ///|
@@ -165,7 +165,7 @@ test "folder block with footnote definition" {
     }),
   )
   let result = folder.fold_block(0, footnote)
-  inspect(result, content="0")
+  debug_inspect(result, content="0")
 }
 
 ///|
@@ -174,5 +174,5 @@ test "folder fold_block with default block handler" {
     @cmark.Folder::ret(acc)
   })
   let block = @cmark.Block::empty()
-  inspect(folder.fold_block(0, block), content="0")
+  debug_inspect(folder.fold_block(0, block), content="0")
 }

--- a/src/cmark/inline.mbt
+++ b/src/cmark/inline.mbt
@@ -15,7 +15,7 @@ pub(all) enum Inline {
   Text(Node[InlineText])
   ExtStrikethrough(Node[InlineStrikethrough])
   ExtMathSpan(Node[InlineMathSpan])
-} derive(Eq, Show, ToJson)
+} derive(Eq, Debug, ToJson)
 
 ///|
 pub fn Inline::empty() -> Inline {
@@ -217,7 +217,7 @@ pub(all) struct InlineAutolink {
   /// https://spec.commonmark.org/0.30/#absolute-uri
   /// https://spec.commonmark.org/0.30/#email-address
   link : StringNode
-} derive(Eq, Show, ToJson)
+} derive(Eq, Debug, ToJson)
 
 ///|
 pub fn InlineAutolink::new(link : StringNode) -> InlineAutolink {
@@ -230,7 +230,7 @@ pub(all) struct InlineBreak {
   layout_before : BlanksNode
   ty : InlineBreakType
   layout_after : BlanksNode
-} derive(Eq, Show, ToJson)
+} derive(Eq, Debug, ToJson)
 
 ///|
 pub fn InlineBreak::new(
@@ -245,14 +245,14 @@ pub fn InlineBreak::new(
 pub(all) enum InlineBreakType {
   Hard
   Soft
-} derive(Eq, Compare, Show, FromJson, ToJson)
+} derive(Eq, Compare, Debug, FromJson, ToJson)
 
 ///|
 /// The type for [code spans](https://spec.commonmark.org/0.30/#code-spans).
 pub(all) struct InlineCodeSpan {
   backticks : Count
   code_layout : Seq[Tight]
-} derive(Eq, Show, ToJson)
+} derive(Eq, Debug, ToJson)
 
 ///|
 pub fn InlineCodeSpan::new(
@@ -344,7 +344,7 @@ pub fn InlineCodeSpan::code(self : InlineCodeSpan) -> String {
 pub(all) struct InlineEmphasis {
   delim : Char
   inline : Inline
-} derive(Eq, Show, ToJson)
+} derive(Eq, Debug, ToJson)
 
 ///|
 pub fn InlineEmphasis::new(
@@ -358,7 +358,7 @@ pub fn InlineEmphasis::new(
 pub(all) struct InlineLink {
   text : Inline
   reference : ReferenceKind
-} derive(Eq, Show, ToJson)
+} derive(Eq, Debug, ToJson)
 
 ///|
 pub(all) enum ReferenceKind {
@@ -367,7 +367,7 @@ pub(all) enum ReferenceKind {
   /// https://spec.commonmark.org/0.30/#reference-link
   /// First label is the label of the reference, second label is the label of the referenced definition.
   Ref(ReferenceLayout, Label, Label)
-} derive(Eq, Show, ToJson)
+} derive(Eq, Debug, ToJson)
 
 ///|
 /// The type for reference link layouts.
@@ -378,7 +378,7 @@ pub(all) enum ReferenceLayout {
   Full
   /// https://spec.commonmark.org/0.30/#shortcut-reference-link
   Shortcut
-} derive(Eq, Show, FromJson, ToJson)
+} derive(Eq, Debug, FromJson, ToJson)
 
 ///|
 pub fn InlineLink::new(text : Inline, reference : ReferenceKind) -> InlineLink {
@@ -442,7 +442,7 @@ pub fn InlineLink::is_unsafe(l : String) -> Bool {
 
 ///|
 /// The type for [inline raw HTML](https://spec.commonmark.org/0.30/#raw-html) (can span multiple lines).
-pub(all) struct InlineRawHtml(Seq[Tight]) derive(Eq, Show, ToJson)
+pub(all) struct InlineRawHtml(Seq[Tight]) derive(Eq, Debug, ToJson)
 
 ///|
 /// The type for [textual content](https://spec.commonmark.org/0.30/#textual-content).
@@ -455,13 +455,13 @@ pub type InlineText = String
 // Extensions
 
 ///|
-pub(all) struct InlineStrikethrough(Inline) derive(Eq, Show, ToJson)
+pub(all) struct InlineStrikethrough(Inline) derive(Eq, Debug, ToJson)
 
 ///|
 pub(all) struct InlineMathSpan {
   display : Bool
   tex_layout : Seq[Tight]
-} derive(Eq, Show, ToJson)
+} derive(Eq, Debug, ToJson)
 
 ///|
 pub fn InlineMathSpan::tex(self : Self) -> String {

--- a/src/cmark/inline_struct.mbt
+++ b/src/cmark/inline_struct.mbt
@@ -23,19 +23,19 @@ priv enum Token {
   RightParen(TokenStart)
   StrikethroughMarks(TokenStrikethroughMarks)
   MathSpanMarks(TokenMathSpanMarks)
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 priv struct TokenStart {
   start : CharCodePos
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 priv struct TokenBackticks {
   start : CharCodePos
   count : Int
   escaped : Bool
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 priv struct TokenEmphasisMarks {
@@ -44,7 +44,7 @@ priv struct TokenEmphasisMarks {
   count : Int
   may_open : Bool
   may_close : Bool
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 priv struct TokenInline {
@@ -52,13 +52,13 @@ priv struct TokenInline {
   inline : Inline
   endline : LineSpan
   next : CharCodePos
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 priv struct TokenLinkStart {
   start : CharCodePos
   image : Bool
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 priv struct TokenNewline {
@@ -66,14 +66,14 @@ priv struct TokenNewline {
   start : CharCodePos
   break_ty : InlineBreakType
   newline : LineSpan
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 priv struct TokenStrikethroughMarks {
   start : CharCodePos
   may_open : Bool
   may_close : Bool
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 priv struct TokenMathSpanMarks {
@@ -81,7 +81,7 @@ priv struct TokenMathSpanMarks {
   count : Int
   may_open : Bool
   may_close : Bool
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 fn Token::start(self : Token) -> CharCodePos {
@@ -1587,12 +1587,12 @@ fn Parser::start_col(
 priv enum StartColResult {
   Col((Inline, TableCellLayout), CharCodePos)
   Start(String, Array[Inline])
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 test {
-  // Prevent warning about unused Show and ToJson
-  (fn(s : StartColResult) { s.to_string() }) |> ignore()
+  // Prevent warning about unused Debug and ToJson
+  (fn(s : StartColResult) { @debug.to_string(s) }) |> ignore()
   (fn(s : StartColResult) { s.to_json() }) |> ignore()
 }
 

--- a/src/cmark/inline_test.mbt
+++ b/src/cmark/inline_test.mbt
@@ -3,8 +3,13 @@ test "InlineAutolink::new with link" {
   let meta = @cmark_base.Meta::none()
   let link = @cmark.Node::new("example.com", meta~)
   let autolink = @cmark.InlineAutolink::new(link)
-  inspect(autolink.is_email, content="false")
-  inspect(autolink.link.v, content="example.com")
+  debug_inspect(autolink.is_email, content="false")
+  debug_inspect(
+    autolink.link.v,
+    content=(
+      #|"example.com"
+    ),
+  )
 }
 
 ///|
@@ -13,7 +18,7 @@ test "Inline::is_empty checks if inline content is empty" {
 
   // Test empty inlines list
   let empty_inlines = @cmark.Inline::Inlines({ v: @cmark.Seq::empty(), meta })
-  inspect(empty_inlines.is_empty(), content="true")
+  debug_inspect(empty_inlines.is_empty(), content="true")
 
   // Test non-empty inlines list
   let text_node = @cmark.Inline::Text(@cmark.Node::new("text", meta~))
@@ -21,15 +26,15 @@ test "Inline::is_empty checks if inline content is empty" {
     v: @cmark.Seq::from_array([text_node]),
     meta,
   })
-  inspect(non_empty_inlines.is_empty(), content="false")
+  debug_inspect(non_empty_inlines.is_empty(), content="false")
 
   // Test empty text
   let empty_text = @cmark.Inline::Text(@cmark.Node::new("", meta~))
-  inspect(empty_text.is_empty(), content="true")
+  debug_inspect(empty_text.is_empty(), content="true")
 
   // Test non-empty text
   let non_empty_text = @cmark.Inline::Text(@cmark.Node::new("Some text", meta~))
-  inspect(non_empty_text.is_empty(), content="false")
+  debug_inspect(non_empty_text.is_empty(), content="false")
 
   // Test other cases which always return false
   let al_node = @cmark.Node::new(
@@ -37,28 +42,33 @@ test "Inline::is_empty checks if inline content is empty" {
     meta~,
   )
   let autolink = @cmark.Inline::Autolink(al_node)
-  inspect(autolink.is_empty(), content="false")
+  debug_inspect(autolink.is_empty(), content="false")
 }
 
 ///|
 test "InlineCodeSpan::code with empty content" {
   let empty_code = @cmark.InlineCodeSpan::from_string("")
-  inspect(empty_code.code(), content="")
+  debug_inspect(
+    empty_code.code(),
+    content=(
+      #|""
+    ),
+  )
 }
 
 ///|
 test "is_unsafe for data URLs" {
   // Test data URL with image/gif
   let data_url = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-  inspect(@cmark.InlineLink::is_unsafe(data_url), content="false")
+  debug_inspect(@cmark.InlineLink::is_unsafe(data_url), content="false")
 
   // Test data URL with missing comma after base64
   let invalid_data = "data:image/gif;base64"
-  inspect(@cmark.InlineLink::is_unsafe(invalid_data), content="true")
+  debug_inspect(@cmark.InlineLink::is_unsafe(invalid_data), content="true")
 
   // Test data URL with no semicolon
   let data_no_semi = "data:image/gif,content"
-  inspect(@cmark.InlineLink::is_unsafe(data_no_semi), content="false")
+  debug_inspect(@cmark.InlineLink::is_unsafe(data_no_semi), content="false")
 }
 
 ///|
@@ -68,10 +78,10 @@ test "is_unsafe for data URLs with various media types" {
   let data_png = "data:image/png,iVBOR"
   let data_jpeg = "data:image/jpeg,/9j/4"
   let data_webp = "data:image/webp,UklGR"
-  inspect(@cmark.InlineLink::is_unsafe(data_gif), content="false")
-  inspect(@cmark.InlineLink::is_unsafe(data_png), content="false")
-  inspect(@cmark.InlineLink::is_unsafe(data_jpeg), content="false")
-  inspect(@cmark.InlineLink::is_unsafe(data_webp), content="false")
+  debug_inspect(@cmark.InlineLink::is_unsafe(data_gif), content="false")
+  debug_inspect(@cmark.InlineLink::is_unsafe(data_png), content="false")
+  debug_inspect(@cmark.InlineLink::is_unsafe(data_jpeg), content="false")
+  debug_inspect(@cmark.InlineLink::is_unsafe(data_webp), content="false")
 }
 
 ///|
@@ -80,7 +90,7 @@ test "referenced_label with inline reference" {
   let link_def = @cmark.Node::new(@cmark.LinkDefinition::new())
   let inline_ref = @cmark.ReferenceKind::Inline(link_def)
   let link = @cmark.InlineLink::new(text, inline_ref)
-  inspect(link.referenced_label(), content="None")
+  debug_inspect(link.referenced_label(), content="None")
 }
 
 ///|
@@ -93,28 +103,48 @@ test "inline id with text containing backticks" {
       ]),
     }),
   )
-  inspect(inline.id(), content="text")
+  debug_inspect(
+    inline.id(),
+    content=(
+      #|"text"
+    ),
+  )
 }
 
 ///|
 test "inline id with whitespace and punctuation" {
   let text = " Hello, World! \t"
   let inline = @cmark.Inline::Text(@cmark.Node::new(text))
-  inspect(inline.id(), content="hello-world")
+  debug_inspect(
+    inline.id(),
+    content=(
+      #|"hello-world"
+    ),
+  )
 }
 
 ///|
 test "inline id with underscore and dash" {
   let text = "hello_world-test"
   let inline = @cmark.Inline::Text(@cmark.Node::new(text))
-  inspect(inline.id(), content="hello_world-test")
+  debug_inspect(
+    inline.id(),
+    content=(
+      #|"hello_world-test"
+    ),
+  )
 }
 
 ///|
 test "inline id with mixed case and punctuation" {
   let text = "Hello, World! This is a Test."
   let inline = @cmark.Inline::Text(@cmark.Node::new(text))
-  inspect(inline.id(), content="hello-world-this-is-a-test")
+  debug_inspect(
+    inline.id(),
+    content=(
+      #|"hello-world-this-is-a-test"
+    ),
+  )
 }
 
 ///|
@@ -164,9 +194,19 @@ test "InlineBreak::new creates a break with specified parameters" {
     layout_after~,
     break_type,
   )
-  inspect(line_break.ty, content="Hard")
-  inspect(line_break.layout_before.v, content="  ")
-  inspect(line_break.layout_after.v, content="   ")
+  debug_inspect(line_break.ty, content="Hard")
+  debug_inspect(
+    line_break.layout_before.v,
+    content=(
+      #|"  "
+    ),
+  )
+  debug_inspect(
+    line_break.layout_after.v,
+    content=(
+      #|"   "
+    ),
+  )
 }
 
 ///|
@@ -178,7 +218,12 @@ test "Inline::id with null character" {
 
   // Should replace null with replacement character in output
   let id = text.id()
-  inspect(id, content="text�more")
+  debug_inspect(
+    id,
+    content=(
+      #|"text�more"
+    ),
+  )
 }
 
 ///|
@@ -195,7 +240,7 @@ test "Inline::normalize with Link type" {
   let normalized = link.normalize()
 
   // Check that the result is correctly normalized
-  inspect(normalized.is_empty(), content="false")
+  debug_inspect(normalized.is_empty(), content="false")
 }
 
 ///|
@@ -271,7 +316,7 @@ test "Inline::normalize with ExtStrikethrough type" {
 
   // Normalize and check
   let normalized = strikethrough.normalize()
-  inspect(
+  debug_inspect(
     normalized,
     content=(
       #|ExtStrikethrough(Node::new(InlineStrikethrough(Text(Node::new("strikethrough")))))
@@ -295,21 +340,31 @@ test "Inline::normalize with complex structure - has nested inlines" {
 
   // Normalize should flatten nested Inlines
   let normalized = outer.normalize()
-  inspect(normalized.is_empty(), content="false")
+  debug_inspect(normalized.is_empty(), content="false")
 }
 
 ///|
 test "InlineCodeSpan::from_string with simple content" {
   // Test with string that needs spaces (contains backticks)
   let code_with_backticks = @cmark.InlineCodeSpan::from_string("`code`")
-  inspect(code_with_backticks.code(), content="`code`")
+  debug_inspect(
+    code_with_backticks.code(),
+    content=(
+      #|"`code`"
+    ),
+  )
 }
 
 ///|
 test "InlineCodeSpan::from_string with empty string" {
   // Test with empty string
   let empty_code = @cmark.InlineCodeSpan::from_string("")
-  inspect(empty_code.code(), content="")
+  debug_inspect(
+    empty_code.code(),
+    content=(
+      #|""
+    ),
+  )
 }
 
 ///|
@@ -320,14 +375,24 @@ test "InlineCodeSpan::from_string with newlines" {
     meta~,
     "code\nwith\nnewlines",
   )
-  inspect(code_with_newlines.code(), content="code with newlines")
+  debug_inspect(
+    code_with_newlines.code(),
+    content=(
+      #|"code with newlines"
+    ),
+  )
 
   // Test with CRLF
   let code_with_crlf = @cmark.InlineCodeSpan::from_string(
     meta~,
     "code\r\nwith\r\ncrlf",
   )
-  inspect(code_with_crlf.code(), content="code with crlf")
+  debug_inspect(
+    code_with_crlf.code(),
+    content=(
+      #|"code with crlf"
+    ),
+  )
 }
 
 ///|
@@ -341,8 +406,13 @@ test "InlineCodeSpan::new creates a code span directly" {
 
   // Create with explicit backtick count
   let code_span = @cmark.InlineCodeSpan::new(backticks=2, code_layout)
-  inspect(code_span.backticks, content="2")
-  inspect(code_span.code(), content="code")
+  debug_inspect(code_span.backticks, content="2")
+  debug_inspect(
+    code_span.code(),
+    content=(
+      #|"code"
+    ),
+  )
 }
 
 ///|
@@ -359,7 +429,7 @@ test "Inline::to_plain_text with hard line break" {
     ),
   )
   let result = hard_break.to_plain_text(break_on_soft=false)
-  inspect(result.length(), content="2")
+  debug_inspect(result.length(), content="2")
 }
 
 ///|
@@ -378,11 +448,11 @@ test "Inline::to_plain_text with soft line break" {
 
   // With break_on_soft=true
   let result_true = soft_break.to_plain_text(break_on_soft=true)
-  inspect(result_true.length(), content="2")
+  debug_inspect(result_true.length(), content="2")
 
   // With break_on_soft=false
   let result_false = soft_break.to_plain_text(break_on_soft=false)
-  inspect(result_false.length(), content="1")
+  debug_inspect(result_false.length(), content="1")
 }
 
 ///|
@@ -393,7 +463,7 @@ test "Inline::to_plain_text with autolink" {
     @cmark.Node::new(@cmark.InlineAutolink::new(link_node), meta~),
   )
   let result = autolink.to_plain_text(break_on_soft=false)
-  inspect(result.length(), content="1")
+  debug_inspect(result.length(), content="1")
 }
 
 ///|
@@ -406,14 +476,14 @@ test "Inline::to_plain_text with emphasis and strong emphasis" {
     @cmark.Node::new({ delim: '*', inline: text }, meta~),
   )
   let emphasis_result = emphasis.to_plain_text(break_on_soft=false)
-  inspect(emphasis_result.length(), content="1")
+  debug_inspect(emphasis_result.length(), content="1")
 
   // Test with StrongEmphasis
   let strong = @cmark.Inline::StrongEmphasis(
     @cmark.Node::new({ delim: '*', inline: text }, meta~),
   )
   let strong_result = strong.to_plain_text(break_on_soft=false)
-  inspect(strong_result.length(), content="1")
+  debug_inspect(strong_result.length(), content="1")
 }
 
 ///|
@@ -427,7 +497,7 @@ test "Inline::to_plain_text with inlines and link" {
     @cmark.Node::new(@cmark.Seq::from_array([text1, text2]), meta~),
   )
   let inlines_result = inlines.to_plain_text(break_on_soft=false)
-  inspect(inlines_result.length(), content="1")
+  debug_inspect(inlines_result.length(), content="1")
 
   // Test with Link
   let link_def = @cmark.Node::new(@cmark.LinkDefinition::new(), meta~)
@@ -436,7 +506,7 @@ test "Inline::to_plain_text with inlines and link" {
     @cmark.Node::new({ text: text1, reference }, meta~),
   )
   let link_result = link.to_plain_text(break_on_soft=false)
-  inspect(link_result.length(), content="1")
+  debug_inspect(link_result.length(), content="1")
 }
 
 ///|
@@ -447,7 +517,7 @@ test "Inline::to_plain_text with raw html and strikethrough" {
   let raw_content = @cmark.Seq::from_array([@cmark.Tight::empty(meta~)])
   let raw_html = @cmark.Inline::RawHtml(@cmark.Node::new(raw_content, meta~))
   let raw_html_result = raw_html.to_plain_text(break_on_soft=false)
-  inspect(raw_html_result.length(), content="1")
+  debug_inspect(raw_html_result.length(), content="1")
 
   // Test with Strikethrough
   let text = @cmark.Inline::Text(@cmark.Node::new("strikethrough", meta~))
@@ -455,7 +525,7 @@ test "Inline::to_plain_text with raw html and strikethrough" {
     @cmark.Node::new(text, meta~),
   )
   let strikethrough_result = strikethrough.to_plain_text(break_on_soft=false)
-  inspect(strikethrough_result.length(), content="1")
+  debug_inspect(strikethrough_result.length(), content="1")
 }
 
 ///|
@@ -469,7 +539,7 @@ test "Inline::to_plain_text with math span" {
     @cmark.Node::new({ display: false, tex_layout }, meta~),
   )
   let math_result = math_span.to_plain_text(break_on_soft=false)
-  inspect(math_result.length(), content="1")
+  debug_inspect(math_result.length(), content="1")
 }
 
 ///|
@@ -486,5 +556,5 @@ test "Inline::normalize with singleton list" {
 
   // Normalize should return just the inner item
   let normalized = inlines.normalize()
-  inspect(normalized, content="Text(Node::new(\"single item\"))")
+  debug_inspect(normalized, content="Text(Node::new(\"single item\"))")
 }

--- a/src/cmark/inline_test.mbt
+++ b/src/cmark/inline_test.mbt
@@ -319,7 +319,39 @@ test "Inline::normalize with ExtStrikethrough type" {
   debug_inspect(
     normalized,
     content=(
-      #|ExtStrikethrough(Node::new(InlineStrikethrough(Text(Node::new("strikethrough")))))
+      #|ExtStrikethrough(
+      #|  {
+      #|    v: InlineStrikethrough(
+      #|      Text(
+      #|        {
+      #|          v: "strikethrough",
+      #|          meta: {
+      #|            id: 0,
+      #|            loc: {
+      #|              file: "-",
+      #|              first_ccode: -1,
+      #|              last_ccode: -1,
+      #|              first_line: LinePos(-1, -1),
+      #|              last_line: LinePos(-1, -1),
+      #|            },
+      #|            extra: None,
+      #|          },
+      #|        },
+      #|      ),
+      #|    ),
+      #|    meta: {
+      #|      id: 0,
+      #|      loc: {
+      #|        file: "-",
+      #|        first_ccode: -1,
+      #|        last_ccode: -1,
+      #|        first_line: LinePos(-1, -1),
+      #|        last_line: LinePos(-1, -1),
+      #|      },
+      #|      extra: None,
+      #|    },
+      #|  },
+      #|)
     ),
   )
 }
@@ -556,5 +588,25 @@ test "Inline::normalize with singleton list" {
 
   // Normalize should return just the inner item
   let normalized = inlines.normalize()
-  debug_inspect(normalized, content="Text(Node::new(\"single item\"))")
+  debug_inspect(
+    normalized,
+    content=(
+      #|Text(
+      #|  {
+      #|    v: "single item",
+      #|    meta: {
+      #|      id: 0,
+      #|      loc: {
+      #|        file: "-",
+      #|        first_ccode: -1,
+      #|        last_ccode: -1,
+      #|        first_line: LinePos(-1, -1),
+      #|        last_line: LinePos(-1, -1),
+      #|      },
+      #|      extra: None,
+      #|    },
+      #|  },
+      #|)
+    ),
+  )
 }

--- a/src/cmark/label.mbt
+++ b/src/cmark/label.mbt
@@ -10,7 +10,7 @@ pub(all) struct Label {
   meta : Meta
   key : LabelKey
   text : Seq[Tight]
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 /// The type for label keys. These are
@@ -46,7 +46,7 @@ pub fn Label::compare(self : Label, other : Label) -> Int {
 pub(all) enum LabelDef {
   LinkDef(Node[LinkDefinition])
   FootnoteDef(Node[Footnote])
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 pub type LabelDefs = Map[LabelKey, LabelDef]

--- a/src/cmark/link_definition.mbt
+++ b/src/cmark/link_definition.mbt
@@ -9,7 +9,7 @@ pub(all) struct LinkDefinition {
   defined_label : Label?
   dest : StringNode?
   title : Seq[Tight]?
-} derive(Eq, Show, ToJson)
+} derive(Eq, Debug, ToJson)
 
 ///|
 pub fn LinkDefinition::new(
@@ -30,7 +30,7 @@ pub(all) struct LinkDefinitionLayout {
   after_dest : Seq[BlockLineBlank]
   title_open_delim : Char
   after_title : Seq[BlockLineBlank]
-} derive(Eq, Show, ToJson)
+} derive(Eq, Debug, ToJson)
 
 ///|
 pub fn LinkDefinitionLayout::default() -> LinkDefinitionLayout {

--- a/src/cmark/link_definition_test.mbt
+++ b/src/cmark/link_definition_test.mbt
@@ -2,19 +2,19 @@
 test "link definition layout for destination with space" {
   let dest = "hello world"
   let layout = @cmark.LinkDefinitionLayout::for_dest(dest)
-  inspect(layout.angled_dest, content="true")
+  debug_inspect(layout.angled_dest, content="true")
 }
 
 ///|
 test "link definition layout for destination with control character" {
   let dest = "hello\u{0}world"
   let layout = @cmark.LinkDefinitionLayout::for_dest(dest)
-  inspect(layout.angled_dest, content="true")
+  debug_inspect(layout.angled_dest, content="true")
 }
 
 ///|
 test "link definition layout for normal destination" {
   let dest = "hello-world"
   let layout = @cmark.LinkDefinitionLayout::for_dest(dest)
-  inspect(layout.angled_dest, content="false")
+  debug_inspect(layout.angled_dest, content="false")
 }

--- a/src/cmark/mapper.mbt
+++ b/src/cmark/mapper.mbt
@@ -30,7 +30,7 @@ pub(all) struct MapperFn[A]((Mapper, A) -> MapperResult[A])
 pub(all) enum MapperResult[A] {
   Default
   Map(A?)
-} derive(Eq, Show, ToJson)
+} derive(Eq, Debug, ToJson)
 
 ///|
 pub impl[A] Default for MapperResult[A] with default() {

--- a/src/cmark/mapper_test.mbt
+++ b/src/cmark/mapper_test.mbt
@@ -2,25 +2,25 @@
 test "mapper ret function" {
   // Test ret function by passing in different types of values
   let int_result = @cmark.Mapper::ret(42)
-  inspect(int_result, content="Map(Some(42))")
+  debug_inspect(int_result, content="Map(Some(42))")
   let str_result = @cmark.Mapper::ret("hello")
-  inspect(str_result, content="Map(Some(\"hello\"))")
+  debug_inspect(str_result, content="Map(Some(\"hello\"))")
   let bool_result = @cmark.Mapper::ret(true)
-  inspect(bool_result, content="Map(Some(true))")
+  debug_inspect(bool_result, content="Map(Some(true))")
 }
 
 ///|
 test "mapper delete function" {
   // Test delete function to ensure it returns None
   let delete_result : @cmark.MapperResult[Unit] = @cmark.Mapper::delete()
-  inspect(delete_result, content="Map(None)")
+  debug_inspect(delete_result, content="Map(None)")
 }
 
 ///|
 test "Default for MapperResult" {
   // Test Default impl
   let default_result : @cmark.MapperResult[Int] = @cmark.MapperResult::default()
-  inspect(default_result, content="Default")
+  debug_inspect(default_result, content="Default")
 }
 
 ///|
@@ -28,7 +28,7 @@ test "mapper_none" {
   // Create a new Mapper with default parameters
   let mapper = @cmark.Mapper::new()
   // Call none with any value to trigger line 44
-  inspect(mapper.none(42), content="Default")
+  debug_inspect(mapper.none(42), content="Default")
 }
 
 ///|
@@ -48,7 +48,7 @@ test "map_inline with Link returns None when text is None" {
     @cmark.Node::new(@cmark.InlineLink::new(text, reference)),
   )
   let result = mapper.map_inline(link)
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -59,10 +59,10 @@ test "map_inline with StrongEmphasis" {
     @cmark.Node::new({ delim: '*', inline: text }),
   )
   let result = mapper.map_inline(strong)
-  inspect(
+  debug_inspect(
     result,
     content=(
-      #|Some(StrongEmphasis(Node::new({delim: '*', inline: Text(Node::new("strongly emphasized text"))})))
+      #|Some(StrongEmphasis(Node::new({ delim: '*', inline: Text(Node::new("strongly emphasized text")) })))
     ),
   )
 }
@@ -82,7 +82,7 @@ test "map_inline with StrongEmphasis returns None when inner inline is None" {
     @cmark.Node::new({ delim: '*', inline: text }),
   )
   let result = mapper.map_inline(strong)
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -94,10 +94,10 @@ test "map_inline with Emphasis" {
     @cmark.Node::new({ delim: '*', inline: text }),
   )
   let result = mapper.map_inline(emphasis)
-  inspect(
+  debug_inspect(
     result,
     content=(
-      #|Some(Emphasis(Node::new({delim: '*', inline: Text(Node::new("emphasized text"))})))
+      #|Some(Emphasis(Node::new({ delim: '*', inline: Text(Node::new("emphasized text")) })))
     ),
   )
 }
@@ -117,7 +117,7 @@ test "map_inline with Emphasis returns None when inner text is None" {
     @cmark.Node::new({ delim: '*', inline: text }),
   )
   let result = mapper.map_inline(emphasis)
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -138,7 +138,10 @@ test "panic inline_ext_none raises error" {
 test "map_inline default case" {
   let mapper = @cmark.Mapper::new()
   let text = @cmark.Inline::Text(@cmark.Node::new("hello"))
-  inspect(mapper.map_inline(text), content="Some(Text(Node::new(\"hello\")))")
+  debug_inspect(
+    mapper.map_inline(text),
+    content="Some(Text(Node::new(\"hello\")))",
+  )
 }
 
 ///|
@@ -146,7 +149,7 @@ test "map_doc with empty document" {
   let mapper = @cmark.Mapper::new()
   let doc = @cmark.Doc::empty()
   let result = mapper.map_doc(doc)
-  inspect(result.block, content="Blocks(Node::new(Seq([])))")
+  debug_inspect(result.block, content="Blocks(Node::new(Seq([])))")
 }
 
 ///|
@@ -154,7 +157,7 @@ test "map_block blocks" {
   // Test blocks mapping
   let mapper = @cmark.Mapper::new()
   let blocks = @cmark.Block::Blocks(@cmark.Node::new(@cmark.Seq::empty()))
-  inspect(mapper.map_block(blocks), content="None")
+  debug_inspect(mapper.map_block(blocks), content="None")
 }
 
 ///|
@@ -162,7 +165,7 @@ test "map_block with default case" {
   let mapper = @cmark.Mapper::new()
   let block = @cmark.Block::BlankLine(@cmark.Node::new(""))
   let result = mapper.map_block(block)
-  inspect(result, content="Some(BlankLine(Node::new(\"\")))")
+  debug_inspect(result, content="Some(BlankLine(Node::new(\"\")))")
 }
 
 ///|
@@ -174,7 +177,7 @@ test "map_block with blocks" {
     ),
   )
   let result = mapper.map_block(block)
-  inspect(
+  debug_inspect(
     result,
     content=(
       #|Some(Blocks(Node::new(Seq([BlankLine(Node::new(""))]))))
@@ -226,14 +229,14 @@ test "map_block with paragraph with empty inline" {
   }
   let mapper = @cmark.Mapper::new(inline=inline_fn)
   let result = mapper.map_block(paragraph)
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
 test "mapper map_inline identity" {
   let text = @cmark.Inline::Text(@cmark.Node::new("text"))
   let mapper = @cmark.Mapper::new()
-  inspect(
+  debug_inspect(
     mapper.map_inline(text),
     content=(
       #|Some(Text(Node::new("text")))
@@ -245,7 +248,7 @@ test "mapper map_inline identity" {
 test "mapper map_block identity" {
   let block = @cmark.Block::BlankLine(@cmark.Node::new(""))
   let mapper = @cmark.Mapper::new()
-  inspect(
+  debug_inspect(
     mapper.map_block(block),
     content=(
       #|Some(BlankLine(Node::new("")))
@@ -264,10 +267,36 @@ test "map_inline with Image" {
     @cmark.Node::new(@cmark.InlineLink::new(text, reference)),
   )
   let result = mapper.map_inline(image)
-  inspect(
+  debug_inspect(
     result,
     content=(
-      #|Some(Image(Node::new({text: Text(Node::new("alt text")), reference: Inline(Node::new({layout: {indent: 0, angled_dest: false, before_dest: Seq([]), after_dest: Seq([]), title_open_delim: '"', after_title: Seq([])}, label: None, defined_label: None, dest: None, title: None}))})))
+      #|Some(
+      #|  Image(
+      #|    Node::new(
+      #|      {
+      #|        text: Text(Node::new("alt text")),
+      #|        reference: Inline(
+      #|          Node::new(
+      #|            {
+      #|              layout: {
+      #|                indent: 0,
+      #|                angled_dest: false,
+      #|                before_dest: Seq([]),
+      #|                after_dest: Seq([]),
+      #|                title_open_delim: '"',
+      #|                after_title: Seq([]),
+      #|              },
+      #|              label: None,
+      #|              defined_label: None,
+      #|              dest: None,
+      #|              title: None,
+      #|            },
+      #|          ),
+      #|        ),
+      #|      },
+      #|    ),
+      #|  ),
+      #|)
     ),
   )
 }
@@ -282,10 +311,36 @@ test "map_inline with Link" {
     @cmark.Node::new(@cmark.InlineLink::new(text, reference)),
   )
   let result = mapper.map_inline(link)
-  inspect(
+  debug_inspect(
     result,
     content=(
-      #|Some(Link(Node::new({text: Text(Node::new("link text")), reference: Inline(Node::new({layout: {indent: 0, angled_dest: false, before_dest: Seq([]), after_dest: Seq([]), title_open_delim: '"', after_title: Seq([])}, label: None, defined_label: None, dest: None, title: None}))})))
+      #|Some(
+      #|  Link(
+      #|    Node::new(
+      #|      {
+      #|        text: Text(Node::new("link text")),
+      #|        reference: Inline(
+      #|          Node::new(
+      #|            {
+      #|              layout: {
+      #|                indent: 0,
+      #|                angled_dest: false,
+      #|                before_dest: Seq([]),
+      #|                after_dest: Seq([]),
+      #|                title_open_delim: '"',
+      #|                after_title: Seq([]),
+      #|              },
+      #|              label: None,
+      #|              defined_label: None,
+      #|              dest: None,
+      #|              title: None,
+      #|            },
+      #|          ),
+      #|        ),
+      #|      },
+      #|    ),
+      #|  ),
+      #|)
     ),
   )
 }
@@ -299,10 +354,10 @@ test "map_inline with Emphasis (2)" {
     @cmark.Node::new({ delim: '*', inline: text }),
   )
   let result = mapper.map_inline(emphasis)
-  inspect(
+  debug_inspect(
     result,
     content=(
-      #|Some(Emphasis(Node::new({delim: '*', inline: Text(Node::new("emphasized text"))})))
+      #|Some(Emphasis(Node::new({ delim: '*', inline: Text(Node::new("emphasized text")) })))
     ),
   )
 }
@@ -325,7 +380,7 @@ test "map_inline with StrongEmphasis with None inline result" {
   }
   let mapper = @cmark.Mapper::new(inline=inline_fn)
   let result = mapper.map_inline(strong)
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -337,7 +392,7 @@ test "map_inline with Inlines" {
   ])
   let inlines = @cmark.Inline::Inlines(@cmark.Node::new(seq))
   let result = mapper.map_inline(inlines)
-  inspect(
+  debug_inspect(
     result,
     content="Some(Inlines(Node::new(Seq([Text(Node::new(\"text 1\")), Text(Node::new(\"text 2\"))]))))",
   )
@@ -360,7 +415,7 @@ test "map_inline with Inlines that becomes empty" {
   }
   let mapper = @cmark.Mapper::new(inline=inline_fn)
   let result = mapper.map_inline(inlines)
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -372,7 +427,7 @@ test "map_inline with ExtStrikethrough" {
     ),
   )
   let result = mapper.map_inline(strikethrough)
-  inspect(
+  debug_inspect(
     result,
     content=(
       #|Some(ExtStrikethrough(Node::new(InlineStrikethrough(Text(Node::new("strikethrough text"))))))
@@ -397,7 +452,7 @@ test "map_inline with ExtStrikethrough with None inline result" {
   }
   let mapper = @cmark.Mapper::new(inline=inline_fn)
   let result = mapper.map_inline(strikethrough)
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -417,10 +472,21 @@ test "map_block with Heading" {
     }),
   )
   let result = mapper.map_block(heading)
-  inspect(
+  debug_inspect(
     result,
     content=(
-      #|Some(Heading(Node::new({layout: Atx({indent: 0, after_opening: "", closing: ""}), level: 1, inline: Text(Node::new("Heading")), id: None})))
+      #|Some(
+      #|  Heading(
+      #|    Node::new(
+      #|      {
+      #|        layout: Atx({ indent: 0, after_opening: "", closing: "" }),
+      #|        level: 1,
+      #|        inline: Text(Node::new("Heading")),
+      #|        id: None,
+      #|      },
+      #|    ),
+      #|  ),
+      #|)
     ),
   )
 }
@@ -439,8 +505,27 @@ test "map_block with BlockQuote" {
     @cmark.Node::new({ indent: 0, block: para }),
   )
   let result = mapper.map_block(blockquote)
-  inspect(
+  debug_inspect(
     result,
-    content="Some(BlockQuote(Node::new({indent: 0, block: Paragraph(Node::new({leading_indent: 0, inline: Text(Node::new(\"quoted text\")), trailing_blanks: \"\"}))})))",
+    content=(
+      #|Some(
+      #|  BlockQuote(
+      #|    Node::new(
+      #|      {
+      #|        indent: 0,
+      #|        block: Paragraph(
+      #|          Node::new(
+      #|            {
+      #|              leading_indent: 0,
+      #|              inline: Text(Node::new("quoted text")),
+      #|              trailing_blanks: "",
+      #|            },
+      #|          ),
+      #|        ),
+      #|      },
+      #|    ),
+      #|  ),
+      #|)
+    ),
   )
 }

--- a/src/cmark/mapper_test.mbt
+++ b/src/cmark/mapper_test.mbt
@@ -62,7 +62,42 @@ test "map_inline with StrongEmphasis" {
   debug_inspect(
     result,
     content=(
-      #|Some(StrongEmphasis(Node::new({ delim: '*', inline: Text(Node::new("strongly emphasized text")) })))
+      #|Some(
+      #|  StrongEmphasis(
+      #|    {
+      #|      v: {
+      #|        delim: '*',
+      #|        inline: Text(
+      #|          {
+      #|            v: "strongly emphasized text",
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|      },
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
     ),
   )
 }
@@ -97,7 +132,42 @@ test "map_inline with Emphasis" {
   debug_inspect(
     result,
     content=(
-      #|Some(Emphasis(Node::new({ delim: '*', inline: Text(Node::new("emphasized text")) })))
+      #|Some(
+      #|  Emphasis(
+      #|    {
+      #|      v: {
+      #|        delim: '*',
+      #|        inline: Text(
+      #|          {
+      #|            v: "emphasized text",
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|      },
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
     ),
   )
 }
@@ -140,7 +210,26 @@ test "map_inline default case" {
   let text = @cmark.Inline::Text(@cmark.Node::new("hello"))
   debug_inspect(
     mapper.map_inline(text),
-    content="Some(Text(Node::new(\"hello\")))",
+    content=(
+      #|Some(
+      #|  Text(
+      #|    {
+      #|      v: "hello",
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
   )
 }
 
@@ -149,7 +238,27 @@ test "map_doc with empty document" {
   let mapper = @cmark.Mapper::new()
   let doc = @cmark.Doc::empty()
   let result = mapper.map_doc(doc)
-  debug_inspect(result.block, content="Blocks(Node::new(Seq([])))")
+  debug_inspect(
+    result.block,
+    content=(
+      #|Blocks(
+      #|  {
+      #|    v: Seq([]),
+      #|    meta: {
+      #|      id: 0,
+      #|      loc: {
+      #|        file: "-",
+      #|        first_ccode: -1,
+      #|        last_ccode: -1,
+      #|        first_line: LinePos(-1, -1),
+      #|        last_line: LinePos(-1, -1),
+      #|      },
+      #|      extra: None,
+      #|    },
+      #|  },
+      #|)
+    ),
+  )
 }
 
 ///|
@@ -165,7 +274,29 @@ test "map_block with default case" {
   let mapper = @cmark.Mapper::new()
   let block = @cmark.Block::BlankLine(@cmark.Node::new(""))
   let result = mapper.map_block(block)
-  debug_inspect(result, content="Some(BlankLine(Node::new(\"\")))")
+  debug_inspect(
+    result,
+    content=(
+      #|Some(
+      #|  BlankLine(
+      #|    {
+      #|      v: "",
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
+  )
 }
 
 ///|
@@ -180,7 +311,43 @@ test "map_block with blocks" {
   debug_inspect(
     result,
     content=(
-      #|Some(Blocks(Node::new(Seq([BlankLine(Node::new(""))]))))
+      #|Some(
+      #|  Blocks(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
     ),
   )
 }
@@ -239,7 +406,24 @@ test "mapper map_inline identity" {
   debug_inspect(
     mapper.map_inline(text),
     content=(
-      #|Some(Text(Node::new("text")))
+      #|Some(
+      #|  Text(
+      #|    {
+      #|      v: "text",
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
     ),
   )
 }
@@ -251,7 +435,24 @@ test "mapper map_block identity" {
   debug_inspect(
     mapper.map_block(block),
     content=(
-      #|Some(BlankLine(Node::new("")))
+      #|Some(
+      #|  BlankLine(
+      #|    {
+      #|      v: "",
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
     ),
   )
 }
@@ -272,12 +473,27 @@ test "map_inline with Image" {
     content=(
       #|Some(
       #|  Image(
-      #|    Node::new(
-      #|      {
-      #|        text: Text(Node::new("alt text")),
+      #|    {
+      #|      v: {
+      #|        text: Text(
+      #|          {
+      #|            v: "alt text",
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
       #|        reference: Inline(
-      #|          Node::new(
-      #|            {
+      #|          {
+      #|            v: {
       #|              layout: {
       #|                indent: 0,
       #|                angled_dest: false,
@@ -291,10 +507,32 @@ test "map_inline with Image" {
       #|              dest: None,
       #|              title: None,
       #|            },
-      #|          ),
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
       #|        ),
       #|      },
-      #|    ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
       #|  ),
       #|)
     ),
@@ -316,12 +554,27 @@ test "map_inline with Link" {
     content=(
       #|Some(
       #|  Link(
-      #|    Node::new(
-      #|      {
-      #|        text: Text(Node::new("link text")),
+      #|    {
+      #|      v: {
+      #|        text: Text(
+      #|          {
+      #|            v: "link text",
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
       #|        reference: Inline(
-      #|          Node::new(
-      #|            {
+      #|          {
+      #|            v: {
       #|              layout: {
       #|                indent: 0,
       #|                angled_dest: false,
@@ -335,10 +588,32 @@ test "map_inline with Link" {
       #|              dest: None,
       #|              title: None,
       #|            },
-      #|          ),
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
       #|        ),
       #|      },
-      #|    ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
       #|  ),
       #|)
     ),
@@ -357,7 +632,42 @@ test "map_inline with Emphasis (2)" {
   debug_inspect(
     result,
     content=(
-      #|Some(Emphasis(Node::new({ delim: '*', inline: Text(Node::new("emphasized text")) })))
+      #|Some(
+      #|  Emphasis(
+      #|    {
+      #|      v: {
+      #|        delim: '*',
+      #|        inline: Text(
+      #|          {
+      #|            v: "emphasized text",
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|      },
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
     ),
   )
 }
@@ -394,7 +704,61 @@ test "map_inline with Inlines" {
   let result = mapper.map_inline(inlines)
   debug_inspect(
     result,
-    content="Some(Inlines(Node::new(Seq([Text(Node::new(\"text 1\")), Text(Node::new(\"text 2\"))]))))",
+    content=(
+      #|Some(
+      #|  Inlines(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          Text(
+      #|            {
+      #|              v: "text 1",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Text(
+      #|            {
+      #|              v: "text 2",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
   )
 }
 
@@ -430,7 +794,41 @@ test "map_inline with ExtStrikethrough" {
   debug_inspect(
     result,
     content=(
-      #|Some(ExtStrikethrough(Node::new(InlineStrikethrough(Text(Node::new("strikethrough text"))))))
+      #|Some(
+      #|  ExtStrikethrough(
+      #|    {
+      #|      v: InlineStrikethrough(
+      #|        Text(
+      #|          {
+      #|            v: "strikethrough text",
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
     ),
   )
 }
@@ -477,14 +875,40 @@ test "map_block with Heading" {
     content=(
       #|Some(
       #|  Heading(
-      #|    Node::new(
-      #|      {
+      #|    {
+      #|      v: {
       #|        layout: Atx({ indent: 0, after_opening: "", closing: "" }),
       #|        level: 1,
-      #|        inline: Text(Node::new("Heading")),
+      #|        inline: Text(
+      #|          {
+      #|            v: "Heading",
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
       #|        id: None,
       #|      },
-      #|    ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
       #|  ),
       #|)
     ),
@@ -510,20 +934,57 @@ test "map_block with BlockQuote" {
     content=(
       #|Some(
       #|  BlockQuote(
-      #|    Node::new(
-      #|      {
+      #|    {
+      #|      v: {
       #|        indent: 0,
       #|        block: Paragraph(
-      #|          Node::new(
-      #|            {
+      #|          {
+      #|            v: {
       #|              leading_indent: 0,
-      #|              inline: Text(Node::new("quoted text")),
+      #|              inline: Text(
+      #|                {
+      #|                  v: "quoted text",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|              ),
       #|              trailing_blanks: "",
       #|            },
-      #|          ),
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
       #|        ),
       #|      },
-      #|    ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
       #|  ),
       #|)
     ),

--- a/src/cmark/moon.pkg
+++ b/src/cmark/moon.pkg
@@ -4,6 +4,7 @@ import {
   "moonbit-community/cmark/char",
   "moonbit-community/cmark/cmark_base",
   "moonbitlang/core/cmp",
+  "moonbitlang/core/debug",
   "moonbitlang/core/deque",
   "moonbitlang/core/sorted_set",
   "moonbitlang/core/json",

--- a/src/cmark/node.mbt
+++ b/src/cmark/node.mbt
@@ -15,14 +15,12 @@ pub fn[A, B] Node::map(self : Node[A], f : (A) -> B) -> Node[B] {
 }
 
 ///|
-pub impl[A : Show] Show for Node[A] with output(self, logger) {
-  logger.write_string("Node::new(")
-  logger.write_object(self.v)
+pub impl[A : @debug.Debug] @debug.Debug for Node[A] with to_repr(self) {
+  let args : Array[(String?, @debug.Repr)] = [(None, @debug.to_repr(self.v))]
   if !self.meta.is_none() {
-    logger.write_string(", meta=")
-    logger.write_object(self.meta)
+    args.push((Some("meta"), @debug.to_repr(self.meta)))
   }
-  logger.write_char(')')
+  @debug.Repr::ctor("Node::new", args)
 }
 
 ///|

--- a/src/cmark/node.mbt
+++ b/src/cmark/node.mbt
@@ -2,7 +2,7 @@
 pub(all) struct Node[A] {
   v : A
   meta : Meta
-} derive(Eq)
+} derive(Eq, Debug)
 
 ///|
 pub fn[A] Node::new(v : A, meta? : Meta = Meta::none()) -> Node[A] {
@@ -12,15 +12,6 @@ pub fn[A] Node::new(v : A, meta? : Meta = Meta::none()) -> Node[A] {
 ///|
 pub fn[A, B] Node::map(self : Node[A], f : (A) -> B) -> Node[B] {
   { v: f(self.v), meta: self.meta }
-}
-
-///|
-pub impl[A : @debug.Debug] @debug.Debug for Node[A] with to_repr(self) {
-  let args : Array[(String?, @debug.Repr)] = [(None, @debug.to_repr(self.v))]
-  if !self.meta.is_none() {
-    args.push((Some("meta"), @debug.to_repr(self.meta)))
-  }
-  @debug.Repr::ctor("Node::new", args)
 }
 
 ///|

--- a/src/cmark/node_test.mbt
+++ b/src/cmark/node_test.mbt
@@ -3,6 +3,11 @@ test "node_map" {
   let meta = @cmark_base.Meta::new()
   let node = @cmark.Node::new("test", meta~)
   let mapped = node.map(fn(s) { s + "!" })
-  inspect(mapped.v, content="test!")
-  inspect(mapped.meta.is_none(), content="false")
+  debug_inspect(
+    mapped.v,
+    content=(
+      #|"test!"
+    ),
+  )
+  debug_inspect(mapped.meta.is_none(), content="false")
 }

--- a/src/cmark/pkg.generated.mbti
+++ b/src/cmark/pkg.generated.mbti
@@ -348,12 +348,11 @@ pub impl[A] Default for MapperResult[A]
 pub(all) struct Node[A] {
   v : A
   meta : @cmark_base.Meta
-} derive(Eq)
+} derive(Eq, @debug.Debug)
 pub fn Node::empty(meta? : @cmark_base.Meta) -> Self[String]
 pub fn[A, B] Node::map(Self[A], (A) -> B) -> Self[B]
 pub fn[A] Node::new(A, meta? : @cmark_base.Meta) -> Self[A]
 pub impl[A : ToJson] ToJson for Node[A]
-pub impl[A : @debug.Debug] @debug.Debug for Node[A]
 
 pub(all) enum ReferenceKind {
   Inline(Node[LinkDefinition])
@@ -408,11 +407,10 @@ pub(all) struct TableSep((TableAlign?, Int)) derive(ToJson, @debug.Debug)
 pub(all) struct Tight {
   blanks : String
   node : Node[String]
-} derive(Eq, ToJson)
+} derive(Eq, ToJson, @debug.Debug)
 pub fn Tight::empty(meta? : @cmark_base.Meta) -> Self
 pub fn Tight::list_text_loc(Seq[Self]) -> @cmark_base.TextLoc
 pub fn Tight::to_string(Self) -> String
-pub impl @debug.Debug for Tight
 
 // Type aliases
 pub type Blanks = String

--- a/src/cmark/pkg.generated.mbti
+++ b/src/cmark/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "moonbit-community/cmark/cmark"
 
 import {
   "moonbit-community/cmark/cmark_base",
+  "moonbitlang/core/debug",
   "moonbitlang/core/json",
 }
 
@@ -18,11 +19,11 @@ pub fn layout_of_string(meta? : @cmark_base.Meta, String) -> Node[String]
 // Errors
 pub(all) suberror FolderError {
   FolderError(String)
-} derive(Show)
+} derive(@debug.Debug)
 
 pub(all) suberror MapperError {
   MapperError(String)
-} derive(Show)
+} derive(@debug.Debug)
 
 // Types and methods
 pub(all) enum Block {
@@ -39,7 +40,7 @@ pub(all) enum Block {
   ExtMathBlock(Node[CodeBlock])
   ExtTable(Node[Table])
   ExtFootnoteDefinition(Node[Footnote])
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 pub fn Block::defs(Self, init? : Map[String, LabelDef]) -> Map[String, LabelDef]
 pub fn Block::empty() -> Self
 pub fn Block::meta(Self) -> @cmark_base.Meta
@@ -50,25 +51,25 @@ pub(all) struct BlockHeading {
   level : Int
   inline : Inline
   id : BlockHeadingId?
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 pub fn BlockHeading::new(id? : BlockHeadingId?, layout? : BlockHeadingLayout, level~ : Int, Inline) -> Self
 
 pub(all) struct BlockHeadingAtxLayout {
   indent : Int
   after_opening : String
   closing : String
-} derive(Show, ToJson, @json.FromJson)
+} derive(ToJson, @debug.Debug, @json.FromJson)
 pub fn BlockHeadingAtxLayout::default() -> Self
 
 pub(all) enum BlockHeadingId {
   Auto(String)
   Id(String)
-} derive(Show, ToJson, @json.FromJson)
+} derive(ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) enum BlockHeadingLayout {
   Atx(BlockHeadingAtxLayout)
   Setext(BlockHeadingSetextLayout)
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 
 pub(all) struct BlockHeadingSetextLayout {
   leading_indent : Int
@@ -76,7 +77,7 @@ pub(all) struct BlockHeadingSetextLayout {
   underline_indent : Int
   underline_count : Node[Int]
   underline_blanks : String
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 
 pub(all) struct BlockLine(Node[String])
 pub fn BlockLine::list_text_loc(Seq[Self]) -> @cmark_base.TextLoc
@@ -86,7 +87,7 @@ pub(all) struct BlockList {
   ty : @cmark_base.ListType
   tight : Bool
   items : Seq[Node[ListItem]]
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 pub fn BlockList::map_items(Self, (ListItem) -> ListItem) -> Self
 pub fn BlockList::normalize_items(Self) -> Self
 
@@ -94,13 +95,13 @@ pub(all) struct BlockParagraph {
   leading_indent : Int
   inline : Inline
   trailing_blanks : String
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 pub fn BlockParagraph::new(leading_indent? : Int, trailing_blanks? : String, Inline) -> Self
 
 pub(all) struct BlockQuote {
   indent : Int
   block : Block
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 pub fn BlockQuote::map_block(Self, (Block) -> Block) -> Self
 pub fn BlockQuote::new(indent? : Int, Block) -> Self
 pub fn BlockQuote::normalize_block(Self) -> Self
@@ -108,14 +109,14 @@ pub fn BlockQuote::normalize_block(Self) -> Self
 pub(all) struct BlockThematicBreak {
   indent : Int
   layout : String
-} derive(Show, ToJson, @json.FromJson)
+} derive(ToJson, @debug.Debug, @json.FromJson)
 pub fn BlockThematicBreak::new(indent? : Int, layout? : String) -> Self
 
 pub(all) struct CodeBlock {
   layout : CodeBlockLayout
   info_string : Node[String]?
   code : Seq[Node[String]]
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 pub fn CodeBlock::language_of_info_string(String) -> (String, String)?
 pub fn CodeBlock::make_fence(Self) -> (Char, Int)
 pub fn CodeBlock::new(layout? : CodeBlockLayout, info_string? : Node[String]?, Seq[Node[String]]) -> Self
@@ -124,19 +125,19 @@ pub(all) struct CodeBlockFencedLayout {
   indent : Int
   opening_fence : Node[String]
   closing_fence : Node[String]?
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 pub fn CodeBlockFencedLayout::default() -> Self
 
 pub(all) enum CodeBlockLayout {
   Indented
   Fenced(CodeBlockFencedLayout)
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 
 pub(all) struct Doc {
   nl : String
   block : Block
   defs : Map[String, LabelDef]
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 pub fn Doc::empty() -> Self
 pub fn Doc::from_string(defs? : Map[String, LabelDef], resolver? : LabelResolverFn, nested_links? : Bool, heading_auto_ids? : Bool, layout? : Bool, locs? : Bool, file? : String, strict? : Bool, String) -> Self
 pub fn Doc::new(nl? : String, defs? : Map[String, LabelDef], Block) -> Self
@@ -163,7 +164,7 @@ pub(all) struct FolderFn[A, B]((Folder[B], B, A) -> FolderResult[B])
 pub(all) enum FolderResult[A] {
   Default
   Fold(A)
-} derive(Eq, Show, ToJson)
+} derive(Eq, ToJson, @debug.Debug)
 pub impl[A] Default for FolderResult[A]
 
 pub(all) struct Footnote {
@@ -171,12 +172,12 @@ pub(all) struct Footnote {
   label : Label
   defined_label : Label?
   block : Block
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 pub fn Footnote::map_block(Self, (Block) -> Block) -> Self
 pub fn Footnote::new(indent? : Int, defined_label? : Label?, Label, Block) -> Self
 pub fn Footnote::normalize_block(Self) -> Self
 
-pub(all) struct HtmlBlock(Seq[Node[String]]) derive(Show, ToJson)
+pub(all) struct HtmlBlock(Seq[Node[String]]) derive(ToJson, @debug.Debug)
 
 pub(all) enum Inline {
   Autolink(Node[InlineAutolink])
@@ -191,7 +192,7 @@ pub(all) enum Inline {
   Text(Node[String])
   ExtStrikethrough(Node[InlineStrikethrough])
   ExtMathSpan(Node[InlineMathSpan])
-} derive(Eq, Show, ToJson)
+} derive(Eq, ToJson, @debug.Debug)
 pub fn Inline::empty() -> Self
 pub fn Inline::id(Self, buf? : StringBuilder) -> String
 pub fn Inline::is_empty(Self) -> Bool
@@ -202,25 +203,25 @@ pub fn Inline::to_plain_text(Self, break_on_soft~ : Bool) -> Seq[Seq[String]]
 pub(all) struct InlineAutolink {
   is_email : Bool
   link : Node[String]
-} derive(Eq, Show, ToJson)
+} derive(Eq, ToJson, @debug.Debug)
 pub fn InlineAutolink::new(Node[String]) -> Self
 
 pub(all) struct InlineBreak {
   layout_before : Node[String]
   ty : InlineBreakType
   layout_after : Node[String]
-} derive(Eq, Show, ToJson)
+} derive(Eq, ToJson, @debug.Debug)
 pub fn InlineBreak::new(layout_before? : Node[String], layout_after? : Node[String], InlineBreakType) -> Self
 
 pub(all) enum InlineBreakType {
   Hard
   Soft
-} derive(Compare, Eq, Show, ToJson, @json.FromJson)
+} derive(Compare, Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) struct InlineCodeSpan {
   backticks : Int
   code_layout : Seq[Tight]
-} derive(Eq, Show, ToJson)
+} derive(Eq, ToJson, @debug.Debug)
 pub fn InlineCodeSpan::code(Self) -> String
 pub fn InlineCodeSpan::from_string(meta? : @cmark_base.Meta, String) -> Self
 pub fn InlineCodeSpan::new(backticks~ : Int, Seq[Tight]) -> Self
@@ -228,13 +229,13 @@ pub fn InlineCodeSpan::new(backticks~ : Int, Seq[Tight]) -> Self
 pub(all) struct InlineEmphasis {
   delim : Char
   inline : Inline
-} derive(Eq, Show, ToJson)
+} derive(Eq, ToJson, @debug.Debug)
 pub fn InlineEmphasis::new(delim? : Char, Inline) -> Self
 
 pub(all) struct InlineLink {
   text : Inline
   reference : ReferenceKind
-} derive(Eq, Show, ToJson)
+} derive(Eq, ToJson, @debug.Debug)
 pub fn InlineLink::is_unsafe(String) -> Bool
 pub fn InlineLink::new(Inline, ReferenceKind) -> Self
 pub fn InlineLink::reference_definition(Self, Map[String, LabelDef]) -> LabelDef?
@@ -243,18 +244,18 @@ pub fn InlineLink::referenced_label(Self) -> Label?
 pub(all) struct InlineMathSpan {
   display : Bool
   tex_layout : Seq[Tight]
-} derive(Eq, Show, ToJson)
+} derive(Eq, ToJson, @debug.Debug)
 pub fn InlineMathSpan::tex(Self) -> String
 
-pub(all) struct InlineRawHtml(Seq[Tight]) derive(Eq, Show, ToJson)
+pub(all) struct InlineRawHtml(Seq[Tight]) derive(Eq, ToJson, @debug.Debug)
 
-pub(all) struct InlineStrikethrough(Inline) derive(Eq, Show, ToJson)
+pub(all) struct InlineStrikethrough(Inline) derive(Eq, ToJson, @debug.Debug)
 
 pub(all) struct Label {
   meta : @cmark_base.Meta
   key : String
   text : Seq[Tight]
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 pub fn Label::compare(Self, Self) -> Int
 pub fn Label::new(meta? : @cmark_base.Meta, key~ : String, Seq[Tight]) -> Self
 pub fn Label::text_loc(Self) -> @cmark_base.TextLoc
@@ -269,7 +270,7 @@ pub fn LabelContext::default_resolver(Self) -> Label?
 pub(all) enum LabelDef {
   LinkDef(Node[LinkDefinition])
   FootnoteDef(Node[Footnote])
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 
 pub(all) struct LabelResolverFn((LabelContext) -> Label?)
 
@@ -279,7 +280,7 @@ pub(all) struct LinkDefinition {
   defined_label : Label?
   dest : Node[String]?
   title : Seq[Tight]?
-} derive(Eq, Show, ToJson)
+} derive(Eq, ToJson, @debug.Debug)
 pub fn LinkDefinition::new(layout? : LinkDefinitionLayout, label? : Label?, defined_label? : Label?, dest? : Node[String]?, title? : Seq[Tight]?) -> Self
 
 pub(all) struct LinkDefinitionLayout {
@@ -289,7 +290,7 @@ pub(all) struct LinkDefinitionLayout {
   after_dest : Seq[Node[String]]
   title_open_delim : Char
   after_title : Seq[Node[String]]
-} derive(Eq, Show, ToJson)
+} derive(Eq, ToJson, @debug.Debug)
 pub fn LinkDefinitionLayout::default() -> Self
 pub fn LinkDefinitionLayout::for_dest(String) -> Self
 
@@ -305,7 +306,7 @@ pub(all) struct ListItem {
   after_marker : Int
   block : Block
   ext_task_marker : Node[Char]?
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 pub fn ListItem::map_block(Self, (Block) -> Block) -> Self
 pub fn ListItem::new(before_marker? : Int, marker? : Node[String], after_marker? : Int, ext_task_marker~ : Node[Char]?, Block) -> Self
 pub fn ListItem::normalize_block(Self) -> Self
@@ -341,7 +342,7 @@ pub(all) struct MapperFn[A]((Mapper, A) -> MapperResult[A])
 pub(all) enum MapperResult[A] {
   Default
   Map(A?)
-} derive(Eq, Show, ToJson)
+} derive(Eq, ToJson, @debug.Debug)
 pub impl[A] Default for MapperResult[A]
 
 pub(all) struct Node[A] {
@@ -351,21 +352,21 @@ pub(all) struct Node[A] {
 pub fn Node::empty(meta? : @cmark_base.Meta) -> Self[String]
 pub fn[A, B] Node::map(Self[A], (A) -> B) -> Self[B]
 pub fn[A] Node::new(A, meta? : @cmark_base.Meta) -> Self[A]
-pub impl[A : Show] Show for Node[A]
 pub impl[A : ToJson] ToJson for Node[A]
+pub impl[A : @debug.Debug] @debug.Debug for Node[A]
 
 pub(all) enum ReferenceKind {
   Inline(Node[LinkDefinition])
   Ref(ReferenceLayout, Label, Label)
-} derive(Eq, Show, ToJson)
+} derive(Eq, ToJson, @debug.Debug)
 
 pub(all) enum ReferenceLayout {
   Collapsed
   Full
   Shortcut
-} derive(Eq, Show, ToJson, @json.FromJson)
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-type Seq[A] derive(Eq, Show)
+type Seq[A] derive(Eq, @debug.Debug)
 pub fn[A] Seq::empty() -> Self[A]
 pub fn[A, B] Seq::fold(Self[A], init~ : B, (B, A) -> B) -> B
 pub fn[A] Seq::from_array(Array[A]) -> Self[A]
@@ -385,24 +386,24 @@ pub(all) struct Table {
   indent : Int
   col_count : Int
   rows : Seq[(Node[TableRow], String)]
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 pub fn Table::new(indent? : Int, Seq[(Node[TableRow], String)]) -> Self
 
 pub(all) enum TableAlign {
   Left
   Center
   Right
-} derive(Show, ToJson, @json.FromJson)
+} derive(ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct TableCellLayout((String, String)) derive(Compare, Eq, Show, ToJson)
+pub(all) struct TableCellLayout((String, String)) derive(Compare, Eq, ToJson, @debug.Debug)
 
 pub(all) enum TableRow {
   Header(Seq[(Inline, TableCellLayout)])
   Sep(Seq[Node[TableSep]])
   Data(Seq[(Inline, TableCellLayout)])
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 
-pub(all) struct TableSep((TableAlign?, Int)) derive(Show, ToJson)
+pub(all) struct TableSep((TableAlign?, Int)) derive(ToJson, @debug.Debug)
 
 pub(all) struct Tight {
   blanks : String
@@ -411,7 +412,7 @@ pub(all) struct Tight {
 pub fn Tight::empty(meta? : @cmark_base.Meta) -> Self
 pub fn Tight::list_text_loc(Seq[Self]) -> @cmark_base.TextLoc
 pub fn Tight::to_string(Self) -> String
-pub impl Show for Tight
+pub impl @debug.Debug for Tight
 
 // Type aliases
 pub type Blanks = String

--- a/src/cmark/seq.mbt
+++ b/src/cmark/seq.mbt
@@ -1,5 +1,5 @@
 ///|
-struct Seq[A](Array[A]) derive(Eq, Show)
+struct Seq[A](Array[A]) derive(Eq, Debug)
 
 ///|
 pub impl[A : ToJson] ToJson for Seq[A] with to_json(self) -> Json {

--- a/src/cmark_base/README.mbt.md
+++ b/src/cmark_base/README.mbt.md
@@ -17,14 +17,20 @@ test "text location handling" {
     last_line: LinePos(1, 10),
   }
   let after_loc = loc.after()
-  inspect(
+  debug_inspect(
     after_loc,
     content=(
-      #|{file: "test.md", first_ccode: 1, last_ccode: -1, first_line: LinePos(1, 10), last_line: LinePos(-1, -1)}
+      #|{
+      #|  file: "test.md",
+      #|  first_ccode: 1,
+      #|  last_ccode: -1,
+      #|  first_line: LinePos(1, 10),
+      #|  last_line: LinePos(-1, -1),
+      #|}
     ),
   )
   let none_loc = @cmark_base.TextLoc::none()
-  inspect(none_loc.is_none(), content="true")
+  debug_inspect(none_loc.is_none(), content="true")
 }
 ```
 
@@ -36,9 +42,9 @@ The package provides functions for parsing links, URIs and email addresses:
 ///|
 test "link parsing" {
   let txt = "Visit <https://mooncakes.io/>!"
-  inspect(@cmark_base.autolink_uri(txt, start=6), content="Some(28)")
+  debug_inspect(@cmark_base.autolink_uri(txt, start=6), content="Some(28)")
   let email = "Contact <user@example.com> today!"
-  inspect(@cmark_base.autolink_email(email, start=8), content="Some(25)")
+  debug_inspect(@cmark_base.autolink_email(email, start=8), content="Some(25)")
 }
 ```
 
@@ -52,10 +58,16 @@ test "string analysis" {
   let start = 0
 
   // Find first non-blank character
-  inspect(@cmark_base.first_non_blank("  hello", last=7, start~), content="2")
+  debug_inspect(
+    @cmark_base.first_non_blank("  hello", last=7, start~),
+    content="2",
+  )
 
   // Count repeated characters
-  inspect(@cmark_base.run_of(char='-', "---hello", last=8, start~), content="2")
+  debug_inspect(
+    @cmark_base.run_of(char='-', "---hello", last=8, start~),
+    content="2",
+  )
 }
 ```
 
@@ -69,23 +81,23 @@ test "line type detection" {
   let start = 0
 
   // ATX Heading
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::atx_heading("# Heading", last=8, start~),
     content="AtxHeadingLine(1, 1, 2, 8)",
   )
 
   // Thematic Break
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::thematic_break("---", last=2, start~),
     content="ThematicBreakLine(2)",
   )
 
   // List Items
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::list_marker("- Item", last=5, start~),
     content="ListMarkerLine(Unordered('-'), 0)",
   )
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::list_marker("1. Item", last=6, start~),
     content="ListMarkerLine(Ordered(1, '.'), 1)",
   )
@@ -103,8 +115,8 @@ test "list types" {
   let ordered = @cmark_base.ListType::Ordered(1, '.')
 
   // Check if lists are of same type
-  inspect(unordered.is_same_type(unordered), content="true")
-  inspect(unordered.is_same_type(ordered), content="false")
+  debug_inspect(unordered.is_same_type(unordered), content="true")
+  debug_inspect(unordered.is_same_type(ordered), content="false")
 }
 ```
 
@@ -116,11 +128,11 @@ Support for detecting and parsing HTML blocks:
 ///|
 test "html blocks" {
   let start = 0
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start("<div>", last=5, start~),
     content="HtmlBlockLine(EndBlank)",
   )
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_end(
       "</div></br>",
       end_cond=@cmark_base.HtmlBlockEndCond::EndStr("</div>"),
@@ -147,8 +159,8 @@ test "metadata handling" {
     last_line: LinePos(1, 10),
   }
   let meta = @cmark_base.Meta::new(loc~)
-  inspect(meta.is_none(), content="false")
+  debug_inspect(meta.is_none(), content="false")
   let none_meta = @cmark_base.Meta::none()
-  inspect(none_meta.is_none(), content="true")
+  debug_inspect(none_meta.is_none(), content="true")
 }
 ```

--- a/src/cmark_base/autolink_test.mbt
+++ b/src/cmark_base/autolink_test.mbt
@@ -1,41 +1,41 @@
 ///|
 test "autolink_email invalid label sequence with non-alphanumeric char" {
-  inspect(@cmark_base.autolink_email("<a@#>"), content="None")
+  debug_inspect(@cmark_base.autolink_email("<a@#>"), content="None")
 }
 
 ///|
 test "autolink_email label sequence with invalid end char" {
-  inspect(@cmark_base.autolink_email("<a@a#"), content="None")
+  debug_inspect(@cmark_base.autolink_email("<a@a#"), content="None")
 }
 
 ///|
 test "autolink_email invalid start" {
-  inspect(@cmark_base.autolink_email("hello"), content="None")
+  debug_inspect(@cmark_base.autolink_email("hello"), content="None")
 }
 
 ///|
 test "autolink_email label sequence ending with invalid char" {
-  inspect(@cmark_base.autolink_email("<a@abc$>"), content="None")
+  debug_inspect(@cmark_base.autolink_email("<a@abc$>"), content="None")
 }
 
 ///|
 test "email autolink - premature end" {
   let email = "<a@b"
-  inspect(@cmark_base.autolink_email(email), content="None")
+  debug_inspect(@cmark_base.autolink_email(email), content="None")
 }
 
 ///|
 test "email autolink - non-alphanum ending" {
   let email = "<a@b->"
-  inspect(@cmark_base.autolink_email(email), content="None")
+  debug_inspect(@cmark_base.autolink_email(email), content="None")
 }
 
 ///|
 test "autolink_uri - incomplete uri at end of string" {
-  inspect(@cmark_base.autolink_uri("<http://example.com"), content="None")
+  debug_inspect(@cmark_base.autolink_uri("<http://example.com"), content="None")
 }
 
 ///|
 test "autolink_uri - incomplete uri with empty content" {
-  inspect(@cmark_base.autolink_uri("<http:"), content="None")
+  debug_inspect(@cmark_base.autolink_uri("<http:"), content="None")
 }

--- a/src/cmark_base/leaf_blocks.mbt
+++ b/src/cmark_base/leaf_blocks.mbt
@@ -7,7 +7,7 @@ pub(all) enum HtmlBlockEndCond {
   EndCond1
   EndBlank
   EndBlank7
-} derive(Show, ToJson, Eq)
+} derive(Debug, ToJson, Eq)
 
 ///|
 pub(all) enum ListType {
@@ -15,7 +15,7 @@ pub(all) enum ListType {
   Unordered(Char)
   /// Starting at given integer, markers ending with given character, i.e. ')' or '.'.
   Ordered(Int, Char)
-} derive(Show, FromJson, ToJson, Eq)
+} derive(Debug, FromJson, ToJson, Eq)
 
 ///|
 pub fn ListType::is_same_type(self : ListType, other : ListType) -> Bool {
@@ -39,7 +39,7 @@ pub(all) enum LineType {
   ExtTableRow(Last)
   ExtFootnoteLabel(Array[Span], Last, String)
   Nomatch
-} derive(Show, ToJson, Eq)
+} derive(Debug, ToJson, Eq)
 
 ///|
 /// https://spec.commonmark.org/current/#thematic-breaks
@@ -249,7 +249,7 @@ pub fn LineType::fenced_code_block_start(
 pub(all) enum FencedCodeBlockContinue {
   Close(First, Last)
   Code
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 /// `fenced_code_block_continue(fence, s, last, start)` indicates

--- a/src/cmark_base/leaf_blocks_test.mbt
+++ b/src/cmark_base/leaf_blocks_test.mbt
@@ -1,7 +1,7 @@
 ///|
 test "thematic break with empty input" {
   // Test case where start > last
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::thematic_break("hello", last=3, start=4),
     content="Nomatch",
   )
@@ -9,7 +9,7 @@ test "thematic break with empty input" {
 
 ///|
 test "atx_heading empty" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::atx_heading("#", last=0, start=0),
     content="AtxHeadingLine(1, 1, 1, 0)",
   )
@@ -17,7 +17,7 @@ test "atx_heading empty" {
 
 ///|
 test "atx_heading too many hashes" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::atx_heading("#######", last=6, start=0),
     content="Nomatch",
   )
@@ -25,7 +25,7 @@ test "atx_heading too many hashes" {
 
 ///|
 test "atx_heading no blank after hash" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::atx_heading("#a", last=1, start=0),
     content="Nomatch",
   )
@@ -35,7 +35,7 @@ test "atx_heading no blank after hash" {
 test "setext_heading_underline empty string" {
   // Tests line 179: if start > last
   let s = ""
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::setext_heading_underline(s, last=0, start=1),
     content="Nomatch",
   )
@@ -44,7 +44,7 @@ test "setext_heading_underline empty string" {
 ///|
 test "setext_heading_underline invalid start char" {
   let s = "abc"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::setext_heading_underline(s, last=2, start=0),
     content="Nomatch",
   )
@@ -53,7 +53,7 @@ test "setext_heading_underline invalid start char" {
 ///|
 test "setext_heading_underline with non-marker char" {
   let s = "=x"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::setext_heading_underline(s, last=1, start=0),
     content="Nomatch",
   )
@@ -63,7 +63,7 @@ test "setext_heading_underline with non-marker char" {
 test "setext_heading_underline with trailing blank" {
   // Tests line 173: if end_blank > last
   let s = "=== \t"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::setext_heading_underline(s, last=4, start=0),
     content="SetextUnderlineLine(1, 2)",
   )
@@ -73,28 +73,28 @@ test "setext_heading_underline with trailing blank" {
 test "fenced_code_block_start empty input" {
   let s = ""
   let result = @cmark_base.LineType::fenced_code_block_start(s, last=0, start=1)
-  inspect(result, content="Nomatch")
+  debug_inspect(result, content="Nomatch")
 }
 
 ///|
 test "fenced_code_block_start with insufficient fence chars" {
   let s = "``"
   let result = @cmark_base.LineType::fenced_code_block_start(s, last=1, start=0)
-  inspect(result, content="Nomatch")
+  debug_inspect(result, content="Nomatch")
 }
 
 ///|
 test "fenced_code_block_start with indentation" {
   let s = "   ```"
   let result = @cmark_base.LineType::fenced_code_block_start(s, last=5, start=0)
-  inspect(result, content="FencedCodeBlockLine(3, 5, None)")
+  debug_inspect(result, content="FencedCodeBlockLine(3, 5, None)")
 }
 
 ///|
 test "fenced_code_block_start with non-fence char" {
   let s = "abc"
   let result = @cmark_base.LineType::fenced_code_block_start(s, last=2, start=0)
-  inspect(result, content="Nomatch")
+  debug_inspect(result, content="Nomatch")
 }
 
 ///|
@@ -102,7 +102,7 @@ test "fenced code block continue - not enough fence chars" {
   // This test covers line 277 - raise Exit when not enough fence chars
   let fence = ('`', 3) // Requiring 3 backticks
   let s = "``" // Only 2 backticks
-  inspect(
+  debug_inspect(
     @cmark_base.FencedCodeBlockContinue::new(s, fence~, last=1, start=0),
     content="Code",
   )
@@ -113,7 +113,7 @@ test "fenced code block continue - fence failure" {
   // This test covers line 300 - Exit => Code
   let fence = ('`', 3)
   let s = "```abc" // Valid fence but with extra content
-  inspect(
+  debug_inspect(
     @cmark_base.FencedCodeBlockContinue::new(s, fence~, last=5, start=0),
     content="Code",
   )
@@ -122,17 +122,17 @@ test "fenced code block continue - fence failure" {
 ///|
 test "html block start negative cases" {
   // Test case for invalid '!' tag (lines 409, 418)
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start("<!>", last=2, start=0),
     content="Nomatch",
   )
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start("<!1>", last=3, start=0),
     content="Nomatch",
   )
 
   // Test case for invalid regular tag (line 423)
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start("<1>", last=2, start=0),
     content="Nomatch",
   )
@@ -141,7 +141,7 @@ test "html block start negative cases" {
 ///|
 test "html block start with open tag" {
   // Test case for open tag (line 449)
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start("<custom>", last=7, start=0),
     content="HtmlBlockLine(EndBlank7)",
   )
@@ -151,12 +151,12 @@ test "html block start with open tag" {
 test "html_block_end with EndStr" {
   let s = "Hello -->World"
   let end_cond = @cmark_base.HtmlBlockEndCond::EndStr("-->")
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_end(s, end_cond~, last=11, start=0),
     content="true",
   )
   let s2 = "Hello World"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_end(s2, end_cond~, last=10, start=0),
     content="false",
   )
@@ -166,12 +166,12 @@ test "html_block_end with EndStr" {
 test "html_block_end with EndCond1" {
   let s = "Hello </pre>World"
   let end_cond = @cmark_base.HtmlBlockEndCond::EndCond1
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_end(s, end_cond~, last=12, start=0),
     content="true",
   )
   let s2 = "Hello World"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_end(s2, end_cond~, last=10, start=0),
     content="false",
   )
@@ -180,7 +180,7 @@ test "html_block_end with EndCond1" {
 ///|
 test "list_marker invalid bullet" {
   let s = "  hello"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::list_marker(s, last=6, start=2),
     content="Nomatch",
   )
@@ -189,7 +189,7 @@ test "list_marker invalid bullet" {
 ///|
 test "list_marker bullet without space" {
   let s = "  -hello"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::list_marker(s, last=7, start=2),
     content="Nomatch",
   )
@@ -198,7 +198,7 @@ test "list_marker bullet without space" {
 ///|
 test "list_marker long ordered list" {
   let s = "  1234567890. "
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::list_marker(s, last=13, start=2),
     content="Nomatch",
   )
@@ -207,7 +207,7 @@ test "list_marker long ordered list" {
 ///|
 test "list_marker ordered list without space" {
   let s = "  1.hello"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::list_marker(s, last=8, start=2),
     content="Nomatch",
   )
@@ -215,14 +215,20 @@ test "list_marker ordered list without space" {
 
 ///|
 test "ext_task_marker returns None when start >= last" {
-  inspect(@cmark_base.ext_task_marker("", last=0, start=1), content="None")
-  inspect(@cmark_base.ext_task_marker("", last=0, start=0), content="None")
+  debug_inspect(
+    @cmark_base.ext_task_marker("", last=0, start=1),
+    content="None",
+  )
+  debug_inspect(
+    @cmark_base.ext_task_marker("", last=0, start=0),
+    content="None",
+  )
 }
 
 ///|
 test "ext_task_marker returns None when the marker is too long" {
   let s = "[\u{d8}00]"
-  inspect(
+  debug_inspect(
     @cmark_base.ext_task_marker(s, last=s.length(), start=0),
     content="None",
   )
@@ -230,7 +236,7 @@ test "ext_task_marker returns None when the marker is too long" {
 
 ///|
 test "atx_heading: empty heading" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::atx_heading("#     ", last=5, start=0),
     content="AtxHeadingLine(1, 1, 6, 5)",
   )
@@ -238,7 +244,7 @@ test "atx_heading: empty heading" {
 
 ///|
 test "atx_heading: heading with trailing hashes" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::atx_heading("# test #", last=7, start=0),
     content="AtxHeadingLine(1, 1, 2, 5)",
   )
@@ -246,7 +252,7 @@ test "atx_heading: heading with trailing hashes" {
 
 ///|
 test "atx_heading: invalid start" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::atx_heading("test", last=3, start=4),
     content="Nomatch",
   )
@@ -255,7 +261,7 @@ test "atx_heading: invalid start" {
 ///|
 test "html_block_start_5 with CDATA" {
   let s = "<![CDATA[foo]]>"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start(s, last=s.length() - 1, start=0),
     content="HtmlBlockLine(EndStr(\"]]>\"))",
   )
@@ -264,7 +270,7 @@ test "html_block_start_5 with CDATA" {
 ///|
 test "html_block_start_5 with incomplete CDATA" {
   let s = "<![CDA"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start(s, last=s.length() - 1, start=0),
     content="Nomatch",
   )
@@ -272,7 +278,7 @@ test "html_block_start_5 with incomplete CDATA" {
 
 ///|
 test "table row - no opening pipe" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::ext_table_row("a | b |", last=6, start=0),
     content="Nomatch",
   )
@@ -280,7 +286,7 @@ test "table row - no opening pipe" {
 
 ///|
 test "table row - no closing pipe" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::ext_table_row("| a | b ", last=6, start=0),
     content="Nomatch",
   )
@@ -288,7 +294,7 @@ test "table row - no closing pipe" {
 
 ///|
 test "table row - escaped closing pipe" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::ext_table_row("| a | b \\|", last=8, start=0),
     content="Nomatch",
   )
@@ -296,7 +302,7 @@ test "table row - escaped closing pipe" {
 
 ///|
 test "list_marker: empty string" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::list_marker("", last=0, start=1),
     content="Nomatch",
   )
@@ -304,7 +310,7 @@ test "list_marker: empty string" {
 
 ///|
 test "list_marker: ordered list with invalid marker" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::list_marker("123x", last=3, start=0),
     content="Nomatch",
   )
@@ -315,7 +321,7 @@ test "html_block_start_7_open_tag - no match due to invalid open tag" {
   // Test case where open_tag returns None
   // This should trigger the uncovered line 361
   let s = "<invalid"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start(s, last=s.length() - 1, start=0),
     content="Nomatch",
   )
@@ -323,11 +329,11 @@ test "html_block_start_7_open_tag - no match due to invalid open tag" {
 
 ///|
 test "html block start nomatch" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start("", last=0, start=0),
     content="Nomatch",
   )
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start("abc", last=2, start=0),
     content="Nomatch",
   )
@@ -335,7 +341,7 @@ test "html block start nomatch" {
 
 ///|
 test "html block start type 3" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start("<?xml", last=4, start=0),
     content="HtmlBlockLine(EndStr(\"?>\"))",
   )
@@ -343,7 +349,7 @@ test "html block start type 3" {
 
 ///|
 test "html block start type 2" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start("<!--", last=4, start=0),
     content="HtmlBlockLine(EndStr(\"-->\"))",
   )
@@ -351,7 +357,7 @@ test "html block start type 2" {
 
 ///|
 test "html block start type 4" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start("<!abc>", last=5, start=0),
     content="HtmlBlockLine(EndStr(\">\"))",
   )
@@ -360,7 +366,7 @@ test "html block start type 4" {
 ///|
 test "ext_table_row with escaped pipe at the end" {
   // Test when there's a backslash before the closing pipe, should return Nomatch
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::ext_table_row("| a b c \\|", last=9, start=0),
     content="Nomatch",
   )
@@ -370,7 +376,7 @@ test "ext_table_row with escaped pipe at the end" {
 test "fenced code block with backtick in info string" {
   let s = "```rust`"
   // This should trigger line 197 by having a backtick in the info string
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::fenced_code_block_start(s, last=7, start=0),
     content="Nomatch",
   )
@@ -385,13 +391,13 @@ test "html_block_start_7_open_tag with non-blank after tag" {
     last=s.length() - 1,
     start=0,
   )
-  inspect(result, content="Nomatch")
+  debug_inspect(result, content="Nomatch")
 }
 
 ///|
 test "html_block_start empty after <!" {
   let s = "<!a"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start(s, last=1, start=0),
     content="Nomatch",
   )
@@ -400,22 +406,22 @@ test "html_block_start empty after <!" {
 ///|
 test "html_block_start with tags" {
   let s = "<pre>test</pre>"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start(s, last=13, start=0),
     content="HtmlBlockLine(EndCond1)",
   )
   let s2 = "</p test>"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start(s2, last=7, start=0),
     content="HtmlBlockLine(EndBlank)",
   )
   let s3 = "<p/>"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start(s3, last=3, start=0),
     content="HtmlBlockLine(EndBlank)",
   )
   let s4 = "</p>"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start(s4, last=3, start=0),
     content="HtmlBlockLine(EndBlank)",
   )
@@ -427,7 +433,7 @@ test "fenced code block continue - another short blank line" {
   let s = " " // Single space string represents another short blank line
   let last = 0
   let start = 0
-  inspect(
+  debug_inspect(
     @cmark_base.FencedCodeBlockContinue::new(s, fence~, last~, start~),
     content="Code",
   )
@@ -436,7 +442,7 @@ test "fenced code block continue - another short blank line" {
 ///|
 test "could_be_link_ref_definition empty input" {
   let s = ""
-  inspect(
+  debug_inspect(
     @cmark_base.could_be_link_ref_definition(s, last=0, start=1),
     content="false",
   )
@@ -445,7 +451,7 @@ test "could_be_link_ref_definition empty input" {
 ///|
 test "could_be_link_ref_definition exceed boundary" {
   let s = "   "
-  inspect(
+  debug_inspect(
     @cmark_base.could_be_link_ref_definition(s, last=2, start=3),
     content="false",
   )
@@ -454,7 +460,7 @@ test "could_be_link_ref_definition exceed boundary" {
 ///|
 test "html block start with closing tag that is not in cond 6 set - no whitespace" {
   let s = "</unknown>something"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start(s, last=s.length() - 1, start=0),
     content="Nomatch",
   )
@@ -462,7 +468,7 @@ test "html block start with closing tag that is not in cond 6 set - no whitespac
 
 ///|
 test "could_be_link_ref_definition no bracket" {
-  inspect(
+  debug_inspect(
     @cmark_base.could_be_link_ref_definition("   ", last=2, start=0),
     content="false",
   )
@@ -471,7 +477,7 @@ test "could_be_link_ref_definition no bracket" {
 ///|
 test "html block start with closing tag that is not in cond 6 set" {
   let s = "</foo>"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start(s, last=s.length() - 1, start=0),
     content="HtmlBlockLine(EndBlank7)",
   )
@@ -480,7 +486,7 @@ test "html block start with closing tag that is not in cond 6 set" {
 ///|
 test "html block start with closing tag that is not in cond 6 set - longer" {
   let s = "</unknown> "
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start(s, last=s.length() - 1, start=0),
     content="HtmlBlockLine(EndBlank7)",
   )
@@ -489,25 +495,25 @@ test "html block start with closing tag that is not in cond 6 set - longer" {
 ///|
 test "atx_heading with ending hashes" {
   // Test case where the heading ends with hashes preceded by a space
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::atx_heading("# Test #", last=7, start=0),
     content="AtxHeadingLine(1, 1, 2, 5)",
   )
 
   // Test case where the heading has multiple ending hashes
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::atx_heading("## Test ###", last=9, start=0),
     content="AtxHeadingLine(2, 2, 3, 6)",
   )
 
   // Test case where the heading has ending hashes with trailing spaces
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::atx_heading("### Test # ", last=9, start=0),
     content="AtxHeadingLine(3, 3, 4, 7)",
   )
 
   // Test case where the heading only has spaces between start and end hashes
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::atx_heading("# #", last=2, start=0),
     content="AtxHeadingLine(1, 1, 2, 1)",
   )
@@ -519,5 +525,5 @@ test "test @cmark_base.LineType::fenced_code_block_start with uncovered section"
   let last = 2
   let start = 1
   let output = @cmark_base.LineType::fenced_code_block_start(s, last~, start~)
-  inspect(output, content="Nomatch")
+  debug_inspect(output, content="Nomatch")
 }

--- a/src/cmark_base/link_test.mbt
+++ b/src/cmark_base/link_test.mbt
@@ -3,7 +3,7 @@ test "link_destination start greater than last" {
   let s = "test"
   let last = 3
   let start = 4
-  inspect(@cmark_base.link_destination(s, last~, start~), content="None")
+  debug_inspect(@cmark_base.link_destination(s, last~, start~), content="None")
 }
 
 ///|
@@ -11,7 +11,7 @@ test "link_destination with angle bracket and early termination" {
   let s = "<test\n>"
   let last = 6
   let start = 0
-  inspect(@cmark_base.link_destination(s, last~, start~), content="None")
+  debug_inspect(@cmark_base.link_destination(s, last~, start~), content="None")
 }
 
 ///|
@@ -19,7 +19,7 @@ test "link_destination not delimited with unbalanced closing parenthesis" {
   let s = "(test(test)"
   let last = 10
   let start = 0
-  inspect(@cmark_base.link_destination(s, last~, start~), content="None")
+  debug_inspect(@cmark_base.link_destination(s, last~, start~), content="None")
 }
 
 ///|
@@ -27,7 +27,10 @@ test "link_destination test with no end delimiter" {
   let input = "<some_url"
   let last = 8
   let start = 0
-  inspect(@cmark_base.link_destination(input, last~, start~), content="None")
+  debug_inspect(
+    @cmark_base.link_destination(input, last~, start~),
+    content="None",
+  )
 }
 
 ///|
@@ -36,25 +39,25 @@ test "link_destination contains no space condition false" {
   let last = s.length() - 1
   let start = 0
   let result = @cmark_base.link_destination(s, last~, start~)
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
 test "test link_destination with escaped backslashes" {
   let result = @cmark_base.link_destination("<\\\\>", last=3, start=0)
-  inspect(result, content="Some((true, 1, 2))")
+  debug_inspect(result, content="Some((true, 1, 2))")
 }
 
 ///|
 test "test link_destination with matched angle brackets" {
   let result = @cmark_base.link_destination("<url>", last=4, start=0)
-  inspect(result, content="Some((true, 1, 3))")
+  debug_inspect(result, content="Some((true, 1, 3))")
 }
 
 ///|
 test "test link_destination with backslash before closing angle bracket" {
   let result = @cmark_base.link_destination("<url\\>", last=5, start=0)
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -62,7 +65,10 @@ test "trigger uncovered line 28 and 29" {
   let input : String = "<test<text"
   let last : Int = 10
   let start : Int = 0
-  inspect(@cmark_base.link_destination(input, last~, start~), content="None")
+  debug_inspect(
+    @cmark_base.link_destination(input, last~, start~),
+    content="None",
+  )
 }
 
 ///|
@@ -70,7 +76,7 @@ test "test escaped parenthesis in not delimited link destination" {
   let s = "Hello(\\)World"
   let last = s.length() - 1
   let start = 0
-  inspect(@cmark_base.link_destination(s, last~, start~), content="None")
+  debug_inspect(@cmark_base.link_destination(s, last~, start~), content="None")
 }
 
 ///|
@@ -78,5 +84,5 @@ test "test double backslash before less-than" {
   let s = "<\\<"
   let last = 2
   let start = 0
-  inspect(@cmark_base.link_destination(s, last~, start~), content="None")
+  debug_inspect(@cmark_base.link_destination(s, last~, start~), content="None")
 }

--- a/src/cmark_base/meta.mbt
+++ b/src/cmark_base/meta.mbt
@@ -3,7 +3,7 @@ pub(all) struct Meta {
   id : MetaId
   loc : TextLoc
   extra : Error?
-}
+} derive(Debug)
 
 ///|
 type MetaId = Int
@@ -39,19 +39,6 @@ pub fn Meta::compare(self : Meta, other : Meta) -> Int {
 ///|
 pub fn Meta::is_none(self : Meta) -> Bool {
   self == meta_none
-}
-
-///|
-pub impl @debug.Debug for Meta with to_repr(self) {
-  if self.is_none() {
-    @debug.Repr::ctor("Meta::none", [])
-  } else {
-    @debug.Repr::ctor("Meta::new", [
-      (Some("id"), @debug.to_repr(self.id)),
-      (Some("loc"), @debug.to_repr(self.loc)),
-      (Some("dict"), @debug.to_repr(self.extra.map(fn(e) { e.to_string() }))),
-    ])
-  }
 }
 
 ///|

--- a/src/cmark_base/meta.mbt
+++ b/src/cmark_base/meta.mbt
@@ -42,17 +42,15 @@ pub fn Meta::is_none(self : Meta) -> Bool {
 }
 
 ///|
-pub impl Show for Meta with output(self, logger) {
+pub impl @debug.Debug for Meta with to_repr(self) {
   if self.is_none() {
-    logger.write_string("Meta::none()")
+    @debug.Repr::ctor("Meta::none", [])
   } else {
-    logger.write_string("Meta::new(id=")
-    logger.write_object(self.id)
-    logger.write_string(", loc=")
-    logger.write_object(self.loc)
-    logger.write_string(", dict=")
-    logger.write_object(self.extra)
-    logger.write_string(")")
+    @debug.Repr::ctor("Meta::new", [
+      (Some("id"), @debug.to_repr(self.id)),
+      (Some("loc"), @debug.to_repr(self.loc)),
+      (Some("dict"), @debug.to_repr(self.extra.map(fn(e) { e.to_string() }))),
+    ])
   }
 }
 
@@ -61,10 +59,14 @@ pub impl ToJson for Meta with to_json(self) {
   if self.is_none() {
     return {}
   }
+  let extra = match self.extra {
+    None => "None"
+    Some(e) => "Some(\{e})"
+  }
   {
     "id": self.id.to_json(),
     "loc": self.loc.to_json(),
-    "dict": self.extra.to_string().to_json(),
+    "dict": extra.to_json(),
   }
 }
 

--- a/src/cmark_base/meta_test.mbt
+++ b/src/cmark_base/meta_test.mbt
@@ -2,23 +2,28 @@
 test "Meta compare" {
   let meta1 = @cmark_base.Meta::new()
   let meta2 = @cmark_base.Meta::new()
-  inspect(meta1.compare(meta2), content="-1")
+  debug_inspect(meta1.compare(meta2), content="-1")
 }
 
 ///|
 test "Meta compare with self" {
   let meta = @cmark_base.Meta::new()
-  inspect(meta.compare(meta), content="0")
+  debug_inspect(meta.compare(meta), content="0")
 }
 
 ///|
 test "show_implementation_for_meta_none" {
   let none_meta = @cmark_base.Meta::none()
-  inspect(Show::to_string(none_meta), content="Meta::none()")
+  debug_inspect(
+    @debug.to_string(none_meta),
+    content=(
+      #|"Meta::none"
+    ),
+  )
 }
 
 ///|
 test "@cmark_base.Meta::to_json empty" {
   let meta = @cmark_base.Meta::none()
-  inspect(meta.to_json(), content="Object({})")
+  debug_inspect(meta.to_json(), content="Object({})")
 }

--- a/src/cmark_base/meta_test.mbt
+++ b/src/cmark_base/meta_test.mbt
@@ -17,7 +17,7 @@ test "show_implementation_for_meta_none" {
   debug_inspect(
     @debug.to_string(none_meta),
     content=(
-      #|"Meta::none"
+      #|"{\n  id: 0,\n  loc: {\n    file: \"-\",\n    first_ccode: -1,\n    last_ccode: -1,\n    first_line: LinePos(-1, -1),\n    last_line: LinePos(-1, -1),\n  },\n  extra: None,\n}"
     ),
   )
 }

--- a/src/cmark_base/moon.pkg
+++ b/src/cmark_base/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "moonbit-community/cmark/char",
   "moonbitlang/core/cmp",
+  "moonbitlang/core/debug",
   "moonbitlang/core/json",
 }

--- a/src/cmark_base/pkg.generated.mbti
+++ b/src/cmark_base/pkg.generated.mbti
@@ -104,7 +104,7 @@ pub(all) struct Meta {
   id : Int
   loc : TextLoc
   extra : Error?
-}
+} derive(@debug.Debug)
 pub fn Meta::compare(Self, Self) -> Int
 pub fn Meta::is_none(Self) -> Bool
 pub fn Meta::new(loc? : TextLoc) -> Self
@@ -112,7 +112,6 @@ pub fn Meta::none() -> Self
 pub fn Meta::to_json(Self) -> Json
 pub impl Eq for Meta
 pub impl ToJson for Meta
-pub impl @debug.Debug for Meta
 
 pub(all) struct NextLineFn[A]((A) -> LineSpan?)
 

--- a/src/cmark_base/pkg.generated.mbti
+++ b/src/cmark_base/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "moonbit-community/cmark/cmark_base"
 
 import {
+  "moonbitlang/core/debug",
   "moonbitlang/core/json",
 }
 
@@ -50,7 +51,7 @@ pub fn run_of(char~ : Char, String, last~ : Int, start~ : Int) -> Int
 pub(all) enum FencedCodeBlockContinue {
   Close(Int, Int)
   Code
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 pub fn FencedCodeBlockContinue::new(String, fence~ : (Char, Int), last~ : Int, start~ : Int) -> Self
 
 pub(all) enum HtmlBlockEndCond {
@@ -58,15 +59,15 @@ pub(all) enum HtmlBlockEndCond {
   EndCond1
   EndBlank
   EndBlank7
-} derive(Eq, Show, ToJson)
+} derive(Eq, ToJson, @debug.Debug)
 
-pub(all) struct LinePos(Int, Int) derive(Compare, Eq, Show, ToJson, @json.FromJson)
+pub(all) struct LinePos(Int, Int) derive(Compare, Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) struct LineSpan {
   pos : LinePos
   first : Int
   last : Int
-} derive(Compare, Eq, Show, ToJson)
+} derive(Compare, Eq, ToJson, @debug.Debug)
 
 pub(all) enum LineType {
   AtxHeadingLine(Int, Int, Int, Int)
@@ -82,7 +83,7 @@ pub(all) enum LineType {
   ExtTableRow(Int)
   ExtFootnoteLabel(Array[Span], Int, String)
   Nomatch
-} derive(Eq, Show, ToJson)
+} derive(Eq, ToJson, @debug.Debug)
 pub fn LineType::atx_heading(String, last~ : Int, start~ : Int) -> Self
 pub fn LineType::ext_footnote_label(StringBuilder, String, line_pos~ : LinePos, last~ : Int, start~ : Int) -> Self
 pub fn LineType::ext_table_row(String, last~ : Int, start~ : Int) -> Self
@@ -96,7 +97,7 @@ pub fn LineType::thematic_break(String, last~ : Int, start~ : Int) -> Self
 pub(all) enum ListType {
   Unordered(Char)
   Ordered(Int, Char)
-} derive(Eq, Show, ToJson, @json.FromJson)
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn ListType::is_same_type(Self, Self) -> Bool
 
 pub(all) struct Meta {
@@ -110,20 +111,20 @@ pub fn Meta::new(loc? : TextLoc) -> Self
 pub fn Meta::none() -> Self
 pub fn Meta::to_json(Self) -> Json
 pub impl Eq for Meta
-pub impl Show for Meta
 pub impl ToJson for Meta
+pub impl @debug.Debug for Meta
 
 pub(all) struct NextLineFn[A]((A) -> LineSpan?)
 
 pub(all) enum NextLineResult {
   ThisLine(Int)
   NextLine(LineSpan, Int)
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 
 pub(all) struct Span {
   start : Int
   span : LineSpan
-} derive(Compare, Eq, Show, ToJson)
+} derive(Compare, Eq, ToJson, @debug.Debug)
 
 pub(all) struct TextLoc {
   file : String
@@ -131,7 +132,7 @@ pub(all) struct TextLoc {
   last_ccode : Int
   first_line : LinePos
   last_line : LinePos
-} derive(Compare, Eq, Show, ToJson, @json.FromJson)
+} derive(Compare, Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn TextLoc::after(Self) -> Self
 pub fn TextLoc::is_empty(Self) -> Bool
 pub fn TextLoc::is_none(Self) -> Bool

--- a/src/cmark_base/raw_html_test.mbt
+++ b/src/cmark_base/raw_html_test.mbt
@@ -22,7 +22,7 @@ test "raw_html with invalid input" {
     line=line_span,
     start=0,
   )
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -41,9 +41,17 @@ test "raw_html with processing instruction" {
     line=line_span,
     start=0,
   )
-  inspect(
+  debug_inspect(
     result,
-    content="Some(({pos: LinePos(1, 0), first: 0, last: 20}, [{start: 0, span: {pos: LinePos(1, 0), first: 0, last: 20}}], 20))",
+    content=(
+      #|Some(
+      #|  (
+      #|    { pos: LinePos(1, 0), first: 0, last: 20 },
+      #|    [{ start: 0, span: { pos: LinePos(1, 0), first: 0, last: 20 } }],
+      #|    20,
+      #|  ),
+      #|)
+    ),
   )
 }
 
@@ -63,9 +71,17 @@ test "raw_html with HTML comment" {
     line=line_span,
     start=0,
   )
-  inspect(
+  debug_inspect(
     result,
-    content="Some(({pos: LinePos(1, 0), first: 0, last: 12}, [{start: 0, span: {pos: LinePos(1, 0), first: 0, last: 12}}], 12))",
+    content=(
+      #|Some(
+      #|  (
+      #|    { pos: LinePos(1, 0), first: 0, last: 12 },
+      #|    [{ start: 0, span: { pos: LinePos(1, 0), first: 0, last: 12 } }],
+      #|    12,
+      #|  ),
+      #|)
+    ),
   )
 }
 
@@ -85,9 +101,17 @@ test "raw_html with declaration" {
     line=line_span,
     start=0,
   )
-  inspect(
+  debug_inspect(
     result,
-    content="Some(({pos: LinePos(1, 0), first: 0, last: 14}, [{start: 0, span: {pos: LinePos(1, 0), first: 0, last: 14}}], 14))",
+    content=(
+      #|Some(
+      #|  (
+      #|    { pos: LinePos(1, 0), first: 0, last: 14 },
+      #|    [{ start: 0, span: { pos: LinePos(1, 0), first: 0, last: 14 } }],
+      #|    14,
+      #|  ),
+      #|)
+    ),
   )
 }
 
@@ -107,9 +131,17 @@ test "raw_html with CDATA section" {
     line=line_span,
     start=0,
   )
-  inspect(
+  debug_inspect(
     result,
-    content="Some(({pos: LinePos(1, 0), first: 0, last: 15}, [{start: 0, span: {pos: LinePos(1, 0), first: 0, last: 15}}], 15))",
+    content=(
+      #|Some(
+      #|  (
+      #|    { pos: LinePos(1, 0), first: 0, last: 15 },
+      #|    [{ start: 0, span: { pos: LinePos(1, 0), first: 0, last: 15 } }],
+      #|    15,
+      #|  ),
+      #|)
+    ),
   )
 }
 
@@ -129,7 +161,7 @@ test "raw_html with invalid char after <!" {
     line=line_span,
     start=0,
   )
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///| Additional tests for raw_html.mbt to improve coverage
@@ -150,7 +182,7 @@ test "raw_html_invalid_start" {
     line=line_span,
     start=0,
   )
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -169,9 +201,17 @@ test "raw_html_closing_tag_invalid_name" {
     line=line_span,
     start=0,
   )
-  inspect(
+  debug_inspect(
     result,
-    content="Some(({pos: LinePos(1, 0), first: 6, last: 6}, [{start: 0, span: {pos: LinePos(1, 0), first: 0, last: 6}}], 6))",
+    content=(
+      #|Some(
+      #|  (
+      #|    { pos: LinePos(1, 0), first: 6, last: 6 },
+      #|    [{ start: 0, span: { pos: LinePos(1, 0), first: 0, last: 6 } }],
+      #|    6,
+      #|  ),
+      #|)
+    ),
   )
 }
 
@@ -191,7 +231,7 @@ test "raw_html_closing_tag_no_end" {
     line=line_span,
     start=0,
   )
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -210,9 +250,17 @@ test "raw_html_open_tag_invalid" {
     line=line_span,
     start=0,
   )
-  inspect(
+  debug_inspect(
     result,
-    content="Some(({pos: LinePos(1, 0), first: 5, last: 5}, [{start: 0, span: {pos: LinePos(1, 0), first: 0, last: 5}}], 5))",
+    content=(
+      #|Some(
+      #|  (
+      #|    { pos: LinePos(1, 0), first: 5, last: 5 },
+      #|    [{ start: 0, span: { pos: LinePos(1, 0), first: 0, last: 5 } }],
+      #|    5,
+      #|  ),
+      #|)
+    ),
   )
 }
 
@@ -232,7 +280,7 @@ test "raw_html_self_closing_tag_no_end" {
     line=line_span,
     start=0,
   )
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -251,7 +299,7 @@ test "raw_html_attribute_invalid_name" {
     line=line_span,
     start=0,
   )
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -270,9 +318,17 @@ test "raw_html_attribute_no_value" {
     line=line_span,
     start=0,
   )
-  inspect(
+  debug_inspect(
     result,
-    content="Some(({pos: LinePos(1, 0), first: 14, last: 14}, [{start: 0, span: {pos: LinePos(1, 0), first: 0, last: 14}}], 14))",
+    content=(
+      #|Some(
+      #|  (
+      #|    { pos: LinePos(1, 0), first: 14, last: 14 },
+      #|    [{ start: 0, span: { pos: LinePos(1, 0), first: 0, last: 14 } }],
+      #|    14,
+      #|  ),
+      #|)
+    ),
   )
 }
 
@@ -292,9 +348,17 @@ test "raw_html_attribute_unquoted_value" {
     line=line_span,
     start=0,
   )
-  inspect(
+  debug_inspect(
     result,
-    content="Some(({pos: LinePos(1, 0), first: 20, last: 20}, [{start: 0, span: {pos: LinePos(1, 0), first: 0, last: 20}}], 20))",
+    content=(
+      #|Some(
+      #|  (
+      #|    { pos: LinePos(1, 0), first: 20, last: 20 },
+      #|    [{ start: 0, span: { pos: LinePos(1, 0), first: 0, last: 20 } }],
+      #|    20,
+      #|  ),
+      #|)
+    ),
   )
 }
 
@@ -314,7 +378,7 @@ test "raw_html_exclamation_invalid" {
     line=line_span,
     start=0,
   )
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -333,7 +397,7 @@ test "raw_html_exclamation_too_short" {
     line=line_span,
     start=0,
   )
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -352,7 +416,7 @@ test "raw_html_comment_incomplete" {
     line=line_span,
     start=0,
   )
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -371,7 +435,7 @@ test "raw_html_comment_invalid1" {
     line=line_span,
     start=0,
   )
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -390,7 +454,7 @@ test "raw_html_comment_invalid2" {
     line=line_span,
     start=0,
   )
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -409,7 +473,7 @@ test "raw_html_cdata_incomplete" {
     line=line_span,
     start=0,
   )
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -428,5 +492,5 @@ test "raw_html_cdata_wrong_format" {
     line=line_span,
     start=0,
   )
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }

--- a/src/cmark_base/raw_html_wbtest.mbt
+++ b/src/cmark_base/raw_html_wbtest.mbt
@@ -3,21 +3,21 @@
 test "tag_name with valid tag" {
   let s = "div class=\"test\">"
   let result = tag_name(s, last=16, start=0)
-  inspect(result, content="Some(2)")
+  debug_inspect(result, content="Some(2)")
 }
 
 ///|
 test "tag_name with hyphen" {
   let s = "custom-tag>"
   let result = tag_name(s, last=10, start=0)
-  inspect(result, content="Some(9)")
+  debug_inspect(result, content="Some(9)")
 }
 
 ///|
 test "tag_name with invalid start condition" {
   let s = "1div>"
   let result = tag_name(s, last=4, start=0)
-  inspect(result, content="Some(3)")
+  debug_inspect(result, content="Some(3)")
 }
 
 ///|
@@ -25,26 +25,26 @@ test "tag_name with invalid start condition" {
 test "attribute_name with valid start chars" {
   let s = "_attr:value"
   let result = attribute_name(s, last=9, start=0)
-  inspect(result, content="Some(9)")
+  debug_inspect(result, content="Some(9)")
 }
 
 ///|
 test "attribute_name with valid continuation chars" {
   let s = "attr.name-with_colons:value"
   let result = attribute_name(s, last=24, start=0)
-  inspect(result, content="Some(24)")
+  debug_inspect(result, content="Some(24)")
 }
 
 ///|
 test "attribute_name with invalid start" {
   let s = ".invalid"
   let result = attribute_name(s, last=7, start=0)
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
 test "attribute_name when start > last" {
   let s = "attr"
   let result = attribute_name(s, last=3, start=4)
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }

--- a/src/cmark_base/runs_test.mbt
+++ b/src/cmark_base/runs_test.mbt
@@ -1,6 +1,6 @@
 ///|
 test "rev_drop_spaces when start is less than first" {
-  inspect(
+  debug_inspect(
     @cmark_base.rev_drop_spaces("hello world", first=5, start=3),
     content="4",
   )
@@ -8,7 +8,7 @@ test "rev_drop_spaces when start is less than first" {
 
 ///|
 test "rev_drop_spaces with spaces" {
-  inspect(
+  debug_inspect(
     @cmark_base.rev_drop_spaces("hello   world", first=0, start=7),
     content="4",
   )
@@ -16,5 +16,8 @@ test "rev_drop_spaces with spaces" {
 
 ///|
 test "rev_drop_spaces with no spaces" {
-  inspect(@cmark_base.rev_drop_spaces("hello", first=0, start=4), content="4")
+  debug_inspect(
+    @cmark_base.rev_drop_spaces("hello", first=0, start=4),
+    content="4",
+  )
 }

--- a/src/cmark_base/text_loc.mbt
+++ b/src/cmark_base/text_loc.mbt
@@ -5,7 +5,7 @@ pub(all) struct TextLoc {
   last_ccode : CharCodePos
   first_line : LinePos
   last_line : LinePos
-} derive(Eq, Compare, Show, FromJson, ToJson)
+} derive(Eq, Compare, Debug, FromJson, ToJson)
 
 ///|
 let text_loc_none : TextLoc = {
@@ -96,7 +96,7 @@ pub let line_num_none = -1
 
 ///|
 pub(all) struct LinePos(LineNum, CharCodePos) derive (
-  Show,
+  Debug,
   Eq,
   Compare,
   FromJson,
@@ -111,14 +111,14 @@ pub(all) struct LineSpan {
   pos : LinePos
   first : CharCodePos
   last : CharCodePos
-} derive(Show, ToJson, Eq, Compare)
+} derive(Debug, ToJson, Eq, Compare)
 
 ///|
 ///  A line span with the byte position on where the line starts (inside a CommonMark container).  The [line_start] is the start of line in the container, the [line_span] has the actual data. The characters in the \[[line_start];[line_span.first - 1]\] are blanks.
 pub(all) struct Span {
   start : CharCodePos
   span : LineSpan
-} derive(Show, ToJson, Eq, Compare)
+} derive(Debug, ToJson, Eq, Compare)
 
 ///|
 pub(all) struct NextLineFn[A]((A) -> LineSpan?)
@@ -127,4 +127,4 @@ pub(all) struct NextLineFn[A]((A) -> LineSpan?)
 pub(all) enum NextLineResult {
   ThisLine(CharCodePos)
   NextLine(LineSpan, CharCodePos)
-} derive(Show, ToJson)
+} derive(Debug, ToJson)

--- a/src/cmark_base/text_loc_test.mbt
+++ b/src/cmark_base/text_loc_test.mbt
@@ -1,41 +1,47 @@
 ///|
 test "TextLoc::is_none with none value" {
   let loc = @cmark_base.TextLoc::none()
-  inspect(loc.is_none(), content="true")
+  debug_inspect(loc.is_none(), content="true")
 }
 
 ///|
 test "TextLoc::is_empty for non-empty location" {
   let loc = @cmark_base.TextLoc::none()
   let loc = { ..loc, first_ccode: 10, last_ccode: 5 }
-  inspect(loc.is_empty(), content="true")
+  debug_inspect(loc.is_empty(), content="true")
 }
 
 ///|
 test "TextLoc::is_empty for empty location" {
   let loc = @cmark_base.TextLoc::none()
   let loc = { ..loc, first_ccode: 5, last_ccode: 10 }
-  inspect(loc.is_empty(), content="false")
+  debug_inspect(loc.is_empty(), content="false")
 }
 
 ///|
 test "TextLoc::after basic functionality" {
   let loc = @cmark_base.TextLoc::none()
   let after_loc = loc.after()
-  inspect(after_loc.first_ccode, content="0")
-  inspect(after_loc.last_ccode, content="-1")
-  inspect(after_loc.first_line, content="LinePos(-1, -1)")
-  inspect(after_loc.last_line, content="LinePos(-1, -1)")
+  debug_inspect(after_loc.first_ccode, content="0")
+  debug_inspect(after_loc.last_ccode, content="-1")
+  debug_inspect(after_loc.first_line, content="LinePos(-1, -1)")
+  debug_inspect(after_loc.last_line, content="LinePos(-1, -1)")
 }
 
 ///|
 test "test case TextLoc::reloc" {
   let loc1 = @cmark_base.TextLoc::none()
   let loc2 = @cmark_base.TextLoc::none()
-  inspect(
+  debug_inspect(
     loc1.reloc(loc2),
     content=(
-      #|{file: "-", first_ccode: -1, last_ccode: -1, first_line: LinePos(-1, -1), last_line: LinePos(-1, -1)}
+      #|{
+      #|  file: "-",
+      #|  first_ccode: -1,
+      #|  last_ccode: -1,
+      #|  first_line: LinePos(-1, -1),
+      #|  last_line: LinePos(-1, -1),
+      #|}
     ),
   )
 }
@@ -50,9 +56,9 @@ test "TextLoc to_first method test" {
     last_line: @cmark_base.LinePos(2, 20),
   }
   let modified_loc = initial_loc.to_first()
-  inspect(modified_loc.last_ccode, content="10")
-  inspect(modified_loc.last_line.0, content="1")
-  inspect(modified_loc.last_line.1, content="10")
+  debug_inspect(modified_loc.last_ccode, content="10")
+  debug_inspect(modified_loc.last_line.0, content="1")
+  debug_inspect(modified_loc.last_line.1, content="10")
 }
 
 ///|
@@ -65,6 +71,6 @@ test "TextLoc to_last method" {
     last_line: LinePos(1, 20),
   }
   let loc_transformed = loc_initial.to_last()
-  inspect(loc_transformed.first_ccode, content="20")
-  inspect(loc_transformed.first_line, content="LinePos(1, 20)")
+  debug_inspect(loc_transformed.first_ccode, content="20")
+  debug_inspect(loc_transformed.first_line, content="LinePos(1, 20)")
 }

--- a/src/cmark_html/README.mbt.md
+++ b/src/cmark_html/README.mbt.md
@@ -13,12 +13,10 @@ test "basic rendering" {
     #|
     #|This is a paragraph.
   let rendered = @cmark_html.render(safe=false, strict=false, doc)
-  inspect(
+  debug_inspect(
     rendered,
     content=(
-      #|<h1>Hello World</h1>
-      #|<p>This is a paragraph.</p>
-      #|
+      #|"<h1>Hello World</h1>\n<p>This is a paragraph.</p>\n"
     ),
   )
 }
@@ -38,12 +36,10 @@ test "rendering from @cmark.Doc" {
     ),
   )
   let rendered = @cmark_html.from_doc(safe=false, doc)
-  inspect(
+  debug_inspect(
     rendered,
     content=(
-      #|<h1>Hello World</h1>
-      #|<p>This is a paragraph.</p>
-      #|
+      #|"<h1>Hello World</h1>\n<p>This is a paragraph.</p>\n"
     ),
   )
 }

--- a/src/cmark_html/html.mbt
+++ b/src/cmark_html/html.mbt
@@ -8,19 +8,7 @@ priv struct State {
   ids : StringSet
   mut footnote_count : Int
   footnotes : Map[LabelKey, HtmlRenderFootnote]
-}
-
-///|
-// Manual Debug impl: Set[String] does not derive Debug yet.
-impl @debug.Debug for State with to_repr(self) {
-  @debug.Repr::ctor("State", [
-    (Some("safe"), @debug.to_repr(self.safe)),
-    (Some("backend_blocks"), @debug.to_repr(self.backend_blocks)),
-    (Some("ids"), @debug.to_repr(self.ids.iter().to_array())),
-    (Some("footnote_count"), @debug.to_repr(self.footnote_count)),
-    (Some("footnotes"), @debug.to_repr(self.footnotes)),
-  ])
-}
+} derive(Debug(ignore=[StringSet]))
 
 ///|
 test {

--- a/src/cmark_html/html.mbt
+++ b/src/cmark_html/html.mbt
@@ -8,12 +8,24 @@ priv struct State {
   ids : StringSet
   mut footnote_count : Int
   footnotes : Map[LabelKey, HtmlRenderFootnote]
-} derive(Show)
+}
+
+///|
+// Manual Debug impl: Set[String] does not derive Debug yet.
+impl @debug.Debug for State with to_repr(self) {
+  @debug.Repr::ctor("State", [
+    (Some("safe"), @debug.to_repr(self.safe)),
+    (Some("backend_blocks"), @debug.to_repr(self.backend_blocks)),
+    (Some("ids"), @debug.to_repr(self.ids.iter().to_array())),
+    (Some("footnote_count"), @debug.to_repr(self.footnote_count)),
+    (Some("footnotes"), @debug.to_repr(self.footnotes)),
+  ])
+}
 
 ///|
 test {
-  // Prevent warning about unused Show
-  (fn(s : State) { s.to_string() }) |> ignore()
+  // Prevent warning about unused Debug
+  (fn(s : State) { @debug.to_string(s) }) |> ignore()
 }
 
 ///|
@@ -22,7 +34,7 @@ priv struct HtmlRenderFootnote {
   id : String
   mut count : Int
   footnote : @cmark.Footnote
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 test {

--- a/src/cmark_html/html_wbtest.mbt
+++ b/src/cmark_html/html_wbtest.mbt
@@ -2,59 +2,104 @@
 test "html escape with null character" {
   let b = StringBuilder::new()
   buffer_add_html_escaped_string(b, "\u{0}abc")
-  inspect(b.to_string(), content="\uFFFDabc")
+  debug_inspect(
+    b.to_string(),
+    content=(
+      #|"�abc"
+    ),
+  )
 }
 
 ///|
 test "html escape with ampersand" {
   let b = StringBuilder::new()
   buffer_add_html_escaped_string(b, "a&b")
-  inspect(b.to_string(), content="a&amp;b")
+  debug_inspect(
+    b.to_string(),
+    content=(
+      #|"a&amp;b"
+    ),
+  )
 }
 
 ///|
 test "html escape with less than" {
   let b = StringBuilder::new()
   buffer_add_html_escaped_string(b, "a<b")
-  inspect(b.to_string(), content="a&lt;b")
+  debug_inspect(
+    b.to_string(),
+    content=(
+      #|"a&lt;b"
+    ),
+  )
 }
 
 ///|
 test "html escape with greater than" {
   let b = StringBuilder::new()
   buffer_add_html_escaped_string(b, "a>b")
-  inspect(b.to_string(), content="a&gt;b")
+  debug_inspect(
+    b.to_string(),
+    content=(
+      #|"a&gt;b"
+    ),
+  )
 }
 
 ///|
 test "html escape with double quote" {
   let b = StringBuilder::new()
   buffer_add_html_escaped_string(b, "a\"b")
-  inspect(b.to_string(), content="a&quot;b")
+  debug_inspect(
+    b.to_string(),
+    content=(
+      #|"a&quot;b"
+    ),
+  )
 }
 
 ///|
 test "buffer_add_pct_encoded_string with ' character" {
   let b = StringBuilder::new()
   buffer_add_pct_encoded_string(b, "don't")
-  inspect(b.to_string(), content="don&apos;t")
+  debug_inspect(
+    b.to_string(),
+    content=(
+      #|"don&apos;t"
+    ),
+  )
 }
 
 ///|
 test "xhtml_renderer with safe mode" {
   let renderer = xhtml_renderer(safe=true)
-  inspect(renderer.doc_to_string(@cmark.Doc::empty()), content="")
+  debug_inspect(
+    renderer.doc_to_string(@cmark.Doc::empty()),
+    content=(
+      #|""
+    ),
+  )
 }
 
 ///|
 test "xhtml_renderer with backend_blocks" {
   let renderer = xhtml_renderer(backend_blocks=true, safe=false)
-  inspect(renderer.doc_to_string(@cmark.Doc::empty()), content="")
+  debug_inspect(
+    renderer.doc_to_string(@cmark.Doc::empty()),
+    content=(
+      #|""
+    ),
+  )
 }
 
 ///|
 test "buffer_add_pct_encoded_string with ampersand" {
   let b = StringBuilder::new()
   buffer_add_pct_encoded_string(b, "test&test") // This will trigger line 211 for "&" handling
-  inspect(b.to_string(), content="test&amp;test")
+  debug_inspect(
+    b.to_string(),
+    content=(
+      #|"test&amp;test"
+    ),
+  )
 }

--- a/src/cmark_html/moon.pkg
+++ b/src/cmark_html/moon.pkg
@@ -3,6 +3,7 @@ import {
   "moonbit-community/cmark/cmark_base",
   "moonbit-community/cmark/cmark",
   "moonbit-community/cmark/cmark_renderer",
+  "moonbitlang/core/debug",
 }
 
 import {

--- a/src/cmark_renderer/error.mbt
+++ b/src/cmark_renderer/error.mbt
@@ -1,4 +1,4 @@
 ///|
 pub(all) suberror RenderError {
   RenderError(String)
-} derive(Show)
+} derive(Debug)

--- a/src/cmark_renderer/moon.pkg
+++ b/src/cmark_renderer/moon.pkg
@@ -1,3 +1,4 @@
 import {
   "moonbit-community/cmark/cmark",
+  "moonbitlang/core/debug",
 }

--- a/src/cmark_renderer/pkg.generated.mbti
+++ b/src/cmark_renderer/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "moonbit-community/cmark/cmark_renderer"
 
 import {
   "moonbit-community/cmark/cmark",
+  "moonbitlang/core/debug",
 }
 
 // Values
@@ -10,7 +11,7 @@ import {
 // Errors
 pub(all) suberror RenderError {
   RenderError(String)
-} derive(Show)
+} derive(@debug.Debug)
 
 // Types and methods
 pub(all) struct BlockFn((Context, @cmark.Block) -> Bool raise)

--- a/src/cmark_renderer/renderer_test.mbt
+++ b/src/cmark_renderer/renderer_test.mbt
@@ -4,7 +4,12 @@ test "context char" {
   let r = @cmark_renderer.Renderer::new()
   let ctx = @cmark_renderer.Context::new(r, b)
   ctx.char('A')
-  inspect(b.to_string(), content="A")
+  debug_inspect(
+    b.to_string(),
+    content=(
+      #|"A"
+    ),
+  )
 }
 
 ///|
@@ -13,7 +18,12 @@ test "context_string" {
   let renderer = @cmark_renderer.Renderer::new()
   let context = @cmark_renderer.Context::new(renderer, buf)
   context.string("hello")
-  inspect(buf.to_string(), content="hello")
+  debug_inspect(
+    buf.to_string(),
+    content=(
+      #|"hello"
+    ),
+  )
 }
 
 ///|
@@ -55,7 +65,12 @@ test "renderer_compose" {
     let buf = StringBuilder::new(size_hint=0)
     let ctx = @cmark_renderer.Context::new(composed, buf)
     ctx.init(@cmark.Doc::empty())
-    inspect(buf.to_string(), content="r1-initr2-init")
+    debug_inspect(
+      buf.to_string(),
+      content=(
+        #|"r1-initr2-init"
+      ),
+    )
   }
 
   // Test inline handler - should call r2 first, if that returns true, r1 shouldn't be called
@@ -63,7 +78,12 @@ test "renderer_compose" {
     let buf = StringBuilder::new(size_hint=0)
     let ctx = @cmark_renderer.Context::new(composed, buf)
     ctx.inline(@cmark.Inline::empty())
-    inspect(buf.to_string(), content="r2-inline")
+    debug_inspect(
+      buf.to_string(),
+      content=(
+        #|"r2-inline"
+      ),
+    )
   }
 
   // Test block handler
@@ -71,14 +91,24 @@ test "renderer_compose" {
     let buf = StringBuilder::new(size_hint=0)
     let ctx = @cmark_renderer.Context::new(composed, buf)
     ctx.block(@cmark.Block::empty())
-    inspect(buf.to_string(), content="r2-block")
+    debug_inspect(
+      buf.to_string(),
+      content=(
+        #|"r2-block"
+      ),
+    )
   }
 
   // Test doc handler
   let buf = StringBuilder::new(size_hint=0)
   let ctx = @cmark_renderer.Context::new(composed, buf)
   ctx.doc(@cmark.Doc::empty())
-  inspect(buf.to_string(), content="r1-initr2-initr2-doc")
+  debug_inspect(
+    buf.to_string(),
+    content=(
+      #|"r1-initr2-initr2-doc"
+    ),
+  )
 }
 
 ///|
@@ -89,7 +119,7 @@ test "renderer_error_handling_inline" {
   let buf = StringBuilder::new(size_hint=0)
   let ctx = @cmark_renderer.Context::new(r, buf)
   let result = try? ctx.inline(@cmark.Inline::empty())
-  inspect(
+  debug_inspect(
     result,
     content=(
       #|Err(RenderError("unknown inline type"))
@@ -105,7 +135,7 @@ test "renderer_error_handling_block" {
   let buf = StringBuilder::new(size_hint=0)
   let ctx = @cmark_renderer.Context::new(r, buf)
   let result = try? ctx.block(@cmark.Block::empty())
-  inspect(
+  debug_inspect(
     result,
     content=(
       #|Err(RenderError("unknown block type"))
@@ -121,7 +151,7 @@ test "renderer_error_handling_doc" {
   let buf = StringBuilder::new(size_hint=0)
   let ctx = @cmark_renderer.Context::new(r, buf)
   let result = try? ctx.doc(@cmark.Doc::empty())
-  inspect(
+  debug_inspect(
     result,
     content=(
       #|Err(RenderError("unhandled doc"))
@@ -138,12 +168,22 @@ test "doc_to_string_and_buffer_add_doc" {
 
   // Test doc_to_string!
   let result = r.doc_to_string(@cmark.Doc::empty())
-  inspect(result, content="doc content")
+  debug_inspect(
+    result,
+    content=(
+      #|"doc content"
+    ),
+  )
 
   // Test buffer_add_doc!
   let buf = StringBuilder::new(size_hint=0)
   r.buffer_add_doc(buf, @cmark.Doc::empty())
-  inspect(buf.to_string(), content="doc content")
+  debug_inspect(
+    buf.to_string(),
+    content=(
+      #|"doc content"
+    ),
+  )
 }
 
 ///|
@@ -175,7 +215,12 @@ test "renderer_fallback" {
     let buf = StringBuilder::new(size_hint=0)
     let ctx = @cmark_renderer.Context::new(composed, buf)
     ctx.inline(@cmark.Inline::empty())
-    inspect(buf.to_string(), content="r2-inline")
+    debug_inspect(
+      buf.to_string(),
+      content=(
+        #|"r2-inline"
+      ),
+    )
   }
 
   // Test block handler with fallback
@@ -183,12 +228,22 @@ test "renderer_fallback" {
     let buf = StringBuilder::new(size_hint=0)
     let ctx = @cmark_renderer.Context::new(composed, buf)
     ctx.block(@cmark.Block::empty())
-    inspect(buf.to_string(), content="r2-block")
+    debug_inspect(
+      buf.to_string(),
+      content=(
+        #|"r2-block"
+      ),
+    )
   }
 
   // Test doc handler with fallback
   let buf = StringBuilder::new(size_hint=0)
   let ctx = @cmark_renderer.Context::new(composed, buf)
   ctx.doc(@cmark.Doc::empty())
-  inspect(buf.to_string(), content="r2-doc")
+  debug_inspect(
+    buf.to_string(),
+    content=(
+      #|"r2-doc"
+    ),
+  )
 }


### PR DESCRIPTION
## Summary
In MoonBit, \`Show\` is for canonical display (like \`Display\` in Rust); \`Debug\` + \`debug_inspect\` are the new path for debugging output. The markdown AST types in this library don't have a canonical display form (rendering goes through \`cmark_renderer\`/\`cmark_html\`), so they're all debug-only consumers — replace \`derive(Show)\` with \`derive(Debug)\` and migrate the test surface to \`debug_inspect\`.

### Mechanical changes
- **77 \`derive(Show, ...)\` → \`derive(Debug, ...)\`** across \`src/cmark/\`, \`src/cmark_base/\`, \`src/cmark_html/\`, \`src/cmark_renderer/\`
- **5 manual \`impl Show for X with output(...)\` → \`impl @debug.Debug for X with to_repr(...)\`**: \`Meta\`, \`Tight\`, \`Node[A]\`, \`Tokens\`, \`RevTokens\`
- **~414 \`inspect(...)\` → \`debug_inspect(...)\`** in test files and README.mbt.md docs; \`Show::to_string\` → \`@debug.to_string\`
- Snapshot content regenerated via \`moon test --update\`
- \`moonbitlang/core/debug\` added to \`moon.pkg\` for \`cmark_base\`, \`cmark\`, \`cmark_html\`

### Notable manual impls
- **\`State\`** (in \`cmark_html\`) and **\`CloserIndex\`** (in \`cmark\`) get hand-written \`@debug.Debug\` because their \`Set[...]\` fields don't yet implement \`Debug\` in \`moonbitlang/core\`.
- **\`Closer\`** retains a manual \`impl Show\` that delegates to \`@debug.to_string\`. \`Map\`'s \`ToJson\` derive requires \`Show\` on its keys, so \`CloserIndex\`'s ToJson would fail without it. This is the single Show island and is private.
- **\`Meta::to_json\`** now matches \`Option\` explicitly instead of \`option.to_string()\` (Option's Show is deprecated).

## Test plan
- [x] \`moon check\`: 0 warnings, 0 errors (was 169 warnings)
- [x] \`moon test\`: 370/370 pass
- [x] \`moon fmt\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbit-community/cmark.mbt/pull/121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
