### PR TITLE
refactor: replace Error? with extensible enum for renderer context state

### DIFF
--- a/src/cmark_base/pkg.generated.mbti
+++ b/src/cmark_base/pkg.generated.mbti
@@ -47,6 +47,9 @@ pub fn run_of(char~ : Char, String, last~ : Int, start~ : Int) -> Int
 // Errors
 
 // Types and methods
+pub extenum ContextState {
+}
+
 pub(all) enum FencedCodeBlockContinue {
   Close(Int, Int)
   Code

--- a/src/cmark_base/state.mbt
+++ b/src/cmark_base/state.mbt
@@ -1,0 +1,8 @@
+///|
+/// Extensible enum for renderer context state.
+///
+/// Concrete renderers extend this type with their own state variants
+/// (e.g. `extenum ContextState += { MyState(...) }`) so the generic
+/// `@cmark_renderer.Context` can carry renderer-specific state without
+/// relying on `Error?` as an untyped container.
+pub extenum ContextState {}

--- a/src/cmark_html/html.mbt
+++ b/src/cmark_html/html.mbt
@@ -41,7 +41,8 @@ impl Compare for HtmlRenderFootnote with compare(self, other) {
 }
 
 ///|
-priv suberror EState {
+/// Extend `ContextState` with the HTML renderer's private state.
+extenum @cmark_base.ContextState += {
   EState(State)
 }
 
@@ -925,6 +926,13 @@ fn doc(c : Context, d : Doc) -> Bool raise {
 // Renderer
 
 ///|
+/// Create an HTML renderer.
+///
+/// Parameters:
+///
+/// - `safe` — when `true`, unsafe raw HTML and links are replaced by comments.
+/// - `backend_blocks` — when `true`, fenced code blocks whose info string
+///   starts with `=` are treated as backend-specific blocks (e.g. `=html`).
 pub fn renderer(
   backend_blocks? : Bool = false,
   safe~ : Bool,
@@ -938,6 +946,7 @@ pub fn renderer(
 }
 
 ///|
+/// Create an XHTML renderer (self-closing tags like `<br />` and `<hr />`).
 pub fn xhtml_renderer(
   backend_blocks? : Bool = false,
   safe~ : Bool,
@@ -951,6 +960,7 @@ pub fn xhtml_renderer(
 }
 
 ///|
+/// Render a parsed `Doc` to an HTML string.
 pub fn from_doc(
   backend_blocks? : Bool = false,
   safe~ : Bool,

--- a/src/cmark_renderer/moon.pkg
+++ b/src/cmark_renderer/moon.pkg
@@ -1,3 +1,4 @@
 import {
   "moonbit-community/cmark/cmark",
+  "moonbit-community/cmark/cmark_base",
 }

--- a/src/cmark_renderer/pkg.generated.mbti
+++ b/src/cmark_renderer/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "moonbit-community/cmark/cmark_renderer"
 
 import {
   "moonbit-community/cmark/cmark",
+  "moonbit-community/cmark/cmark_base",
 }
 
 // Values
@@ -17,7 +18,7 @@ pub(all) struct BlockFn((Context, @cmark.Block) -> Bool raise)
 
 pub(all) struct Context {
   renderer : Renderer
-  mut state : Error?
+  mut state : @cmark_base.ContextState?
   b : StringBuilder
   mut doc : @cmark.Doc
 }

--- a/src/cmark_renderer/renderer.mbt
+++ b/src/cmark_renderer/renderer.mbt
@@ -32,9 +32,13 @@ pub fn Renderer::compose(self : Renderer, other : Renderer) -> Renderer {
 }
 
 ///|
+/// Mutable rendering context threaded through every render callback.
+///
+/// `state` holds renderer-specific data via the `@cmark_base.ContextState`
+/// extensible enum — each concrete renderer extends it with its own variant.
 pub(all) struct Context {
   renderer : Renderer
-  mut state : Error?
+  mut state : @cmark_base.ContextState?
   b : StringBuilder
   mut doc : Doc
 }


### PR DESCRIPTION
## Summary

Replace the untyped `Error?` field on `Context.state` with a new `@cmark_base.ContextState` extensible enum. Concrete renderers now extend this enum with their own variant instead of abusing the error type as an opaque container.

## Changes

- **`cmark_base/state.mbt`** (new): Add `pub extenum ContextState {}` — the extensible enum that renderers extend with their own state.
- **`cmark_renderer/renderer.mbt`**: Change `Context.state` from `Error?` to `@cmark_base.ContextState?`.
- **`cmark_renderer/moon.pkg`**: Add `cmark_base` as a dependency.
- **`cmark_html/html.mbt`**: Replace `priv suberror EState` with `extenum @cmark_base.ContextState += { EState(State) }`.
- Add doc comments to public API and key internal declarations.

## Motivation

Using `Error?` as an opaque state container was a workaround that lost type safety. The extensible enum pattern provides a typed, extensible mechanism for renderers to attach their own state to the shared `Context`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbit-community/cmark.mbt/pull/122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
