### PR TITLE
[codex] Replace debug-only Show and ToJson derives

### DIFF
--- a/src/cmark/README.mbt.md
+++ b/src/cmark/README.mbt.md
@@ -15,41 +15,121 @@ test "basic parsing" {
     #|This is a paragraph.
   let doc = @cmark.Doc::from_string(input)
   // Should contain a heading and a paragraph
-  json_inspect(doc, content={
-    "nl": "\n",
-    "block": [
-      "Blocks",
-      [
-        [
-          [
-            "Heading",
-            [
-              {
-                "layout": [
-                  "Atx",
-                  { "indent": 0, "after_opening": "", "closing": "" },
-                ],
-                "level": 1,
-                "inline": ["Text", ["Hello World"]],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "Paragraph",
-            [
-              {
-                "leading_indent": 0,
-                "inline": ["Text", ["This is a paragraph."]],
-                "trailing_blanks": "",
-              },
-            ],
-          ],
-        ],
-      ],
-    ],
-    "defs": {},
-  })
+  debug_inspect(
+    doc,
+    content=(
+      #|{
+      #|  nl: "\n",
+      #|  block: Blocks(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          Heading(
+      #|            {
+      #|              v: {
+      #|                layout: Atx({ indent: 0, after_opening: "", closing: "" }),
+      #|                level: 1,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "Hello World",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                id: None,
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Paragraph(
+      #|            {
+      #|              v: {
+      #|                leading_indent: 0,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "This is a paragraph.",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                trailing_blanks: "",
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|  defs: {},
+      #|}
+    ),
+  )
 }
 ```
 
@@ -66,35 +146,137 @@ test "emphasis and strong emphasis" {
   let input =
     #|_Emphasis_ and **strong emphasis**
   let doc = @cmark.Doc::from_string(input)
-  json_inspect(doc, content={
-    "nl": "\n",
-    "block": [
-      "Paragraph",
-      [
-        {
-          "leading_indent": 0,
-          "inline": [
-            "Inlines",
-            [
-              [
-                [
-                  "Emphasis",
-                  [{ "delim": "_", "inline": ["Text", ["Emphasis"]] }],
-                ],
-                ["Text", [" and "]],
-                [
-                  "StrongEmphasis",
-                  [{ "delim": "*", "inline": ["Text", ["strong emphasis"]] }],
-                ],
-              ],
-            ],
-          ],
-          "trailing_blanks": "",
-        },
-      ],
-    ],
-    "defs": {},
-  })
+  debug_inspect(
+    doc,
+    content=(
+      #|{
+      #|  nl: "\n",
+      #|  block: Paragraph(
+      #|    {
+      #|      v: {
+      #|        leading_indent: 0,
+      #|        inline: Inlines(
+      #|          {
+      #|            v: Seq(
+      #|              [
+      #|                Emphasis(
+      #|                  {
+      #|                    v: {
+      #|                      delim: '_',
+      #|                      inline: Text(
+      #|                        {
+      #|                          v: "Emphasis",
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                        },
+      #|                      ),
+      #|                    },
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                Text(
+      #|                  {
+      #|                    v: " and ",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                StrongEmphasis(
+      #|                  {
+      #|                    v: {
+      #|                      delim: '*',
+      #|                      inline: Text(
+      #|                        {
+      #|                          v: "strong emphasis",
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                        },
+      #|                      ),
+      #|                    },
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|              ],
+      #|            ),
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|        trailing_blanks: "",
+      #|      },
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|  defs: {},
+      #|}
+    ),
+  )
 }
 ```
 
@@ -106,47 +288,121 @@ test "inline code and math" {
   let input =
     $|$E = mc^2$ in Python: `E = m * (c ** 2)`
   let doc = @cmark.Doc::from_string(input, strict=false)
-  json_inspect(doc, content={
-    "nl": "\n",
-    "block": [
-      "Paragraph",
-      [
-        {
-          "leading_indent": 0,
-          "inline": [
-            "Inlines",
-            [
-              [
-                [
-                  "ExtMathSpan",
-                  [
-                    {
-                      "display": false,
-                      "tex_layout": [{ "blanks": "", "node": ["E = mc^2"] }],
-                    },
-                  ],
-                ],
-                ["Text", [" in Python: "]],
-                [
-                  "CodeSpan",
-                  [
-                    {
-                      "backticks": 1,
-                      "code_layout": [
-                        { "blanks": "", "node": ["E = m * (c ** 2)"] },
-                      ],
-                    },
-                  ],
-                ],
-              ],
-            ],
-          ],
-          "trailing_blanks": "",
-        },
-      ],
-    ],
-    "defs": {},
-  })
+  debug_inspect(
+    doc,
+    content=(
+      #|{
+      #|  nl: "\n",
+      #|  block: Paragraph(
+      #|    {
+      #|      v: {
+      #|        leading_indent: 0,
+      #|        inline: Inlines(
+      #|          {
+      #|            v: Seq(
+      #|              [
+      #|                ExtMathSpan(
+      #|                  {
+      #|                    v: {
+      #|                      display: false,
+      #|                      tex_layout: Seq(
+      #|                        [
+      #|                          {
+      #|                            blanks: "",
+      #|                            node: { v: "E = mc^2", meta: { id: 0, loc: ..., extra: None } },
+      #|                          },
+      #|                        ],
+      #|                      ),
+      #|                    },
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                Text(
+      #|                  {
+      #|                    v: " in Python: ",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                CodeSpan(
+      #|                  {
+      #|                    v: {
+      #|                      backticks: 1,
+      #|                      code_layout: Seq(
+      #|                        [
+      #|                          {
+      #|                            blanks: "",
+      #|                            node: { v: "E = m * (c ** 2)", meta: { id: 0, loc: ..., extra: None } },
+      #|                          },
+      #|                        ],
+      #|                      ),
+      #|                    },
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|              ],
+      #|            ),
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|        trailing_blanks: "",
+      #|      },
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|  defs: {},
+      #|}
+    ),
+  )
 }
 ```
 
@@ -161,20 +417,51 @@ test "headings" {
     #|# Level 1
   let doc = @cmark.Doc::from_string(input)
   // Should contain a heading and a paragraph
-  json_inspect(doc, content={
-    "nl": "\n",
-    "block": [
-      "Heading",
-      [
-        {
-          "layout": ["Atx", { "indent": 0, "after_opening": "", "closing": "" }],
-          "level": 1,
-          "inline": ["Text", ["Level 1"]],
-        },
-      ],
-    ],
-    "defs": {},
-  })
+  debug_inspect(
+    doc,
+    content=(
+      #|{
+      #|  nl: "\n",
+      #|  block: Heading(
+      #|    {
+      #|      v: {
+      #|        layout: Atx({ indent: 0, after_opening: "", closing: "" }),
+      #|        level: 1,
+      #|        inline: Text(
+      #|          {
+      #|            v: "Level 1",
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|        id: None,
+      #|      },
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|  defs: {},
+      #|}
+    ),
+  )
 }
 ```
 
@@ -189,90 +476,188 @@ test "lists" {
     #|  1. Nested item
   let doc = @cmark.Doc::from_string(input)
   // Should find an ordered list within an unordered one.
-  json_inspect(doc, content={
-    "nl": "\n",
-    "block": [
-      "List",
-      [
-        {
-          "ty": ["Unordered", "-"],
-          "tight": true,
-          "items": [
-            [
-              {
-                "before_marker": 0,
-                "marker": ["-"],
-                "after_marker": 1,
-                "block": [
-                  "Paragraph",
-                  [
-                    {
-                      "leading_indent": 0,
-                      "inline": ["Text", ["First item"]],
-                      "trailing_blanks": "",
-                    },
-                  ],
-                ],
-              },
-            ],
-            [
-              {
-                "before_marker": 0,
-                "marker": ["-"],
-                "after_marker": 1,
-                "block": [
-                  "Blocks",
-                  [
-                    [
-                      [
-                        "Paragraph",
-                        [
-                          {
-                            "leading_indent": 0,
-                            "inline": ["Text", ["Second item"]],
-                            "trailing_blanks": "",
-                          },
-                        ],
-                      ],
-                      [
-                        "List",
-                        [
-                          {
-                            "ty": ["Ordered", 1, "."],
-                            "tight": true,
-                            "items": [
-                              [
-                                {
-                                  "before_marker": 0,
-                                  "marker": ["1."],
-                                  "after_marker": 1,
-                                  "block": [
-                                    "Paragraph",
-                                    [
-                                      {
-                                        "leading_indent": 0,
-                                        "inline": ["Text", ["Nested item"]],
-                                        "trailing_blanks": "",
-                                      },
-                                    ],
-                                  ],
-                                },
-                              ],
-                            ],
-                          },
-                        ],
-                      ],
-                    ],
-                  ],
-                ],
-              },
-            ],
-          ],
-        },
-      ],
-    ],
-    "defs": {},
-  })
+  debug_inspect(
+    doc,
+    content=(
+      #|{
+      #|  nl: "\n",
+      #|  block: List(
+      #|    {
+      #|      v: {
+      #|        ty: Unordered('-'),
+      #|        tight: true,
+      #|        items: Seq(
+      #|          [
+      #|            {
+      #|              v: {
+      #|                before_marker: 0,
+      #|                marker: {
+      #|                  v: "-",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|                after_marker: 1,
+      #|                block: Paragraph(
+      #|                  {
+      #|                    v: {
+      #|                      leading_indent: 0,
+      #|                      inline: Text(
+      #|                        {
+      #|                          v: "First item",
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                        },
+      #|                      ),
+      #|                      trailing_blanks: "",
+      #|                    },
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                ext_task_marker: None,
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|            {
+      #|              v: {
+      #|                before_marker: 0,
+      #|                marker: {
+      #|                  v: "-",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|                after_marker: 1,
+      #|                block: Blocks(
+      #|                  {
+      #|                    v: Seq(
+      #|                      [
+      #|                        Paragraph(
+      #|                          {
+      #|                            v: { leading_indent: 0, inline: Text(...), trailing_blanks: "" },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        List(
+      #|                          {
+      #|                            v: { ty: Ordered(1, '.'), tight: true, items: Seq(...) },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                      ],
+      #|                    ),
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                ext_task_marker: None,
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ],
+      #|        ),
+      #|      },
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|  defs: {},
+      #|}
+    ),
+  )
 }
 ```
 
@@ -289,23 +674,129 @@ test "code blocks" {
     #|}
     $|\{tick3}
   let doc = @cmark.Doc::from_string(input)
-  json_inspect(doc, content={
-    "nl": "\n",
-    "block": [
-      "CodeBlock",
-      [
-        {
-          "layout": [
-            "Fenced",
-            { "indent": 0, "opening_fence": [""], "closing_fence": [""] },
-          ],
-          "info_string": ["moonbit"],
-          "code": [["fn main {"], ["  println(\"Hello\")"], ["}"]],
-        },
-      ],
-    ],
-    "defs": {},
-  })
+  debug_inspect(
+    doc,
+    content=(
+      #|{
+      #|  nl: "\n",
+      #|  block: CodeBlock(
+      #|    {
+      #|      v: {
+      #|        layout: Fenced(
+      #|          {
+      #|            indent: 0,
+      #|            opening_fence: {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|            closing_fence: Some(
+      #|              {
+      #|                v: "",
+      #|                meta: {
+      #|                  id: 0,
+      #|                  loc: {
+      #|                    file: "-",
+      #|                    first_ccode: -1,
+      #|                    last_ccode: -1,
+      #|                    first_line: LinePos(-1, -1),
+      #|                    last_line: LinePos(-1, -1),
+      #|                  },
+      #|                  extra: None,
+      #|                },
+      #|              },
+      #|            ),
+      #|          },
+      #|        ),
+      #|        info_string: Some(
+      #|          {
+      #|            v: "moonbit",
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|        code: Seq(
+      #|          [
+      #|            {
+      #|              v: "fn main {",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|            {
+      #|              v: "  println(\"Hello\")",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|            {
+      #|              v: "}",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ],
+      #|        ),
+      #|      },
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|  defs: {},
+      #|}
+    ),
+  )
 }
 ```
 
@@ -319,55 +810,208 @@ test "tables" {
     #||----------|----------|
     #|| Cell 1   | Cell 2   |
   let doc = @cmark.Doc::from_string(input, strict=false)
-  let null = Json::null()
-  json_inspect(doc, content={
-    "nl": "\n",
-    "block": [
-      "ExtTable",
-      [
-        {
-          "indent": 0,
-          "col_count": 2,
-          "rows": [
-            [
-              [
-                [
-                  "Header",
-                  [
-                    [["Text", ["Header 1"]], ["TableCellLayout", ["", ""]]],
-                    [["Text", ["Header 2"]], ["TableCellLayout", ["", ""]]],
-                  ],
-                ],
-              ],
-              "",
-            ],
-            [
-              [
-                [
-                  "Sep",
-                  [[["TableSep", [null, 10]]], [["TableSep", [null, 10]]]],
-                ],
-              ],
-              "",
-            ],
-            [
-              [
-                [
-                  "Data",
-                  [
-                    [["Text", ["Cell 1"]], ["TableCellLayout", ["", ""]]],
-                    [["Text", ["Cell 2"]], ["TableCellLayout", ["", ""]]],
-                  ],
-                ],
-              ],
-              "",
-            ],
-          ],
-        },
-      ],
-    ],
-    "defs": {},
-  })
+  debug_inspect(
+    doc,
+    content=(
+      #|{
+      #|  nl: "\n",
+      #|  block: ExtTable(
+      #|    {
+      #|      v: {
+      #|        indent: 0,
+      #|        col_count: 2,
+      #|        rows: Seq(
+      #|          [
+      #|            (
+      #|              {
+      #|                v: Header(
+      #|                  Seq(
+      #|                    [
+      #|                      (
+      #|                        Text(
+      #|                          {
+      #|                            v: "Header 1",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        TableCellLayout(("", "")),
+      #|                      ),
+      #|                      (
+      #|                        Text(
+      #|                          {
+      #|                            v: "Header 2",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        TableCellLayout(("", "")),
+      #|                      ),
+      #|                    ],
+      #|                  ),
+      #|                ),
+      #|                meta: {
+      #|                  id: 0,
+      #|                  loc: {
+      #|                    file: "-",
+      #|                    first_ccode: -1,
+      #|                    last_ccode: -1,
+      #|                    first_line: LinePos(-1, -1),
+      #|                    last_line: LinePos(-1, -1),
+      #|                  },
+      #|                  extra: None,
+      #|                },
+      #|              },
+      #|              "",
+      #|            ),
+      #|            (
+      #|              {
+      #|                v: Sep(
+      #|                  Seq(
+      #|                    [
+      #|                      {
+      #|                        v: TableSep((None, 10)),
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                      {
+      #|                        v: TableSep((None, 10)),
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    ],
+      #|                  ),
+      #|                ),
+      #|                meta: {
+      #|                  id: 0,
+      #|                  loc: {
+      #|                    file: "-",
+      #|                    first_ccode: -1,
+      #|                    last_ccode: -1,
+      #|                    first_line: LinePos(-1, -1),
+      #|                    last_line: LinePos(-1, -1),
+      #|                  },
+      #|                  extra: None,
+      #|                },
+      #|              },
+      #|              "",
+      #|            ),
+      #|            (
+      #|              {
+      #|                v: Data(
+      #|                  Seq(
+      #|                    [
+      #|                      (
+      #|                        Text(
+      #|                          {
+      #|                            v: "Cell 1",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        TableCellLayout(("", "")),
+      #|                      ),
+      #|                      (
+      #|                        Text(
+      #|                          {
+      #|                            v: "Cell 2",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        TableCellLayout(("", "")),
+      #|                      ),
+      #|                    ],
+      #|                  ),
+      #|                ),
+      #|                meta: {
+      #|                  id: 0,
+      #|                  loc: {
+      #|                    file: "-",
+      #|                    first_ccode: -1,
+      #|                    last_ccode: -1,
+      #|                    first_line: LinePos(-1, -1),
+      #|                    last_line: LinePos(-1, -1),
+      #|                  },
+      #|                  extra: None,
+      #|                },
+      #|              },
+      #|              "",
+      #|            ),
+      #|          ],
+      #|        ),
+      #|      },
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|  defs: {},
+      #|}
+    ),
+  )
 }
 ```
 
@@ -381,114 +1025,371 @@ test "footnotes" {
     #|
     #|[^1]: Footnote content
   let doc = @cmark.Doc::from_string(input, strict=false)
-  json_inspect(doc, content={
-    "nl": "\n",
-    "block": [
-      "Blocks",
-      [
-        [
-          [
-            "Paragraph",
-            [
-              {
-                "leading_indent": 0,
-                "inline": [
-                  "Inlines",
-                  [
-                    [
-                      ["Text", ["Text"]],
-                      [
-                        "Link",
-                        [
-                          {
-                            "text": ["Text", ["^1"]],
-                            "reference": [
-                              "Ref",
-                              "Shortcut",
-                              {
-                                "meta": {},
-                                "key": "^1",
-                                "text": [{ "blanks": "", "node": ["^1"] }],
-                              },
-                              {
-                                "meta": {},
-                                "key": "^1",
-                                "text": [{ "blanks": "", "node": ["^1"] }],
-                              },
-                            ],
-                          },
-                        ],
-                      ],
-                    ],
-                  ],
-                ],
-                "trailing_blanks": "",
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "ExtFootnoteDefinition",
-            [
-              {
-                "indent": 0,
-                "label": {
-                  "meta": {},
-                  "key": "^1",
-                  "text": [{ "blanks": "", "node": ["^1"] }],
-                },
-                "defined_label": {
-                  "meta": {},
-                  "key": "^1",
-                  "text": [{ "blanks": "", "node": ["^1"] }],
-                },
-                "block": [
-                  "Paragraph",
-                  [
-                    {
-                      "leading_indent": 1,
-                      "inline": ["Text", ["Footnote content"]],
-                      "trailing_blanks": "",
-                    },
-                  ],
-                ],
-              },
-            ],
-          ],
-        ],
-      ],
-    ],
-    "defs": {
-      "^1": [
-        "FootnoteDef",
-        [
-          {
-            "indent": 0,
-            "label": {
-              "meta": {},
-              "key": "^1",
-              "text": [{ "blanks": "", "node": ["^1"] }],
-            },
-            "defined_label": {
-              "meta": {},
-              "key": "^1",
-              "text": [{ "blanks": "", "node": ["^1"] }],
-            },
-            "block": [
-              "Paragraph",
-              [
-                {
-                  "leading_indent": 1,
-                  "inline": ["Text", ["Footnote content"]],
-                  "trailing_blanks": "",
-                },
-              ],
-            ],
-          },
-        ],
-      ],
-    },
-  })
+  debug_inspect(
+    doc,
+    content=(
+      #|{
+      #|  nl: "\n",
+      #|  block: Blocks(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          Paragraph(
+      #|            {
+      #|              v: {
+      #|                leading_indent: 0,
+      #|                inline: Inlines(
+      #|                  {
+      #|                    v: Seq(
+      #|                      [
+      #|                        Text(
+      #|                          {
+      #|                            v: "Text",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Link(
+      #|                          {
+      #|                            v: { text: Text(...), reference: Ref(Shortcut, ..., ...) },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                      ],
+      #|                    ),
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                trailing_blanks: "",
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          ExtFootnoteDefinition(
+      #|            {
+      #|              v: {
+      #|                indent: 0,
+      #|                label: {
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                  key: "^1",
+      #|                  text: Seq(
+      #|                    [
+      #|                      {
+      #|                        blanks: "",
+      #|                        node: {
+      #|                          v: "^1",
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                        },
+      #|                      },
+      #|                    ],
+      #|                  ),
+      #|                },
+      #|                defined_label: Some(
+      #|                  {
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                    key: "^1",
+      #|                    text: Seq(
+      #|                      [
+      #|                        {
+      #|                          blanks: "",
+      #|                          node: {
+      #|                            v: "^1",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        },
+      #|                      ],
+      #|                    ),
+      #|                  },
+      #|                ),
+      #|                block: Paragraph(
+      #|                  {
+      #|                    v: {
+      #|                      leading_indent: 1,
+      #|                      inline: Text(
+      #|                        {
+      #|                          v: "Footnote content",
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                        },
+      #|                      ),
+      #|                      trailing_blanks: "",
+      #|                    },
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|  defs: {
+      #|    "^1": FootnoteDef(
+      #|      {
+      #|        v: {
+      #|          indent: 0,
+      #|          label: {
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|            key: "^1",
+      #|            text: Seq(
+      #|              [
+      #|                {
+      #|                  blanks: "",
+      #|                  node: {
+      #|                    v: "^1",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                },
+      #|              ],
+      #|            ),
+      #|          },
+      #|          defined_label: Some(
+      #|            {
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|              key: "^1",
+      #|              text: Seq(
+      #|                [
+      #|                  {
+      #|                    blanks: "",
+      #|                    node: {
+      #|                      v: "^1",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                  },
+      #|                ],
+      #|              ),
+      #|            },
+      #|          ),
+      #|          block: Paragraph(
+      #|            {
+      #|              v: {
+      #|                leading_indent: 1,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "Footnote content",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                trailing_blanks: "",
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        },
+      #|        meta: {
+      #|          id: 0,
+      #|          loc: {
+      #|            file: "-",
+      #|            first_ccode: -1,
+      #|            last_ccode: -1,
+      #|            first_line: LinePos(-1, -1),
+      #|            last_line: LinePos(-1, -1),
+      #|          },
+      #|          extra: None,
+      #|        },
+      #|      },
+      #|    ),
+      #|  },
+      #|}
+    ),
+  )
 }
 ```
 

--- a/src/cmark/alias.mbt
+++ b/src/cmark/alias.mbt
@@ -26,23 +26,12 @@ using @cmark_base {type Span}
 using @cmark_base {type LineSpan}
 
 ///|
-priv struct Tokens(@deque.Deque[Token])
-
-///|
-impl Show for Tokens with output(self, logger) {
-  logger.write_object(self.0)
-}
-
-///|
-impl ToJson for Tokens with to_json(self) {
-  Json::array(Array::from_iter(self.0.iter().map(ToJson::to_json)))
-}
+priv struct Tokens(@deque.Deque[Token]) derive(Debug)
 
 ///|
 test {
-  // Prevent warning about unused Show and ToJson
-  (fn(t : Tokens) { t.to_string() }) |> ignore()
-  (fn(t : Tokens) { t.to_json() }) |> ignore()
+  // Prevent warning about unused Debug.
+  (fn(t : Tokens) { @debug.to_string(t) }) |> ignore()
 }
 
 ///|
@@ -55,23 +44,12 @@ fn Tokens::push(self : Tokens, t : Token) -> Unit {
 // }
 
 ///|
-priv struct RevTokens(@deque.Deque[Token])
-
-///|
-impl Show for RevTokens with output(self, logger) {
-  logger.write_object(self.0)
-}
-
-///|
-impl ToJson for RevTokens with to_json(self) {
-  Json::array(Array::from_iter(self.0.iter().map(ToJson::to_json)))
-}
+priv struct RevTokens(@deque.Deque[Token]) derive(Debug)
 
 ///|
 test {
-  // Prevent warning about unused Show and ToJson
-  (fn(t : RevTokens) { t.to_string() }) |> ignore()
-  (fn(t : RevTokens) { t.to_json() }) |> ignore()
+  // Prevent warning about unused Debug.
+  (fn(t : RevTokens) { @debug.to_string(t) }) |> ignore()
 }
 
 ///|

--- a/src/cmark/block.mbt
+++ b/src/cmark/block.mbt
@@ -14,7 +14,7 @@ pub(all) enum Block {
   ExtMathBlock(Node[CodeBlock])
   ExtTable(Node[Table])
   ExtFootnoteDefinition(Node[Footnote])
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 pub fn Block::empty() -> Block {
@@ -110,7 +110,7 @@ pub(all) struct BlockQuote {
   indent : Indent
   /// The quoted block.
   block : Block
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 pub fn BlockQuote::new(indent? : Int = 0, block : Block) -> BlockQuote {
@@ -137,20 +137,20 @@ pub(all) struct CodeBlock {
   layout : CodeBlockLayout
   info_string : StringNode?
   code : Seq[StringNode]
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 pub(all) enum CodeBlockLayout {
   Indented
   Fenced(CodeBlockFencedLayout)
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 pub(all) struct CodeBlockFencedLayout {
   indent : Indent
   opening_fence : StringNode
   closing_fence : StringNode?
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 pub fn CodeBlockFencedLayout::default() -> CodeBlockFencedLayout {
@@ -225,20 +225,20 @@ pub(all) struct BlockHeading {
   level : Int
   inline : Inline
   id : BlockHeadingId?
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 pub(all) enum BlockHeadingLayout {
   Atx(BlockHeadingAtxLayout)
   Setext(BlockHeadingSetextLayout)
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 pub(all) struct BlockHeadingAtxLayout {
   indent : Indent
   after_opening : Blanks
   closing : String
-} derive(Show, FromJson, ToJson)
+} derive(Debug, FromJson, ToJson)
 
 ///|
 pub fn BlockHeadingAtxLayout::default() -> BlockHeadingAtxLayout {
@@ -252,13 +252,13 @@ pub(all) struct BlockHeadingSetextLayout {
   underline_indent : Indent
   underline_count : Node[Count]
   underline_blanks : Blanks
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 pub(all) enum BlockHeadingId {
   Auto(String)
   Id(String)
-} derive(Show, FromJson, ToJson)
+} derive(Debug, FromJson, ToJson)
 
 ///|
 pub fn BlockHeading::new(
@@ -272,7 +272,7 @@ pub fn BlockHeading::new(
 
 ///|
 /// The type for [HTML blocks](https://spec.commonmark.org/0.30/#html-blocks).
-pub(all) struct HtmlBlock(Seq[StringNode]) derive(Show, ToJson)
+pub(all) struct HtmlBlock(Seq[StringNode]) derive(Debug)
 
 ///|
 pub(all) struct ListItem {
@@ -281,7 +281,7 @@ pub(all) struct ListItem {
   after_marker : Indent
   block : Block
   ext_task_marker : Node[Char]?
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 pub type ListItemBlock = ListItem
@@ -331,7 +331,7 @@ pub(all) struct BlockList {
   ty : ListType
   tight : Bool
   items : Seq[Node[ListItem]]
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 pub fn BlockList::map_items(
@@ -352,7 +352,7 @@ pub(all) struct BlockParagraph {
   leading_indent : Indent
   inline : Inline
   trailing_blanks : Blanks
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 pub fn BlockParagraph::new(
@@ -368,7 +368,7 @@ pub fn BlockParagraph::new(
 pub(all) struct BlockThematicBreak {
   indent : Indent
   layout : String
-} derive(Show, FromJson, ToJson)
+} derive(Debug, FromJson, ToJson)
 
 ///|
 pub fn BlockThematicBreak::new(
@@ -386,7 +386,7 @@ pub(all) struct Footnote {
   label : Label
   defined_label : Label?
   block : Block
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 pub fn Footnote::new(
@@ -421,32 +421,27 @@ pub(all) struct Table {
   indent : Indent
   col_count : Count
   rows : Seq[(Node[TableRow], Blanks)]
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 pub(all) enum TableAlign {
   Left
   Center
   Right
-} derive(Show, FromJson, ToJson)
+} derive(Debug, FromJson, ToJson)
 
 ///|
 pub(all) enum TableRow {
   Header(Seq[(Inline, TableCellLayout)])
   Sep(Seq[Node[TableSep]])
   Data(Seq[(Inline, TableCellLayout)])
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
-pub(all) struct TableSep((TableAlign?, Count)) derive(Show, ToJson)
+pub(all) struct TableSep((TableAlign?, Count)) derive(Debug)
 
 ///|
-pub(all) struct TableCellLayout((Blanks, Blanks)) derive (
-  Show,
-  ToJson,
-  Eq,
-  Compare,
-)
+pub(all) struct TableCellLayout((Blanks, Blanks)) derive(Debug, Eq, Compare)
 
 ///|
 pub fn Table::new(

--- a/src/cmark/block_line.mbt
+++ b/src/cmark/block_line.mbt
@@ -38,8 +38,8 @@ pub fn Tight::empty(meta? : Meta = Meta::none()) -> Tight {
 }
 
 ///|
-pub impl Show for Tight with output(self, logger) {
-  logger.write_object(self.node.v)
+pub impl Show for Tight with to_string(self) {
+  self.node.v
 }
 
 ///|

--- a/src/cmark/block_line.mbt
+++ b/src/cmark/block_line.mbt
@@ -30,16 +30,11 @@ pub fn BlockLine::list_text_loc(ls : Seq[BlockLine]) -> TextLoc {
 pub(all) struct Tight {
   blanks : Blanks
   node : StringNode
-} derive(Eq, ToJson)
+} derive(Eq, Debug)
 
 ///|
 pub fn Tight::empty(meta? : Meta = Meta::none()) -> Tight {
   { blanks: "", node: StringNode::empty(meta~) }
-}
-
-///|
-pub impl Show for Tight with to_string(self) {
-  self.node.v
 }
 
 ///|

--- a/src/cmark/block_line_test.mbt
+++ b/src/cmark/block_line_test.mbt
@@ -1,7 +1,12 @@
 ///|
-test "Show for Tight outputs the node content" {
+test "Tight::to_string outputs the node content" {
   let tight = @cmark.Tight::empty()
-  inspect(Show::to_string(tight), content="\"\"")
+  debug_inspect(
+    tight.to_string(),
+    content=(
+      #|""
+    ),
+  )
 }
 
 ///|
@@ -9,16 +14,27 @@ test "BlockLine::to_string extracts the string value" {
   let meta = @cmark_base.Meta::none()
   let block_line : @cmark.BlockLine = { v: "Test string", meta }
   let result = block_line.to_string()
-  inspect(result, content="Test string")
+  debug_inspect(
+    result,
+    content=(
+      #|"Test string"
+    ),
+  )
 }
 
 ///|
 test "BlockLine::list_text_loc handles empty sequence" {
   let empty_seq = @cmark.Seq::empty()
-  inspect(
+  debug_inspect(
     @cmark.BlockLine::list_text_loc(empty_seq),
     content=(
-      #|{file: "-", first_ccode: -1, last_ccode: -1, first_line: LinePos(-1, -1), last_line: LinePos(-1, -1)}
+      #|{
+      #|  file: "-",
+      #|  first_ccode: -1,
+      #|  last_ccode: -1,
+      #|  first_line: LinePos(-1, -1),
+      #|  last_line: LinePos(-1, -1),
+      #|}
     ),
   )
 }
@@ -36,10 +52,16 @@ test "BlockLine::list_text_loc handles single element sequence" {
   let single_node : @cmark.BlockLine = { v: "hello", meta }
   let single_seq = @cmark.Seq::from_array([single_node])
   let result = @cmark.BlockLine::list_text_loc(single_seq)
-  inspect(
+  debug_inspect(
     result,
     content=(
-      #|{file: "-", first_ccode: 0, last_ccode: 5, first_line: LinePos(1, 0), last_line: LinePos(1, 5)}
+      #|{
+      #|  file: "-",
+      #|  first_ccode: 0,
+      #|  last_ccode: 5,
+      #|  first_line: LinePos(1, 0),
+      #|  last_line: LinePos(1, 5),
+      #|}
     ),
   )
 }
@@ -71,10 +93,16 @@ test "BlockLine::list_text_loc handles multiple element sequence" {
   let result = @cmark.BlockLine::list_text_loc(multi_seq)
 
   // Should span from first_ccode of first node to last_ccode of last node
-  inspect(
+  debug_inspect(
     result,
     content=(
-      #|{file: "-", first_ccode: 0, last_ccode: 11, first_line: LinePos(1, 0), last_line: LinePos(2, 5)}
+      #|{
+      #|  file: "-",
+      #|  first_ccode: 0,
+      #|  last_ccode: 11,
+      #|  first_line: LinePos(1, 0),
+      #|  last_line: LinePos(2, 5),
+      #|}
     ),
   )
 }
@@ -82,10 +110,16 @@ test "BlockLine::list_text_loc handles multiple element sequence" {
 ///|
 test "Tight::list_text_loc handles empty sequence" {
   let empty_seq = @cmark.Seq::empty()
-  inspect(
+  debug_inspect(
     @cmark.Tight::list_text_loc(empty_seq),
     content=(
-      #|{file: "-", first_ccode: -1, last_ccode: -1, first_line: LinePos(-1, -1), last_line: LinePos(-1, -1)}
+      #|{
+      #|  file: "-",
+      #|  first_ccode: -1,
+      #|  last_ccode: -1,
+      #|  first_line: LinePos(-1, -1),
+      #|  last_line: LinePos(-1, -1),
+      #|}
     ),
   )
 }
@@ -103,10 +137,16 @@ test "Tight::list_text_loc handles single element sequence" {
   let node : @cmark.StringNode = { v: "hello", meta }
   let t : @cmark.Tight = { blanks: "", node }
   let seq = @cmark.Seq::from_array([t])
-  inspect(
+  debug_inspect(
     @cmark.Tight::list_text_loc(seq),
     content=(
-      #|{file: "-", first_ccode: 0, last_ccode: 5, first_line: LinePos(1, 0), last_line: LinePos(1, 5)}
+      #|{
+      #|  file: "-",
+      #|  first_ccode: 0,
+      #|  last_ccode: 5,
+      #|  first_line: LinePos(1, 0),
+      #|  last_line: LinePos(1, 5),
+      #|}
     ),
   )
 }
@@ -137,10 +177,16 @@ test "Tight::list_text_loc handles multiple element sequence" {
   let node2 : @cmark.StringNode = { v: "world", meta: meta2 }
   let t2 : @cmark.Tight = { blanks: "  ", node: node2 }
   let seq = @cmark.Seq::from_array([t1, t2])
-  inspect(
+  debug_inspect(
     @cmark.Tight::list_text_loc(seq),
     content=(
-      #|{file: "-", first_ccode: 0, last_ccode: 11, first_line: LinePos(1, 0), last_line: LinePos(2, 5)}
+      #|{
+      #|  file: "-",
+      #|  first_ccode: 0,
+      #|  last_ccode: 11,
+      #|  first_line: LinePos(1, 0),
+      #|  last_line: LinePos(2, 5),
+      #|}
     ),
   )
 }

--- a/src/cmark/block_struct.mbt
+++ b/src/cmark/block_struct.mbt
@@ -135,7 +135,7 @@ priv struct IndentedCodeLine {
   pad : SpacePad
   code : LineSpan
   is_blank : Bool
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 priv struct Fence {
@@ -144,19 +144,19 @@ priv struct Fence {
   fence : (Char, Int) // Fence length
   info_string : LineSpan? // We drop the trailing blanks
   closing_fence : LineSpan?
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 priv struct FenceCodeBlockStruct {
   fence : Fence
   code : Array[(SpacePad, LineSpan)]
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 priv enum CodeBlockStruct {
   Indented(Array[IndentedCodeLine])
   Fenced(FenceCodeBlockStruct)
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 priv struct Atx {
@@ -165,7 +165,7 @@ priv struct Atx {
   after_open : CharCodePos
   heading : LineSpan
   layout_after : LineSpan
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 priv struct Setext {
@@ -173,25 +173,25 @@ priv struct Setext {
   heading_lines : Array[LineSpan]
   /// Indent, underline char count, blanks
   underline : (Indent, LineSpan, LineSpan)
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 priv enum Heading {
   Atx(Atx)
   Setext(Setext)
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 priv struct HtmlBlockStruct {
   end_cond : HtmlBlockEndCond?
   html : Array[LineSpan]
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 priv struct Paragraph {
   maybe_ref : Bool
   lines : Array[LineSpan]
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 priv enum BlockStruct {
@@ -206,7 +206,7 @@ priv enum BlockStruct {
   ThematicBreak(Indent, LineSpan) // Including trailing blanks
   ExtTable(Indent, Array[(LineSpan, LineSpan)]) // The second `LineSpan` is for trailing blanks
   ExtFootnote(Indent, (Label, Label?), Array[BlockStruct])
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 priv struct ListItemStruct {
@@ -215,7 +215,7 @@ priv struct ListItemStruct {
   after_marker : Indent
   ext_task_marker : (Char, LineSpan)?
   blocks : Array[BlockStruct]
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 priv struct ListBlockStruct {
@@ -224,7 +224,7 @@ priv struct ListBlockStruct {
   item_min_indent : Indent // Last item minimal indent
   list_type : ListType
   items : Array[ListItemStruct]
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 fn BlockStruct::is_blank_line(self : BlockStruct) -> Bool {

--- a/src/cmark/block_struct_test.mbt
+++ b/src/cmark/block_struct_test.mbt
@@ -2,5 +2,10 @@
 test "get_first_line with CRLF" {
   let line = "hello\r\nworld"
   let doc = @cmark.Doc::from_string(line)
-  inspect(doc.nl, content="\r\n")
+  debug_inspect(
+    doc.nl,
+    content=(
+      #|"\r\n"
+    ),
+  )
 }

--- a/src/cmark/block_struct_wbtest.mbt
+++ b/src/cmark/block_struct_wbtest.mbt
@@ -4,49 +4,126 @@ test "plain" {
     #|Basic tests
     #|===========
     #|Basic tests for all CommonMark constructs.
-  json_inspect(Doc::from_string(doc), content={
-    "nl": "\n",
-    "block": [
-      "Blocks",
-      [
-        [
-          [
-            "Heading",
-            [
-              {
-                "layout": [
-                  "Setext",
-                  {
-                    "leading_indent": 0,
-                    "trailing_blanks": "",
-                    "underline_indent": 0,
-                    "underline_count": [11],
-                    "underline_blanks": "",
-                  },
-                ],
-                "level": 1,
-                "inline": ["Text", ["Basic tests"]],
-              },
-            ],
-          ],
-          [
-            "Paragraph",
-            [
-              {
-                "leading_indent": 0,
-                "inline": [
-                  "Text",
-                  ["Basic tests for all CommonMark constructs."],
-                ],
-                "trailing_blanks": "",
-              },
-            ],
-          ],
-        ],
-      ],
-    ],
-    "defs": {},
-  })
+  debug_inspect(
+    Doc::from_string(doc),
+    content=(
+      #|{
+      #|  nl: "\n",
+      #|  block: Blocks(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          Heading(
+      #|            {
+      #|              v: {
+      #|                layout: Setext(
+      #|                  {
+      #|                    leading_indent: 0,
+      #|                    trailing_blanks: "",
+      #|                    underline_indent: 0,
+      #|                    underline_count: {
+      #|                      v: 11,
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    underline_blanks: "",
+      #|                  },
+      #|                ),
+      #|                level: 1,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "Basic tests",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                id: None,
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Paragraph(
+      #|            {
+      #|              v: {
+      #|                leading_indent: 0,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "Basic tests for all CommonMark constructs.",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                trailing_blanks: "",
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|  defs: {},
+      #|}
+    ),
+  )
 }
 
 ///|
@@ -55,125 +132,412 @@ test "complex ref definitions" {
     #|  to [c    d][]
     #|> [c d]: /ha "Multi
     #|>   line titles"
-  json_inspect(Doc::from_string(doc), content={
-    "nl": "\n",
-    "block": [
-      "Blocks",
-      [
-        [
-          [
-            "Paragraph",
-            [
-              {
-                "leading_indent": 2,
-                "inline": [
-                  "Inlines",
-                  [
-                    [
-                      ["Text", ["to "]],
-                      [
-                        "Link",
-                        [
-                          {
-                            "text": ["Text", ["c    d"]],
-                            "reference": [
-                              "Ref",
-                              "Collapsed",
-                              {
-                                "meta": {},
-                                "key": "c d",
-                                "text": [{ "blanks": "", "node": ["c    d"] }],
-                              },
-                              {
-                                "meta": {},
-                                "key": "c d",
-                                "text": [{ "blanks": "", "node": ["c d"] }],
-                              },
-                            ],
-                          },
-                        ],
-                      ],
-                    ],
-                  ],
-                ],
-                "trailing_blanks": "",
-              },
-            ],
-          ],
-          [
-            "BlockQuote",
-            [
-              {
-                "indent": 0,
-                "block": [
-                  "LinkRefDefinition",
-                  [
-                    {
-                      "layout": {
-                        "indent": 0,
-                        "angled_dest": false,
-                        "before_dest": [[" "]],
-                        "after_dest": [[" "]],
-                        "title_open_delim": "\"",
-                        "after_title": [[""]],
-                      },
-                      "label": {
-                        "meta": {},
-                        "key": "c d",
-                        "text": [{ "blanks": "", "node": ["c d"] }],
-                      },
-                      "defined_label": {
-                        "meta": {},
-                        "key": "c d",
-                        "text": [{ "blanks": "", "node": ["c d"] }],
-                      },
-                      "dest": ["/ha"],
-                      "title": [
-                        { "blanks": "", "node": ["Multi"] },
-                        { "blanks": "", "node": ["line titles"] },
-                      ],
-                    },
-                  ],
-                ],
-              },
-            ],
-          ],
-        ],
-      ],
-    ],
-    "defs": {
-      "c d": [
-        "LinkDef",
-        [
-          {
-            "layout": {
-              "indent": 0,
-              "angled_dest": false,
-              "before_dest": [[" "]],
-              "after_dest": [[" "]],
-              "title_open_delim": "\"",
-              "after_title": [[""]],
-            },
-            "label": {
-              "meta": {},
-              "key": "c d",
-              "text": [{ "blanks": "", "node": ["c d"] }],
-            },
-            "defined_label": {
-              "meta": {},
-              "key": "c d",
-              "text": [{ "blanks": "", "node": ["c d"] }],
-            },
-            "dest": ["/ha"],
-            "title": [
-              { "blanks": "", "node": ["Multi"] },
-              { "blanks": "", "node": ["line titles"] },
-            ],
-          },
-        ],
-      ],
-    },
-  })
+  debug_inspect(
+    Doc::from_string(doc),
+    content=(
+      #|{
+      #|  nl: "\n",
+      #|  block: Blocks(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          Paragraph(
+      #|            {
+      #|              v: {
+      #|                leading_indent: 2,
+      #|                inline: Inlines(
+      #|                  {
+      #|                    v: Seq(
+      #|                      [
+      #|                        Text(
+      #|                          {
+      #|                            v: "to ",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Link(
+      #|                          {
+      #|                            v: { text: Text(...), reference: Ref(Collapsed, ..., ...) },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                      ],
+      #|                    ),
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                trailing_blanks: "",
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlockQuote(
+      #|            {
+      #|              v: {
+      #|                indent: 0,
+      #|                block: LinkRefDefinition(
+      #|                  {
+      #|                    v: {
+      #|                      layout: {
+      #|                        indent: 0,
+      #|                        angled_dest: false,
+      #|                        before_dest: Seq([{ v: " ", meta: { id: 0, loc: ..., extra: None } }]),
+      #|                        after_dest: Seq([{ v: " ", meta: { id: 0, loc: ..., extra: None } }]),
+      #|                        title_open_delim: '"',
+      #|                        after_title: Seq([{ v: "", meta: { id: 0, loc: ..., extra: None } }]),
+      #|                      },
+      #|                      label: Some(
+      #|                        {
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                          key: "c d",
+      #|                          text: Seq([{ blanks: "", node: ... }]),
+      #|                        },
+      #|                      ),
+      #|                      defined_label: Some(
+      #|                        {
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                          key: "c d",
+      #|                          text: Seq([{ blanks: "", node: ... }]),
+      #|                        },
+      #|                      ),
+      #|                      dest: Some(
+      #|                        {
+      #|                          v: "/ha",
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                        },
+      #|                      ),
+      #|                      title: Some(
+      #|                        Seq(
+      #|                          [
+      #|                            { blanks: "", node: { v: "Multi", meta: ... } },
+      #|                            { blanks: "", node: { v: "line titles", meta: ... } },
+      #|                          ],
+      #|                        ),
+      #|                      ),
+      #|                    },
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|  defs: {
+      #|    "c d": LinkDef(
+      #|      {
+      #|        v: {
+      #|          layout: {
+      #|            indent: 0,
+      #|            angled_dest: false,
+      #|            before_dest: Seq(
+      #|              [
+      #|                {
+      #|                  v: " ",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|              ],
+      #|            ),
+      #|            after_dest: Seq(
+      #|              [
+      #|                {
+      #|                  v: " ",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|              ],
+      #|            ),
+      #|            title_open_delim: '"',
+      #|            after_title: Seq(
+      #|              [
+      #|                {
+      #|                  v: "",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|              ],
+      #|            ),
+      #|          },
+      #|          label: Some(
+      #|            {
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|              key: "c d",
+      #|              text: Seq(
+      #|                [
+      #|                  {
+      #|                    blanks: "",
+      #|                    node: {
+      #|                      v: "c d",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                  },
+      #|                ],
+      #|              ),
+      #|            },
+      #|          ),
+      #|          defined_label: Some(
+      #|            {
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|              key: "c d",
+      #|              text: Seq(
+      #|                [
+      #|                  {
+      #|                    blanks: "",
+      #|                    node: {
+      #|                      v: "c d",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                  },
+      #|                ],
+      #|              ),
+      #|            },
+      #|          ),
+      #|          dest: Some(
+      #|            {
+      #|              v: "/ha",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          title: Some(
+      #|            Seq(
+      #|              [
+      #|                {
+      #|                  blanks: "",
+      #|                  node: {
+      #|                    v: "Multi",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                },
+      #|                {
+      #|                  blanks: "",
+      #|                  node: {
+      #|                    v: "line titles",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                },
+      #|              ],
+      #|            ),
+      #|          ),
+      #|        },
+      #|        meta: {
+      #|          id: 0,
+      #|          loc: {
+      #|            file: "-",
+      #|            first_ccode: -1,
+      #|            last_ccode: -1,
+      #|            first_line: LinePos(-1, -1),
+      #|            last_line: LinePos(-1, -1),
+      #|          },
+      #|          extra: None,
+      #|        },
+      #|      },
+      #|    ),
+      #|  },
+      #|}
+    ),
+  )
 }
 
 ///|
@@ -184,29 +548,148 @@ test "HTML block" {
     #|</div>
     #|
     #| world
-  json_inspect(Doc::from_string(doc), content={
-    "nl": "\n",
-    "block": [
-      "Blocks",
-      [
-        [
-          ["HtmlBlock", [["HtmlBlock", [["<div>"], ["  hello"], ["</div>"]]]]],
-          ["BlankLine", [""]],
-          [
-            "Paragraph",
-            [
-              {
-                "leading_indent": 1,
-                "inline": ["Text", ["world"]],
-                "trailing_blanks": "",
-              },
-            ],
-          ],
-        ],
-      ],
-    ],
-    "defs": {},
-  })
+  debug_inspect(
+    Doc::from_string(doc),
+    content=(
+      #|{
+      #|  nl: "\n",
+      #|  block: Blocks(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          HtmlBlock(
+      #|            {
+      #|              v: HtmlBlock(
+      #|                Seq(
+      #|                  [
+      #|                    {
+      #|                      v: "<div>",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: "  hello",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: "</div>",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|              ),
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Paragraph(
+      #|            {
+      #|              v: {
+      #|                leading_indent: 1,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "world",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                trailing_blanks: "",
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|  defs: {},
+      #|}
+    ),
+  )
 }
 
 ///|
@@ -215,30 +698,36 @@ test "should tokenize inline image across multiple lines" {
     #|This is an ![inline image](
     #|  /heyho    (The
     #|    multiline title))
-  json_inspect(tokenize_only(doc), content=[
-    ["CloserIndex", { "RightBrack": [25], "RightParen": [64, 65] }],
-    [
-      ["LinkStart", { "start": 11, "image": true }],
-      ["RightBrack", { "start": 25 }],
-      [
-        "Newline",
-        {
-          "start": 27,
-          "break_ty": "Soft",
-          "newline": { "pos": ["LinePos", 2, 0], "first": 28, "last": 43 },
-        },
-      ],
-      [
-        "Newline",
-        {
-          "start": 44,
-          "break_ty": "Soft",
-          "newline": { "pos": ["LinePos", 3, 0], "first": 45, "last": 65 },
-        },
-      ],
-    ],
-    { "pos": ["LinePos", 1, 0], "first": 0, "last": 26 },
-  ])
+  debug_inspect(
+    tokenize_only(doc),
+    content=(
+      #|(
+      #|  CloserIndex({ RightBrack: <Set: [25]>, RightParen: <Set: [64, 65]> }),
+      #|  Tokens(
+      #|    <Deque:
+      #|      [
+      #|        LinkStart({ start: 11, image: true }),
+      #|        RightBrack({ start: 25 }),
+      #|        Newline(
+      #|          {
+      #|            start: 27,
+      #|            break_ty: Soft,
+      #|            newline: { pos: LinePos(2, 0), first: 28, last: 43 },
+      #|          },
+      #|        ),
+      #|        Newline(
+      #|          {
+      #|            start: 44,
+      #|            break_ty: Soft,
+      #|            newline: { pos: LinePos(3, 0), first: 45, last: 65 },
+      #|          },
+      #|        ),
+      #|      ]>,
+      #|  ),
+      #|  { pos: LinePos(1, 0), first: 0, last: 26 },
+      #|)
+    ),
+  )
 }
 
 ///|
@@ -253,61 +742,214 @@ test "should parse normal raw HTML block" {
     #|  <h2>Section Title</h2>
     #|  <p>This is a paragraph inside a custom HTML container.</p>
     #|</div>
-  json_inspect(Doc::from_string(doc), content={
-    "nl": "\n",
-    "block": [
-      "Blocks",
-      [
-        [
-          [
-            "Heading",
-            [
-              {
-                "layout": [
-                  "Atx",
-                  { "indent": 0, "after_opening": "", "closing": "" },
-                ],
-                "level": 1,
-                "inline": ["Text", ["My Document"]],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "Paragraph",
-            [
-              {
-                "leading_indent": 0,
-                "inline": [
-                  "Text",
-                  ["This is a standard paragraph in Markdown."],
-                ],
-                "trailing_blanks": "",
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "HtmlBlock",
-            [
-              [
-                "HtmlBlock",
-                [
-                  ["<div class=\"custom-container\">"],
-                  ["  <h2>Section Title</h2>"],
-                  [
-                    "  <p>This is a paragraph inside a custom HTML container.</p>",
-                  ],
-                  ["</div>"],
-                ],
-              ],
-            ],
-          ],
-        ],
-      ],
-    ],
-    "defs": {},
-  })
+  debug_inspect(
+    Doc::from_string(doc),
+    content=(
+      #|{
+      #|  nl: "\n",
+      #|  block: Blocks(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          Heading(
+      #|            {
+      #|              v: {
+      #|                layout: Atx({ indent: 0, after_opening: "", closing: "" }),
+      #|                level: 1,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "My Document",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                id: None,
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Paragraph(
+      #|            {
+      #|              v: {
+      #|                leading_indent: 0,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "This is a standard paragraph in Markdown.",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                trailing_blanks: "",
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          HtmlBlock(
+      #|            {
+      #|              v: HtmlBlock(
+      #|                Seq(
+      #|                  [
+      #|                    {
+      #|                      v: "<div class=\"custom-container\">",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: "  <h2>Section Title</h2>",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: "  <p>This is a paragraph inside a custom HTML container.</p>",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: "</div>",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|              ),
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|  defs: {},
+      #|}
+    ),
+  )
 }
 
 ///|
@@ -321,61 +963,204 @@ test "should parse normal code block" {
     #| assert_false!(v[:].all(fn(elem) { elem % 2 == 0 }))
     #| assert_true!(v[1:4].all(fn(elem) { elem % 2 == 0 }))
     #| ```
-  json_inspect(Doc::from_string(doc), content={
-    "nl": "\n",
-    "block": [
-      "Blocks",
-      [
-        [
-          [
-            "Paragraph",
-            [
-              {
-                "leading_indent": 1,
-                "inline": [
-                  "Text",
-                  [
-                    "Checks if all elements in the array view match the condition.",
-                  ],
-                ],
-                "trailing_blanks": "",
-              },
-            ],
-          ],
-          [
-            "Heading",
-            [
-              {
-                "layout": [
-                  "Atx",
-                  { "indent": 1, "after_opening": "", "closing": "" },
-                ],
-                "level": 1,
-                "inline": ["Text", ["Example"]],
-              },
-            ],
-          ],
-          [
-            "CodeBlock",
-            [
-              {
-                "layout": [
-                  "Fenced",
-                  { "indent": 1, "opening_fence": [""], "closing_fence": [""] },
-                ],
-                "code": [
-                  ["let v = [1, 4, 6, 8, 9]"],
-                  ["assert_false!(v[:].all(fn(elem) { elem % 2 == 0 }))"],
-                  ["assert_true!(v[1:4].all(fn(elem) { elem % 2 == 0 }))"],
-                ],
-              },
-            ],
-          ],
-        ],
-      ],
-    ],
-    "defs": {},
-  })
+  debug_inspect(
+    Doc::from_string(doc),
+    content=(
+      #|{
+      #|  nl: "\n",
+      #|  block: Blocks(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          Paragraph(
+      #|            {
+      #|              v: {
+      #|                leading_indent: 1,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "Checks if all elements in the array view match the condition.",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                trailing_blanks: "",
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Heading(
+      #|            {
+      #|              v: {
+      #|                layout: Atx({ indent: 1, after_opening: "", closing: "" }),
+      #|                level: 1,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "Example",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                id: None,
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          CodeBlock(
+      #|            {
+      #|              v: {
+      #|                layout: Fenced(
+      #|                  {
+      #|                    indent: 1,
+      #|                    opening_fence: {
+      #|                      v: "",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    closing_fence: Some(
+      #|                      {
+      #|                        v: "",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    ),
+      #|                  },
+      #|                ),
+      #|                info_string: None,
+      #|                code: Seq(
+      #|                  [
+      #|                    {
+      #|                      v: "let v = [1, 4, 6, 8, 9]",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: "assert_false!(v[:].all(fn(elem) { elem % 2 == 0 }))",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: "assert_true!(v[1:4].all(fn(elem) { elem % 2 == 0 }))",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|  defs: {},
+      #|}
+    ),
+  )
 }
 
 ///|
@@ -385,194 +1170,701 @@ test "should parse link refs" {
     #|
     #|[Extism PDK]: https://extism.org/docs/concepts/pdk
     #|[Extism Plug-ins]: https://extism.org/docs/concepts/plug-in
-  json_inspect(Doc::from_string(doc), content={
-    "nl": "\n",
-    "block": [
-      "Blocks",
-      [
-        [
-          [
-            "Paragraph",
-            [
-              {
-                "leading_indent": 0,
-                "inline": [
-                  "Inlines",
-                  [
-                    [
-                      ["Text", ["This is an "]],
-                      [
-                        "Link",
-                        [
-                          {
-                            "text": ["Text", ["Extism PDK"]],
-                            "reference": [
-                              "Ref",
-                              "Shortcut",
-                              {
-                                "meta": {},
-                                "key": "extism pdk",
-                                "text": [
-                                  { "blanks": "", "node": ["Extism PDK"] },
-                                ],
-                              },
-                              {
-                                "meta": {},
-                                "key": "extism pdk",
-                                "text": [
-                                  { "blanks": "", "node": ["Extism PDK"] },
-                                ],
-                              },
-                            ],
-                          },
-                        ],
-                      ],
-                      ["Text", [" that can be used to write "]],
-                      [
-                        "Link",
-                        [
-                          {
-                            "text": ["Text", ["Extism Plug-ins"]],
-                            "reference": [
-                              "Ref",
-                              "Shortcut",
-                              {
-                                "meta": {},
-                                "key": "extism plug-ins",
-                                "text": [
-                                  { "blanks": "", "node": ["Extism Plug-ins"] },
-                                ],
-                              },
-                              {
-                                "meta": {},
-                                "key": "extism plug-ins",
-                                "text": [
-                                  { "blanks": "", "node": ["Extism Plug-ins"] },
-                                ],
-                              },
-                            ],
-                          },
-                        ],
-                      ],
-                      ["Text", ["."]],
-                    ],
-                  ],
-                ],
-                "trailing_blanks": "",
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "LinkRefDefinition",
-            [
-              {
-                "layout": {
-                  "indent": 0,
-                  "angled_dest": false,
-                  "before_dest": [[" "]],
-                  "after_dest": [],
-                  "title_open_delim": "\"",
-                  "after_title": [],
-                },
-                "label": {
-                  "meta": {},
-                  "key": "extism pdk",
-                  "text": [{ "blanks": "", "node": ["Extism PDK"] }],
-                },
-                "defined_label": {
-                  "meta": {},
-                  "key": "extism pdk",
-                  "text": [{ "blanks": "", "node": ["Extism PDK"] }],
-                },
-                "dest": ["https://extism.org/docs/concepts/pdk"],
-              },
-            ],
-          ],
-          [
-            "LinkRefDefinition",
-            [
-              {
-                "layout": {
-                  "indent": 0,
-                  "angled_dest": false,
-                  "before_dest": [[" "]],
-                  "after_dest": [],
-                  "title_open_delim": "\"",
-                  "after_title": [],
-                },
-                "label": {
-                  "meta": {},
-                  "key": "extism plug-ins",
-                  "text": [{ "blanks": "", "node": ["Extism Plug-ins"] }],
-                },
-                "defined_label": {
-                  "meta": {},
-                  "key": "extism plug-ins",
-                  "text": [{ "blanks": "", "node": ["Extism Plug-ins"] }],
-                },
-                "dest": ["https://extism.org/docs/concepts/plug-in"],
-              },
-            ],
-          ],
-        ],
-      ],
-    ],
-    "defs": {
-      "extism pdk": [
-        "LinkDef",
-        [
-          {
-            "layout": {
-              "indent": 0,
-              "angled_dest": false,
-              "before_dest": [[" "]],
-              "after_dest": [],
-              "title_open_delim": "\"",
-              "after_title": [],
-            },
-            "label": {
-              "meta": {},
-              "key": "extism pdk",
-              "text": [{ "blanks": "", "node": ["Extism PDK"] }],
-            },
-            "defined_label": {
-              "meta": {},
-              "key": "extism pdk",
-              "text": [{ "blanks": "", "node": ["Extism PDK"] }],
-            },
-            "dest": ["https://extism.org/docs/concepts/pdk"],
-          },
-        ],
-      ],
-      "extism plug-ins": [
-        "LinkDef",
-        [
-          {
-            "layout": {
-              "indent": 0,
-              "angled_dest": false,
-              "before_dest": [[" "]],
-              "after_dest": [],
-              "title_open_delim": "\"",
-              "after_title": [],
-            },
-            "label": {
-              "meta": {},
-              "key": "extism plug-ins",
-              "text": [{ "blanks": "", "node": ["Extism Plug-ins"] }],
-            },
-            "defined_label": {
-              "meta": {},
-              "key": "extism plug-ins",
-              "text": [{ "blanks": "", "node": ["Extism Plug-ins"] }],
-            },
-            "dest": ["https://extism.org/docs/concepts/plug-in"],
-          },
-        ],
-      ],
-    },
-  })
+  debug_inspect(
+    Doc::from_string(doc),
+    content=(
+      #|{
+      #|  nl: "\n",
+      #|  block: Blocks(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          Paragraph(
+      #|            {
+      #|              v: {
+      #|                leading_indent: 0,
+      #|                inline: Inlines(
+      #|                  {
+      #|                    v: Seq(
+      #|                      [
+      #|                        Text(
+      #|                          {
+      #|                            v: "This is an ",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Link(
+      #|                          {
+      #|                            v: { text: Text(...), reference: Ref(Shortcut, ..., ...) },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: " that can be used to write ",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Link(
+      #|                          {
+      #|                            v: { text: Text(...), reference: Ref(Shortcut, ..., ...) },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: ".",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                      ],
+      #|                    ),
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                trailing_blanks: "",
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          LinkRefDefinition(
+      #|            {
+      #|              v: {
+      #|                layout: {
+      #|                  indent: 0,
+      #|                  angled_dest: false,
+      #|                  before_dest: Seq(
+      #|                    [
+      #|                      {
+      #|                        v: " ",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    ],
+      #|                  ),
+      #|                  after_dest: Seq([]),
+      #|                  title_open_delim: '"',
+      #|                  after_title: Seq([]),
+      #|                },
+      #|                label: Some(
+      #|                  {
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                    key: "extism pdk",
+      #|                    text: Seq(
+      #|                      [
+      #|                        {
+      #|                          blanks: "",
+      #|                          node: {
+      #|                            v: "Extism PDK",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        },
+      #|                      ],
+      #|                    ),
+      #|                  },
+      #|                ),
+      #|                defined_label: Some(
+      #|                  {
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                    key: "extism pdk",
+      #|                    text: Seq(
+      #|                      [
+      #|                        {
+      #|                          blanks: "",
+      #|                          node: {
+      #|                            v: "Extism PDK",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        },
+      #|                      ],
+      #|                    ),
+      #|                  },
+      #|                ),
+      #|                dest: Some(
+      #|                  {
+      #|                    v: "https://extism.org/docs/concepts/pdk",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                title: None,
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          LinkRefDefinition(
+      #|            {
+      #|              v: {
+      #|                layout: {
+      #|                  indent: 0,
+      #|                  angled_dest: false,
+      #|                  before_dest: Seq(
+      #|                    [
+      #|                      {
+      #|                        v: " ",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    ],
+      #|                  ),
+      #|                  after_dest: Seq([]),
+      #|                  title_open_delim: '"',
+      #|                  after_title: Seq([]),
+      #|                },
+      #|                label: Some(
+      #|                  {
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                    key: "extism plug-ins",
+      #|                    text: Seq(
+      #|                      [
+      #|                        {
+      #|                          blanks: "",
+      #|                          node: {
+      #|                            v: "Extism Plug-ins",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        },
+      #|                      ],
+      #|                    ),
+      #|                  },
+      #|                ),
+      #|                defined_label: Some(
+      #|                  {
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                    key: "extism plug-ins",
+      #|                    text: Seq(
+      #|                      [
+      #|                        {
+      #|                          blanks: "",
+      #|                          node: {
+      #|                            v: "Extism Plug-ins",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        },
+      #|                      ],
+      #|                    ),
+      #|                  },
+      #|                ),
+      #|                dest: Some(
+      #|                  {
+      #|                    v: "https://extism.org/docs/concepts/plug-in",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                title: None,
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|  defs: {
+      #|    "extism pdk": LinkDef(
+      #|      {
+      #|        v: {
+      #|          layout: {
+      #|            indent: 0,
+      #|            angled_dest: false,
+      #|            before_dest: Seq(
+      #|              [
+      #|                {
+      #|                  v: " ",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|              ],
+      #|            ),
+      #|            after_dest: Seq([]),
+      #|            title_open_delim: '"',
+      #|            after_title: Seq([]),
+      #|          },
+      #|          label: Some(
+      #|            {
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|              key: "extism pdk",
+      #|              text: Seq(
+      #|                [
+      #|                  {
+      #|                    blanks: "",
+      #|                    node: {
+      #|                      v: "Extism PDK",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                  },
+      #|                ],
+      #|              ),
+      #|            },
+      #|          ),
+      #|          defined_label: Some(
+      #|            {
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|              key: "extism pdk",
+      #|              text: Seq(
+      #|                [
+      #|                  {
+      #|                    blanks: "",
+      #|                    node: {
+      #|                      v: "Extism PDK",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                  },
+      #|                ],
+      #|              ),
+      #|            },
+      #|          ),
+      #|          dest: Some(
+      #|            {
+      #|              v: "https://extism.org/docs/concepts/pdk",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          title: None,
+      #|        },
+      #|        meta: {
+      #|          id: 0,
+      #|          loc: {
+      #|            file: "-",
+      #|            first_ccode: -1,
+      #|            last_ccode: -1,
+      #|            first_line: LinePos(-1, -1),
+      #|            last_line: LinePos(-1, -1),
+      #|          },
+      #|          extra: None,
+      #|        },
+      #|      },
+      #|    ),
+      #|    "extism plug-ins": LinkDef(
+      #|      {
+      #|        v: {
+      #|          layout: {
+      #|            indent: 0,
+      #|            angled_dest: false,
+      #|            before_dest: Seq(
+      #|              [
+      #|                {
+      #|                  v: " ",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|              ],
+      #|            ),
+      #|            after_dest: Seq([]),
+      #|            title_open_delim: '"',
+      #|            after_title: Seq([]),
+      #|          },
+      #|          label: Some(
+      #|            {
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|              key: "extism plug-ins",
+      #|              text: Seq(
+      #|                [
+      #|                  {
+      #|                    blanks: "",
+      #|                    node: {
+      #|                      v: "Extism Plug-ins",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                  },
+      #|                ],
+      #|              ),
+      #|            },
+      #|          ),
+      #|          defined_label: Some(
+      #|            {
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|              key: "extism plug-ins",
+      #|              text: Seq(
+      #|                [
+      #|                  {
+      #|                    blanks: "",
+      #|                    node: {
+      #|                      v: "Extism Plug-ins",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                  },
+      #|                ],
+      #|              ),
+      #|            },
+      #|          ),
+      #|          dest: Some(
+      #|            {
+      #|              v: "https://extism.org/docs/concepts/plug-in",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          title: None,
+      #|        },
+      #|        meta: {
+      #|          id: 0,
+      #|          loc: {
+      #|            file: "-",
+      #|            first_ccode: -1,
+      #|            last_ccode: -1,
+      #|            first_line: LinePos(-1, -1),
+      #|            last_line: LinePos(-1, -1),
+      #|          },
+      #|          extra: None,
+      #|        },
+      #|      },
+      #|    ),
+      #|  },
+      #|}
+    ),
+  )
 }
 
 ///|
@@ -587,45 +1879,206 @@ test "should parse indented code block" {
     #|
     #|    a
     #|       a b c
-  json_inspect(Doc::from_string(doc), content={
-    "nl": "\n",
-    "block": [
-      "Blocks",
-      [
-        [
-          [
-            "Paragraph",
-            [
-              {
-                "leading_indent": 0,
-                "inline": ["Text", ["The indented code block:"]],
-                "trailing_blanks": "",
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "CodeBlock",
-            [
-              {
-                "layout": "Indented",
-                "code": [
-                  ["a b c d "],
-                  [" a b c d"],
-                  [" a b c d"],
-                  ["  "],
-                  [""],
-                  ["a"],
-                  ["   a b c"],
-                ],
-              },
-            ],
-          ],
-        ],
-      ],
-    ],
-    "defs": {},
-  })
+  debug_inspect(
+    Doc::from_string(doc),
+    content=(
+      #|{
+      #|  nl: "\n",
+      #|  block: Blocks(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          Paragraph(
+      #|            {
+      #|              v: {
+      #|                leading_indent: 0,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "The indented code block:",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                trailing_blanks: "",
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          CodeBlock(
+      #|            {
+      #|              v: {
+      #|                layout: Indented,
+      #|                info_string: None,
+      #|                code: Seq(
+      #|                  [
+      #|                    {
+      #|                      v: "a b c d ",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: " a b c d",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: " a b c d",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: "  ",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: "",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: "a",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: "   a b c",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|  defs: {},
+      #|}
+    ),
+  )
 }
 
 ///|
@@ -636,119 +2089,257 @@ test "should parse quoted bullets" {
     #|* Well it's in the spec
     #|*
     #|Empty list item above
-  json_inspect(Doc::from_string(doc), content={
-    "nl": "\n",
-    "block": [
-      "Blocks",
-      [
-        [
-          [
-            "BlockQuote",
-            [
-              {
-                "indent": 0,
-                "block": [
-                  "Blocks",
-                  [
-                    [
-                      [
-                        "Paragraph",
-                        [
-                          {
-                            "leading_indent": 0,
-                            "inline": ["Text", ["Quoted bullets"]],
-                            "trailing_blanks": "",
-                          },
-                        ],
-                      ],
-                      [
-                        "List",
-                        [
-                          {
-                            "ty": ["Unordered", "*"],
-                            "tight": true,
-                            "items": [
-                              [
-                                {
-                                  "before_marker": 0,
-                                  "marker": ["*"],
-                                  "after_marker": 1,
-                                  "block": [
-                                    "Paragraph",
-                                    [
-                                      {
-                                        "leading_indent": 0,
-                                        "inline": [
-                                          "Text",
-                                          ["Is this important ?"],
-                                        ],
-                                        "trailing_blanks": "",
-                                      },
-                                    ],
-                                  ],
-                                },
-                              ],
-                            ],
-                          },
-                        ],
-                      ],
-                    ],
-                  ],
-                ],
-              },
-            ],
-          ],
-          [
-            "List",
-            [
-              {
-                "ty": ["Unordered", "*"],
-                "tight": true,
-                "items": [
-                  [
-                    {
-                      "before_marker": 0,
-                      "marker": ["*"],
-                      "after_marker": 1,
-                      "block": [
-                        "Paragraph",
-                        [
-                          {
-                            "leading_indent": 0,
-                            "inline": ["Text", ["Well it's in the spec"]],
-                            "trailing_blanks": "",
-                          },
-                        ],
-                      ],
-                    },
-                  ],
-                  [
-                    {
-                      "before_marker": 0,
-                      "marker": ["*"],
-                      "after_marker": 1,
-                      "block": ["BlankLine", [""]],
-                    },
-                  ],
-                ],
-              },
-            ],
-          ],
-          [
-            "Paragraph",
-            [
-              {
-                "leading_indent": 0,
-                "inline": ["Text", ["Empty list item above"]],
-                "trailing_blanks": "",
-              },
-            ],
-          ],
-        ],
-      ],
-    ],
-    "defs": {},
-  })
+  debug_inspect(
+    Doc::from_string(doc),
+    content=(
+      #|{
+      #|  nl: "\n",
+      #|  block: Blocks(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          BlockQuote(
+      #|            {
+      #|              v: {
+      #|                indent: 0,
+      #|                block: Blocks(
+      #|                  {
+      #|                    v: Seq(
+      #|                      [
+      #|                        Paragraph(
+      #|                          {
+      #|                            v: { leading_indent: 0, inline: Text(...), trailing_blanks: "" },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        List(
+      #|                          {
+      #|                            v: { ty: Unordered('*'), tight: true, items: Seq(...) },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                      ],
+      #|                    ),
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          List(
+      #|            {
+      #|              v: {
+      #|                ty: Unordered('*'),
+      #|                tight: true,
+      #|                items: Seq(
+      #|                  [
+      #|                    {
+      #|                      v: {
+      #|                        before_marker: 0,
+      #|                        marker: {
+      #|                          v: "*",
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                        },
+      #|                        after_marker: 1,
+      #|                        block: Paragraph(
+      #|                          {
+      #|                            v: { leading_indent: 0, inline: Text(...), trailing_blanks: "" },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        ext_task_marker: None,
+      #|                      },
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: {
+      #|                        before_marker: 0,
+      #|                        marker: {
+      #|                          v: "*",
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                        },
+      #|                        after_marker: 1,
+      #|                        block: BlankLine(
+      #|                          {
+      #|                            v: "",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        ext_task_marker: None,
+      #|                      },
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Paragraph(
+      #|            {
+      #|              v: {
+      #|                leading_indent: 0,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "Empty list item above",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                trailing_blanks: "",
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|  defs: {},
+      #|}
+    ),
+  )
 }
 
 ///|
@@ -777,212 +2368,231 @@ test "should parse list item with multiple inlines" {
     #|
     #|    (There are some relevant comments by John Gruber
     #|    [here](https://web.archive.org/web/20170611172104/http://article.gmane.org/gmane.text.markdown.general/2554).)
-  json_inspect(Doc::from_string(doc), content={
-    "nl": "\n",
-    "block": [
-      "List",
-      [
-        {
-          "ty": ["Ordered", 4, "."],
-          "tight": false,
-          "items": [
-            [
-              {
-                "before_marker": 0,
-                "marker": ["4."],
-                "after_marker": 2,
-                "block": [
-                  "Blocks",
-                  [
-                    [
-                      [
-                        "Paragraph",
-                        [
-                          {
-                            "leading_indent": 0,
-                            "inline": [
-                              "Inlines",
-                              [
-                                [
-                                  [
-                                    "Text",
-                                    [
-                                      "What is the exact rule for determining when list items get",
-                                    ],
-                                  ],
-                                  [
-                                    "Break",
-                                    [
-                                      {
-                                        "layout_before": [""],
-                                        "ty": "Soft",
-                                        "layout_after": [""],
-                                      },
-                                    ],
-                                  ],
-                                  ["Text", ["wrapped in "]],
-                                  [
-                                    "CodeSpan",
-                                    [
-                                      {
-                                        "backticks": 1,
-                                        "code_layout": [
-                                          { "blanks": "", "node": ["<p>"] },
-                                        ],
-                                      },
-                                    ],
-                                  ],
-                                  [
-                                    "Text",
-                                    [
-                                      " tags?  Can a list be partially \"loose\" and partially",
-                                    ],
-                                  ],
-                                  [
-                                    "Break",
-                                    [
-                                      {
-                                        "layout_before": [""],
-                                        "ty": "Soft",
-                                        "layout_after": [""],
-                                      },
-                                    ],
-                                  ],
-                                  [
-                                    "Text",
-                                    [
-                                      "\"tight\"?  What should we do with a list like this?",
-                                    ],
-                                  ],
-                                ],
-                              ],
-                            ],
-                            "trailing_blanks": "",
-                          },
-                        ],
-                      ],
-                      ["BlankLine", [""]],
-                      [
-                        "CodeBlock",
-                        [
-                          {
-                            "layout": [
-                              "Fenced",
-                              {
-                                "indent": 0,
-                                "opening_fence": [""],
-                                "closing_fence": [""],
-                              },
-                            ],
-                            "info_string": ["markdown"],
-                            "code": [["1. one"], [""], ["2. two"], ["3. three"]],
-                          },
-                        ],
-                      ],
-                      ["BlankLine", [""]],
-                      [
-                        "Paragraph",
-                        [
-                          {
-                            "leading_indent": 0,
-                            "inline": ["Text", ["Or this?"]],
-                            "trailing_blanks": "",
-                          },
-                        ],
-                      ],
-                      ["BlankLine", [""]],
-                      [
-                        "CodeBlock",
-                        [
-                          {
-                            "layout": [
-                              "Fenced",
-                              {
-                                "indent": 0,
-                                "opening_fence": [""],
-                                "closing_fence": [""],
-                              },
-                            ],
-                            "info_string": ["markdown"],
-                            "code": [
-                              ["1.  one"],
-                              ["    - a"],
-                              [""],
-                              ["    - b"],
-                              ["2.  two"],
-                            ],
-                          },
-                        ],
-                      ],
-                      ["BlankLine", [""]],
-                      [
-                        "Paragraph",
-                        [
-                          {
-                            "leading_indent": 0,
-                            "inline": [
-                              "Inlines",
-                              [
-                                [
-                                  [
-                                    "Text",
-                                    [
-                                      "(There are some relevant comments by John Gruber",
-                                    ],
-                                  ],
-                                  [
-                                    "Break",
-                                    [
-                                      {
-                                        "layout_before": [""],
-                                        "ty": "Soft",
-                                        "layout_after": [""],
-                                      },
-                                    ],
-                                  ],
-                                  [
-                                    "Link",
-                                    [
-                                      {
-                                        "text": ["Text", ["here"]],
-                                        "reference": [
-                                          "Inline",
-                                          [
-                                            {
-                                              "layout": {
-                                                "indent": 0,
-                                                "angled_dest": false,
-                                                "before_dest": [],
-                                                "after_dest": [],
-                                                "title_open_delim": "\"",
-                                                "after_title": [],
-                                              },
-                                              "dest": [
-                                                "https://web.archive.org/web/20170611172104/http://article.gmane.org/gmane.text.markdown.general/2554",
-                                              ],
-                                            },
-                                          ],
-                                        ],
-                                      },
-                                    ],
-                                  ],
-                                  ["Text", [".)"]],
-                                ],
-                              ],
-                            ],
-                            "trailing_blanks": "",
-                          },
-                        ],
-                      ],
-                    ],
-                  ],
-                ],
-              },
-            ],
-          ],
-        },
-      ],
-    ],
-    "defs": {},
-  })
+  debug_inspect(
+    Doc::from_string(doc),
+    content=(
+      #|{
+      #|  nl: "\n",
+      #|  block: List(
+      #|    {
+      #|      v: {
+      #|        ty: Ordered(4, '.'),
+      #|        tight: false,
+      #|        items: Seq(
+      #|          [
+      #|            {
+      #|              v: {
+      #|                before_marker: 0,
+      #|                marker: {
+      #|                  v: "4.",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|                after_marker: 2,
+      #|                block: Blocks(
+      #|                  {
+      #|                    v: Seq(
+      #|                      [
+      #|                        Paragraph(
+      #|                          {
+      #|                            v: { leading_indent: 0, inline: Inlines(...), trailing_blanks: "" },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        BlankLine(
+      #|                          {
+      #|                            v: "",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        CodeBlock(
+      #|                          {
+      #|                            v: { layout: Fenced(...), info_string: Some(...), code: Seq(...) },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        BlankLine(
+      #|                          {
+      #|                            v: "",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Paragraph(
+      #|                          {
+      #|                            v: { leading_indent: 0, inline: Text(...), trailing_blanks: "" },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        BlankLine(
+      #|                          {
+      #|                            v: "",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        CodeBlock(
+      #|                          {
+      #|                            v: { layout: Fenced(...), info_string: Some(...), code: Seq(...) },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        BlankLine(
+      #|                          {
+      #|                            v: "",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Paragraph(
+      #|                          {
+      #|                            v: { leading_indent: 0, inline: Inlines(...), trailing_blanks: "" },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                      ],
+      #|                    ),
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                ext_task_marker: None,
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ],
+      #|        ),
+      #|      },
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|  defs: {},
+      #|}
+    ),
+  )
 }

--- a/src/cmark/block_test.mbt
+++ b/src/cmark/block_test.mbt
@@ -1,26 +1,84 @@
 ///|
 test "normalize other block types" {
   let block = @cmark.Block::BlankLine(@cmark.Node::empty())
-  inspect(block.normalize(), content="BlankLine(Node::new(\"\"))")
+  debug_inspect(
+    block.normalize(),
+    content=(
+      #|BlankLine(
+      #|  {
+      #|    v: "",
+      #|    meta: {
+      #|      id: 0,
+      #|      loc: {
+      #|        file: "-",
+      #|        first_ccode: -1,
+      #|        last_ccode: -1,
+      #|        first_line: LinePos(-1, -1),
+      #|        last_line: LinePos(-1, -1),
+      #|      },
+      #|      extra: None,
+      #|    },
+      #|  },
+      #|)
+    ),
+  )
 
   // Test BlockQuote normalization
   let quote_block = @cmark.Block::BlockQuote(
     @cmark.Node::new(@cmark.BlockQuote::new(@cmark.Block::empty())),
   )
-  inspect(
+  debug_inspect(
     quote_block.normalize(),
-    content="BlockQuote(Node::new({indent: 0, block: Blocks(Node::new(Seq([])))}))",
+    content=(
+      #|BlockQuote(
+      #|  {
+      #|    v: {
+      #|      indent: 0,
+      #|      block: Blocks(
+      #|        {
+      #|          v: Seq([]),
+      #|          meta: {
+      #|            id: 0,
+      #|            loc: {
+      #|              file: "-",
+      #|              first_ccode: -1,
+      #|              last_ccode: -1,
+      #|              first_line: LinePos(-1, -1),
+      #|              last_line: LinePos(-1, -1),
+      #|            },
+      #|            extra: None,
+      #|          },
+      #|        },
+      #|      ),
+      #|    },
+      #|    meta: {
+      #|      id: 0,
+      #|      loc: {
+      #|        file: "-",
+      #|        first_ccode: -1,
+      #|        last_ccode: -1,
+      #|        first_line: LinePos(-1, -1),
+      #|        last_line: LinePos(-1, -1),
+      #|      },
+      #|      extra: None,
+      #|    },
+      #|  },
+      #|)
+    ),
   )
 }
 
 ///|
 test "language_of_info_string with empty string" {
-  inspect(@cmark.CodeBlock::language_of_info_string(""), content="None")
+  debug_inspect(@cmark.CodeBlock::language_of_info_string(""), content="None")
 }
 
 ///|
 test "language_of_info_string with only whitespace in language" {
-  inspect(@cmark.CodeBlock::language_of_info_string("   "), content="None")
+  debug_inspect(
+    @cmark.CodeBlock::language_of_info_string("   "),
+    content="None",
+  )
 }
 
 ///|
@@ -30,8 +88,14 @@ test "code block new with info string" {
   let info = @cmark.Node::new("info")
   let codeBlock = @cmark.CodeBlock::new(info_string=Some(info), code)
   match codeBlock.info_string {
-    Some(info_node) => inspect(info_node.v, content="info")
-    None => inspect(false, content="true")
+    Some(info_node) =>
+      debug_inspect(
+        info_node.v,
+        content=(
+          #|"info"
+        ),
+      )
+    None => debug_inspect(false, content="true")
   }
 }
 
@@ -48,10 +112,10 @@ test "code block with indented layout and info string" {
   )
   match codeBlock.layout {
     @cmark.CodeBlockLayout::Fenced(layout) => {
-      inspect(layout.indent, content="0")
-      inspect(true, content="true")
+      debug_inspect(layout.indent, content="0")
+      debug_inspect(true, content="true")
     }
-    @cmark.CodeBlockLayout::Indented => inspect(false, content="true")
+    @cmark.CodeBlockLayout::Indented => debug_inspect(false, content="true")
   }
 }
 
@@ -63,16 +127,26 @@ test "code block make fence" {
   let code = @cmark.Seq::from_array([node])
   let codeBlock = @cmark.CodeBlock::new(code)
   let (char, count) = codeBlock.make_fence()
-  inspect(char, content="`")
-  inspect(count, content="3")
+  debug_inspect(
+    char,
+    content=(
+      #|'`'
+    ),
+  )
+  debug_inspect(count, content="3")
 
   // Test with backticks in code
   let node_with_backticks = @cmark.Node::new("```Example with backticks```")
   let code_with_backticks = @cmark.Seq::from_array([node_with_backticks])
   let codeBlock_with_backticks = @cmark.CodeBlock::new(code_with_backticks)
   let (char2, count2) = codeBlock_with_backticks.make_fence()
-  inspect(char2, content="`")
-  inspect(count2, content="4")
+  debug_inspect(
+    char2,
+    content=(
+      #|'`'
+    ),
+  )
+  debug_inspect(count2, content="4")
 }
 
 ///|
@@ -80,9 +154,44 @@ test "code block make fence" {
 test "block normalize with block quote" {
   let blockQuote = @cmark.BlockQuote::new(@cmark.Block::empty())
   let normalized = @cmark.Block::BlockQuote(@cmark.Node::new(blockQuote)).normalize()
-  inspect(
+  debug_inspect(
     normalized,
-    content="BlockQuote(Node::new({indent: 0, block: Blocks(Node::new(Seq([])))}))",
+    content=(
+      #|BlockQuote(
+      #|  {
+      #|    v: {
+      #|      indent: 0,
+      #|      block: Blocks(
+      #|        {
+      #|          v: Seq([]),
+      #|          meta: {
+      #|            id: 0,
+      #|            loc: {
+      #|              file: "-",
+      #|              first_ccode: -1,
+      #|              last_ccode: -1,
+      #|              first_line: LinePos(-1, -1),
+      #|              last_line: LinePos(-1, -1),
+      #|            },
+      #|            extra: None,
+      #|          },
+      #|        },
+      #|      ),
+      #|    },
+      #|    meta: {
+      #|      id: 0,
+      #|      loc: {
+      #|        file: "-",
+      #|        first_ccode: -1,
+      #|        last_ccode: -1,
+      #|        first_line: LinePos(-1, -1),
+      #|        last_line: LinePos(-1, -1),
+      #|      },
+      #|      extra: None,
+      #|    },
+      #|  },
+      #|)
+    ),
   )
 }
 
@@ -96,9 +205,26 @@ test "block normalize with list using Seq.empty" {
     items,
   }
   let normalized = @cmark.Block::List(@cmark.Node::new(list)).normalize()
-  inspect(
+  debug_inspect(
     normalized,
-    content="List(Node::new({ty: Unordered('*'), tight: true, items: Seq([])}))",
+    content=(
+      #|List(
+      #|  {
+      #|    v: { ty: Unordered('*'), tight: true, items: Seq([]) },
+      #|    meta: {
+      #|      id: 0,
+      #|      loc: {
+      #|        file: "-",
+      #|        first_ccode: -1,
+      #|        last_ccode: -1,
+      #|        first_line: LinePos(-1, -1),
+      #|        last_line: LinePos(-1, -1),
+      #|      },
+      #|      extra: None,
+      #|    },
+      #|  },
+      #|)
+    ),
   )
 }
 
@@ -106,14 +232,19 @@ test "block normalize with list using Seq.empty" {
 /// Tests to improve coverage for the block.mbt file
 test "code block fenced layout default" {
   let layout = @cmark.CodeBlockFencedLayout::default()
-  inspect(layout.indent, content="0")
+  debug_inspect(layout.indent, content="0")
 }
 
 ///|
 test "thematic break new" {
   let tb = @cmark.BlockThematicBreak::new(indent=2, layout="***")
-  inspect(tb.indent, content="2")
-  inspect(tb.layout, content="***")
+  debug_inspect(tb.indent, content="2")
+  debug_inspect(
+    tb.layout,
+    content=(
+      #|"***"
+    ),
+  )
 }
 
 ///|
@@ -126,22 +257,42 @@ test "create new list item" {
     ext_task_marker=None,
     block,
   )
-  inspect(item.before_marker, content="2")
-  inspect(item.after_marker, content="1")
+  debug_inspect(item.before_marker, content="2")
+  debug_inspect(item.after_marker, content="1")
 
   // Test ListItem::map_block and ListItem::normalize_block
   let new_block = @cmark.Block::BlankLine(@cmark.Node::new(""))
   let mapped_item = item.map_block(fn(_) { new_block })
-  inspect(mapped_item.block, content="BlankLine(Node::new(\"\"))")
+  debug_inspect(
+    mapped_item.block,
+    content=(
+      #|BlankLine(
+      #|  {
+      #|    v: "",
+      #|    meta: {
+      #|      id: 0,
+      #|      loc: {
+      #|        file: "-",
+      #|        first_ccode: -1,
+      #|        last_ccode: -1,
+      #|        first_line: LinePos(-1, -1),
+      #|        last_line: LinePos(-1, -1),
+      #|      },
+      #|      extra: None,
+      #|    },
+      #|  },
+      #|)
+    ),
+  )
   let normalized_item = item.normalize_block()
-  inspect(normalized_item.before_marker, content="2")
+  debug_inspect(normalized_item.before_marker, content="2")
 }
 
 ///|
 test "block quote normalize_block" {
   let quote = @cmark.BlockQuote::new(@cmark.Block::empty())
   let normalized_quote = quote.normalize_block()
-  inspect(normalized_quote.indent, content="0")
+  debug_inspect(normalized_quote.indent, content="0")
 }
 
 ///|
@@ -149,8 +300,14 @@ test "block quote normalize_block" {
 test "list task status from marker with custom marker" {
   let status = @cmark.ListTaskStatus::from_marker('?')
   match status {
-    Other(c) => inspect(c, content="?")
-    _ => inspect(false, content="true")
+    Other(c) =>
+      debug_inspect(
+        c,
+        content=(
+          #|'?'
+        ),
+      )
+    _ => debug_inspect(false, content="true")
   }
 }
 
@@ -162,20 +319,45 @@ test "paragraph new" {
     trailing_blanks="  ",
     inline,
   )
-  inspect(para.leading_indent, content="2")
-  inspect(para.trailing_blanks, content="  ")
+  debug_inspect(para.leading_indent, content="2")
+  debug_inspect(
+    para.trailing_blanks,
+    content=(
+      #|"  "
+    ),
+  )
 }
 
 ///|
 test "heading new" {
   let inline = @cmark.Inline::Text(@cmark.Node::new("heading"))
   let heading = @cmark.BlockHeading::new(level=2, inline)
-  inspect(heading.level, content="2")
+  debug_inspect(heading.level, content="2")
 }
 
 ///|
 test "block normalize" {
   let block = @cmark.Block::BlankLine(@cmark.Node::new(""))
   let normalized = block.normalize()
-  inspect(normalized, content="BlankLine(Node::new(\"\"))")
+  debug_inspect(
+    normalized,
+    content=(
+      #|BlankLine(
+      #|  {
+      #|    v: "",
+      #|    meta: {
+      #|      id: 0,
+      #|      loc: {
+      #|        file: "-",
+      #|        first_ccode: -1,
+      #|        last_ccode: -1,
+      #|        first_line: LinePos(-1, -1),
+      #|        last_line: LinePos(-1, -1),
+      #|      },
+      #|      extra: None,
+      #|    },
+      #|  },
+      #|)
+    ),
+  )
 }

--- a/src/cmark/closer.mbt
+++ b/src/cmark/closer.mbt
@@ -12,26 +12,18 @@ priv enum Closer {
   EmphasisMarks(Char)
   StrikethroughMarks
   MathSpanMarks(Int)
-} derive(Eq, Hash, Show, ToJson)
-
-///|
-test {
-  // Prevent warning about unused Show and ToJson
-  (fn(c : Closer) { c.to_string() }) |> ignore()
-  (fn(c : Closer) { c.to_json() }) |> ignore()
-}
+} derive(Eq, Hash, Debug)
 
 ///|
 type PosSet = Set[Int]
 
 ///|
-priv struct CloserIndex(Map[Closer, PosSet]) derive(Show, ToJson)
+priv struct CloserIndex(Map[Closer, PosSet]) derive(Debug)
 
 ///|
 test {
-  // Prevent warning about unused Show and ToJson
-  (fn(c : CloserIndex) { c.to_string() }) |> ignore()
-  (fn(c : CloserIndex) { c.to_json() }) |> ignore()
+  // Prevent warning about unused Debug.
+  (fn(c : CloserIndex) { @debug.to_string(c) }) |> ignore()
 }
 
 ///|

--- a/src/cmark/doc.mbt
+++ b/src/cmark/doc.mbt
@@ -4,7 +4,7 @@ pub(all) struct Doc {
   nl : String
   block : Block
   defs : LabelDefs
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 pub fn Doc::new(

--- a/src/cmark/doc_test.mbt
+++ b/src/cmark/doc_test.mbt
@@ -1,1941 +1,6036 @@
 ///|
 test "basic" {
   let rendered = @cmark.Doc::from_string(test_base_md_str)
-  json_inspect(rendered, content={
-    "nl": "\n",
-    "block": [
-      "Blocks",
-      [
-        [
-          [
-            "Heading",
-            [
-              {
-                "layout": [
-                  "Setext",
-                  {
-                    "leading_indent": 0,
-                    "trailing_blanks": "",
-                    "underline_indent": 0,
-                    "underline_count": [11],
-                    "underline_blanks": "",
-                  },
-                ],
-                "level": 1,
-                "inline": ["Text", ["Basic tests"]],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "Paragraph",
-            [
-              {
-                "leading_indent": 0,
-                "inline": [
-                  "Text",
-                  ["Basic tests for all CommonMark constructs."],
-                ],
-                "trailing_blanks": "",
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "Heading",
-            [
-              {
-                "layout": [
-                  "Atx",
-                  { "indent": 0, "after_opening": "", "closing": "" },
-                ],
-                "level": 2,
-                "inline": ["Text", ["Testing autolinks"]],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "Paragraph",
-            [
-              {
-                "leading_indent": 0,
-                "inline": [
-                  "Inlines",
-                  [
-                    [
-                      ["Text", ["This is an "]],
-                      [
-                        "Autolink",
-                        [{ "is_email": false, "link": ["http://example.org"] }],
-                      ],
-                      ["Text", [" and another one "]],
-                      [
-                        "Autolink",
-                        [{ "is_email": true, "link": ["you@example.org"] }],
-                      ],
-                      ["Text", ["."]],
-                    ],
-                  ],
-                ],
-                "trailing_blanks": "",
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          ["BlankLine", [""]],
-          [
-            "Heading",
-            [
-              {
-                "layout": [
-                  "Atx",
-                  { "indent": 0, "after_opening": "", "closing": "" },
-                ],
-                "level": 2,
-                "inline": ["Text", ["Testing breaks"]],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "Paragraph",
-            [
-              {
-                "leading_indent": 0,
-                "inline": [
-                  "Inlines",
-                  [
-                    [
-                      [
-                        "Text",
-                        [
-                          "A line ending (not in a code span or HTML tag) that is preceded by two",
-                        ],
-                      ],
-                      [
-                        "Break",
-                        [
-                          {
-                            "layout_before": [""],
-                            "ty": "Soft",
-                            "layout_after": [""],
-                          },
-                        ],
-                      ],
-                      [
-                        "Text",
-                        [
-                          "or more spaces and does not occur at the end of a block is parsed as a",
-                        ],
-                      ],
-                      [
-                        "Break",
-                        [
-                          {
-                            "layout_before": [""],
-                            "ty": "Soft",
-                            "layout_after": [""],
-                          },
-                        ],
-                      ],
-                      ["Text", ["hard line break."]],
-                    ],
-                  ],
-                ],
-                "trailing_blanks": "",
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "Paragraph",
-            [
-              {
-                "leading_indent": 0,
-                "inline": [
-                  "Inlines",
-                  [
-                    [
-                      [
-                        "Text",
-                        [
-                          "So this means we had softbreaks so far and now we get  ",
-                        ],
-                      ],
-                      [
-                        "Break",
-                        [
-                          {
-                            "layout_before": [""],
-                            "ty": "Hard",
-                            "layout_after": [""],
-                          },
-                        ],
-                      ],
-                      ["Text", ["a hard break"]],
-                      [
-                        "Break",
-                        [
-                          {
-                            "layout_before": [""],
-                            "ty": "Hard",
-                            "layout_after": [""],
-                          },
-                        ],
-                      ],
-                      ["Text", ["and another one."]],
-                    ],
-                  ],
-                ],
-                "trailing_blanks": "",
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "BlockQuote",
-            [
-              {
-                "indent": 0,
-                "block": [
-                  "Paragraph",
-                  [
-                    {
-                      "leading_indent": 0,
-                      "inline": [
-                        "Inlines",
-                        [
-                          [
-                            [
-                              "Text",
-                              [
-                                "So this means we had softbreaks so far and now we get  ",
-                              ],
-                            ],
-                            [
-                              "Break",
-                              [
-                                {
-                                  "layout_before": [""],
-                                  "ty": "Hard",
-                                  "layout_after": [""],
-                                },
-                              ],
-                            ],
-                            ["Text", ["a hard break"]],
-                            [
-                              "Break",
-                              [
-                                {
-                                  "layout_before": [""],
-                                  "ty": "Hard",
-                                  "layout_after": [""],
-                                },
-                              ],
-                            ],
-                            ["Text", ["and another one."]],
-                            [
-                              "Break",
-                              [
-                                {
-                                  "layout_before": [""],
-                                  "ty": "Soft",
-                                  "layout_after": [""],
-                                },
-                              ],
-                            ],
-                            ["Text", ["This is very soooft."]],
-                          ],
-                        ],
-                      ],
-                      "trailing_blanks": "",
-                    },
-                  ],
-                ],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "Heading",
-            [
-              {
-                "layout": [
-                  "Atx",
-                  { "indent": 0, "after_opening": "", "closing": "" },
-                ],
-                "level": 2,
-                "inline": ["Text", ["Testing code spans"]],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "Paragraph",
-            [
-              {
-                "leading_indent": 0,
-                "inline": [
-                  "Inlines",
-                  [
-                    [
-                      ["Text", ["This is a multi-line code"]],
-                      [
-                        "CodeSpan",
-                        [
-                          {
-                            "backticks": 1,
-                            "code_layout": [
-                              { "blanks": "", "node": [""] },
-                              {
-                                "blanks": "",
-                                "node": ["code span `` it has backticks"],
-                              },
-                              { "blanks": "", "node": ["in there"] },
-                            ],
-                          },
-                        ],
-                      ],
-                    ],
-                  ],
-                ],
-                "trailing_blanks": "",
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "Paragraph",
-            [
-              {
-                "leading_indent": 0,
-                "inline": [
-                  "Inlines",
-                  [
-                    [
-                      ["Text", ["Sometimes code spans "]],
-                      [
-                        "CodeSpan",
-                        [
-                          {
-                            "backticks": 2,
-                            "code_layout": [
-                              { "blanks": "", "node": [" `can have"] },
-                              { "blanks": "", "node": ["really ```"] },
-                              { "blanks": "", "node": ["strange"] },
-                              { "blanks": "", "node": ["layout "] },
-                            ],
-                          },
-                        ],
-                      ],
-                      ["Text", [". Do you fancy "]],
-                      [
-                        "CodeSpan",
-                        [
-                          {
-                            "backticks": 2,
-                            "code_layout": [
-                              {
-                                "blanks": "",
-                                "node": [" `A_polymorphic_variant "],
-                              },
-                            ],
-                          },
-                        ],
-                      ],
-                      ["Text", [" ?"]],
-                    ],
-                  ],
-                ],
-                "trailing_blanks": "",
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          ["BlankLine", [""]],
-          [
-            "Heading",
-            [
-              {
-                "layout": [
-                  "Atx",
-                  { "indent": 0, "after_opening": "", "closing": "" },
-                ],
-                "level": 2,
-                "inline": ["Text", ["Testing emphasis"]],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "Paragraph",
-            [
-              {
-                "leading_indent": 0,
-                "inline": [
-                  "Inlines",
-                  [
-                    [
-                      ["Text", ["There is "]],
-                      [
-                        "Emphasis",
-                        [{ "delim": "_", "inline": ["Text", ["more"]] }],
-                      ],
-                      ["Text", [" than "]],
-                      [
-                        "Emphasis",
-                        [{ "delim": "*", "inline": ["Text", ["one syntax"]] }],
-                      ],
-                      ["Text", [" for "]],
-                      [
-                        "StrongEmphasis",
-                        [{ "delim": "_", "inline": ["Text", ["emphasis"]] }],
-                      ],
-                      ["Text", [" and "]],
-                      [
-                        "StrongEmphasis",
-                        [
-                          {
-                            "delim": "*",
-                            "inline": [
-                              "Inlines",
-                              [
-                                [
-                                  ["Text", ["strong"]],
-                                  [
-                                    "Break",
-                                    [
-                                      {
-                                        "layout_before": [""],
-                                        "ty": "Soft",
-                                        "layout_after": [""],
-                                      },
-                                    ],
-                                  ],
-                                  ["Text", ["emphasis"]],
-                                ],
-                              ],
-                            ],
-                          },
-                        ],
-                      ],
-                      ["Text", [".  We should be careful about "]],
-                      [
-                        "StrongEmphasis",
-                        [
-                          {
-                            "delim": "*",
-                            "inline": ["Text", ["embedded * marker"]],
-                          },
-                        ],
-                      ],
-                      ["Text", [". This"]],
-                      [
-                        "Break",
-                        [
-                          {
-                            "layout_before": [""],
-                            "ty": "Soft",
-                            "layout_after": [""],
-                          },
-                        ],
-                      ],
-                      ["Text", ["will be "]],
-                      [
-                        "StrongEmphasis",
-                        [
-                          {
-                            "delim": "*",
-                            "inline": ["Text", ["tricky * to handle"]],
-                          },
-                        ],
-                      ],
-                      ["Text", [". This "]],
-                      [
-                        "Emphasis",
-                        [
-                          {
-                            "delim": "*",
-                            "inline": ["Text", ["is not ** what"]],
-                          },
-                        ],
-                      ],
-                      ["Text", [" you want ?"]],
-                    ],
-                  ],
-                ],
-                "trailing_blanks": "",
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          ["BlankLine", [""]],
-          [
-            "Heading",
-            [
-              {
-                "layout": [
-                  "Atx",
-                  { "indent": 0, "after_opening": "", "closing": "" },
-                ],
-                "level": 2,
-                "inline": [
-                  "Text",
-                  ["Testing links, images and link reference definitions"],
-                ],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "Paragraph",
-            [
-              {
-                "leading_indent": 0,
-                "inline": [
-                  "Inlines",
-                  [
-                    [
-                      ["Text", ["This is an "]],
-                      [
-                        "Image",
-                        [
-                          {
-                            "text": ["Text", ["inline image"]],
-                            "reference": [
-                              "Inline",
-                              [
-                                {
-                                  "layout": {
-                                    "indent": 0,
-                                    "angled_dest": false,
-                                    "before_dest": [[""], ["  "]],
-                                    "after_dest": [["    "]],
-                                    "title_open_delim": "(",
-                                    "after_title": [],
-                                  },
-                                  "dest": ["/heyho"],
-                                  "title": [
-                                    { "blanks": "", "node": ["The"] },
-                                    {
-                                      "blanks": "",
-                                      "node": ["multiline title"],
-                                    },
-                                  ],
-                                },
-                              ],
-                            ],
-                          },
-                        ],
-                      ],
-                    ],
-                  ],
-                ],
-                "trailing_blanks": "",
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "Paragraph",
-            [
-              {
-                "leading_indent": 2,
-                "inline": [
-                  "Inlines",
-                  [
-                    [
-                      ["Text", ["That is totally "]],
-                      [
-                        "Link",
-                        [
-                          {
-                            "text": ["Text", ["colla    psed"]],
-                            "reference": [
-                              "Ref",
-                              "Collapsed",
-                              {
-                                "meta": {},
-                                "key": "colla psed",
-                                "text": [
-                                  { "blanks": "", "node": ["colla    psed"] },
-                                ],
-                              },
-                              {
-                                "meta": {},
-                                "key": "colla psed",
-                                "text": [
-                                  { "blanks": "", "node": ["colla psed"] },
-                                ],
-                              },
-                            ],
-                          },
-                        ],
-                      ],
-                      ["Text", [" and"]],
-                      [
-                        "Break",
-                        [
-                          {
-                            "layout_before": [""],
-                            "ty": "Soft",
-                            "layout_after": [""],
-                          },
-                        ],
-                      ],
-                      ["Text", ["that is "]],
-                      [
-                        "Link",
-                        [
-                          {
-                            "text": [
-                              "CodeSpan",
-                              [
-                                {
-                                  "backticks": 1,
-                                  "code_layout": [
-                                    { "blanks": "", "node": ["short cuted"] },
-                                  ],
-                                },
-                              ],
-                            ],
-                            "reference": [
-                              "Ref",
-                              "Shortcut",
-                              {
-                                "meta": {},
-                                "key": "`short cuted`",
-                                "text": [
-                                  { "blanks": "", "node": ["`short cuted`"] },
-                                ],
-                              },
-                              {
-                                "meta": {},
-                                "key": "`short cuted`",
-                                "text": [
-                                  { "blanks": "", "node": ["`short cuted`"] },
-                                ],
-                              },
-                            ],
-                          },
-                        ],
-                      ],
-                    ],
-                  ],
-                ],
-                "trailing_blanks": "",
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "Paragraph",
-            [
-              {
-                "leading_indent": 0,
-                "inline": [
-                  "Inlines",
-                  [
-                    [
-                      ["Text", ["Shortcuts can be better than "]],
-                      [
-                        "Link",
-                        [
-                          {
-                            "text": ["Text", ["full references"]],
-                            "reference": [
-                              "Ref",
-                              "Full",
-                              {
-                                "meta": {},
-                                "key": "`short cuted`",
-                                "text": [
-                                  { "blanks": "", "node": ["`short "] },
-                                  { "blanks": "", "node": ["cuted`"] },
-                                ],
-                              },
-                              {
-                                "meta": {},
-                                "key": "`short cuted`",
-                                "text": [
-                                  { "blanks": "", "node": ["`short cuted`"] },
-                                ],
-                              },
-                            ],
-                          },
-                        ],
-                      ],
-                      ["Text", [" but not"]],
-                      [
-                        "Break",
-                        [
-                          {
-                            "layout_before": [""],
-                            "ty": "Soft",
-                            "layout_after": [""],
-                          },
-                        ],
-                      ],
-                      ["Text", ["always and we'd like to trip their "]],
-                      [
-                        "Link",
-                        [
-                          {
-                            "text": ["Text", ["label"]],
-                            "reference": [
-                              "Ref",
-                              "Full",
-                              {
-                                "meta": {},
-                                "key": "`short cuted`",
-                                "text": [
-                                  { "blanks": "", "node": ["`short    cuted`"] },
-                                ],
-                              },
-                              {
-                                "meta": {},
-                                "key": "`short cuted`",
-                                "text": [
-                                  { "blanks": "", "node": ["`short cuted`"] },
-                                ],
-                              },
-                            ],
-                          },
-                        ],
-                      ],
-                      ["Text", ["."]],
-                    ],
-                  ],
-                ],
-                "trailing_blanks": "",
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "BlockQuote",
-            [
-              {
-                "indent": 0,
-                "block": [
-                  "LinkRefDefinition",
-                  [
-                    {
-                      "layout": {
-                        "indent": 0,
-                        "angled_dest": false,
-                        "before_dest": [[" "]],
-                        "after_dest": [[" "]],
-                        "title_open_delim": "\"",
-                        "after_title": [[""]],
-                      },
-                      "label": {
-                        "meta": {},
-                        "key": "colla psed",
-                        "text": [{ "blanks": "", "node": ["colla psed"] }],
-                      },
-                      "defined_label": {
-                        "meta": {},
-                        "key": "colla psed",
-                        "text": [{ "blanks": "", "node": ["colla psed"] }],
-                      },
-                      "dest": ["/hohoho"],
-                      "title": [
-                        { "blanks": "", "node": ["And again these "] },
-                        { "blanks": "", "node": ["multi"] },
-                        { "blanks": "", "node": ["line titles"] },
-                      ],
-                    },
-                  ],
-                ],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "LinkRefDefinition",
-            [
-              {
-                "layout": {
-                  "indent": 1,
-                  "angled_dest": false,
-                  "before_dest": [["    "]],
-                  "after_dest": [["   "]],
-                  "title_open_delim": "\"",
-                  "after_title": [[""]],
-                },
-                "label": {
-                  "meta": {},
-                  "key": "`short cuted`",
-                  "text": [{ "blanks": "", "node": ["`short cuted`"] }],
-                },
-                "defined_label": {
-                  "meta": {},
-                  "key": "`short cuted`",
-                  "text": [{ "blanks": "", "node": ["`short cuted`"] }],
-                },
-                "dest": ["/veryshort"],
-                "title": [
-                  { "blanks": "", "node": ["But very"] },
-                  { "blanks": "", "node": ["important"] },
-                ],
-              },
-            ],
-          ],
-          ["BlankLine", ["  "]],
-          ["BlankLine", [""]],
-          [
-            "Heading",
-            [
-              {
-                "layout": [
-                  "Atx",
-                  { "indent": 0, "after_opening": "", "closing": "" },
-                ],
-                "level": 2,
-                "inline": ["Text", ["Testing raw HTML"]],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "Paragraph",
-            [
-              {
-                "leading_indent": 0,
-                "inline": [
-                  "Inlines",
-                  [
-                    [
-                      ["Text", ["Haha "]],
-                      [
-                        "RawHtml",
-                        [["InlineRawHtml", [{ "blanks": "", "node": ["<a>"] }]]],
-                      ],
-                      ["Text", ["a"]],
-                      [
-                        "RawHtml",
-                        [
-                          [
-                            "InlineRawHtml",
-                            [{ "blanks": "", "node": ["</a>"] }],
-                          ],
-                        ],
-                      ],
-                      [
-                        "RawHtml",
-                        [
-                          [
-                            "InlineRawHtml",
-                            [
-                              { "blanks": "", "node": ["<b2"] },
-                              { "blanks": "", "node": ["data=\"foo\" >"] },
-                            ],
-                          ],
-                        ],
-                      ],
-                      ["Text", [" hihi this is not the end yet."]],
-                    ],
-                  ],
-                ],
-                "trailing_blanks": "",
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "Paragraph",
-            [
-              {
-                "leading_indent": 0,
-                "inline": [
-                  "Inlines",
-                  [
-                    [
-                      ["Text", ["foo "]],
-                      [
-                        "RawHtml",
-                        [
-                          [
-                            "InlineRawHtml",
-                            [{ "blanks": "", "node": ["<a href=\"\\*\" />"] }],
-                          ],
-                        ],
-                      ],
-                      ["Text", ["u"]],
-                      [
-                        "RawHtml",
-                        [
-                          [
-                            "InlineRawHtml",
-                            [{ "blanks": "", "node": ["</a>"] }],
-                          ],
-                        ],
-                      ],
-                    ],
-                  ],
-                ],
-                "trailing_blanks": "",
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "BlockQuote",
-            [
-              {
-                "indent": 0,
-                "block": [
-                  "Paragraph",
-                  [
-                    {
-                      "leading_indent": 1,
-                      "inline": [
-                        "Inlines",
-                        [
-                          [
-                            ["Text", ["Haha "]],
-                            [
-                              "RawHtml",
-                              [
-                                [
-                                  "InlineRawHtml",
-                                  [{ "blanks": "", "node": ["<a>"] }],
-                                ],
-                              ],
-                            ],
-                            ["Text", ["a"]],
-                            [
-                              "RawHtml",
-                              [
-                                [
-                                  "InlineRawHtml",
-                                  [{ "blanks": "", "node": ["</a>"] }],
-                                ],
-                              ],
-                            ],
-                            [
-                              "RawHtml",
-                              [
-                                [
-                                  "InlineRawHtml",
-                                  [
-                                    { "blanks": "", "node": ["<b2"] },
-                                    { "blanks": "", "node": ["data=\"foo\" >"] },
-                                  ],
-                                ],
-                              ],
-                            ],
-                            ["Text", [" hihi this is not the end yet."]],
-                          ],
-                        ],
-                      ],
-                      "trailing_blanks": "",
-                    },
-                  ],
-                ],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "Heading",
-            [
-              {
-                "layout": [
-                  "Atx",
-                  { "indent": 0, "after_opening": "", "closing": "" },
-                ],
-                "level": 2,
-                "inline": ["Text", ["Testing blank lines"]],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          ["BlankLine", ["    "]],
-          ["BlankLine", ["     "]],
-          [
-            "Paragraph",
-            [
-              {
-                "leading_indent": 0,
-                "inline": ["Text", ["Impressive isn't it ?"]],
-                "trailing_blanks": "",
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "Heading",
-            [
-              {
-                "layout": [
-                  "Atx",
-                  { "indent": 0, "after_opening": "", "closing": "" },
-                ],
-                "level": 2,
-                "inline": ["Text", ["Testing block quotes"]],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          ["BlankLine", [""]],
-          [
-            "BlockQuote",
-            [
-              {
-                "indent": 2,
-                "block": [
-                  "BlockQuote",
-                  [
-                    {
-                      "indent": 2,
-                      "block": [
-                        "Paragraph",
-                        [
-                          {
-                            "leading_indent": 0,
-                            "inline": [
-                              "Inlines",
-                              [
-                                [
-                                  ["Text", ["How is"]],
-                                  [
-                                    "Break",
-                                    [
-                                      {
-                                        "layout_before": [""],
-                                        "ty": "Soft",
-                                        "layout_after": [""],
-                                      },
-                                    ],
-                                  ],
-                                  ["Text", ["Nestyfing going on"]],
-                                  [
-                                    "Break",
-                                    [
-                                      {
-                                        "layout_before": [""],
-                                        "ty": "Soft",
-                                        "layout_after": [""],
-                                      },
-                                    ],
-                                  ],
-                                  ["Text", ["These irregularities "]],
-                                  [
-                                    "StrongEmphasis",
-                                    [
-                                      {
-                                        "delim": "*",
-                                        "inline": ["Text", ["will"]],
-                                      },
-                                    ],
-                                  ],
-                                  ["Text", [" normalize"]],
-                                  [
-                                    "Break",
-                                    [
-                                      {
-                                        "layout_before": [""],
-                                        "ty": "Soft",
-                                        "layout_after": [""],
-                                      },
-                                    ],
-                                  ],
-                                  [
-                                    "Text",
-                                    [
-                                      "We keep only the first block quote indent",
-                                    ],
-                                  ],
-                                ],
-                              ],
-                            ],
-                            "trailing_blanks": "",
-                          },
-                        ],
-                      ],
-                    },
-                  ],
-                ],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "BlockQuote",
-            [
-              {
-                "indent": 0,
-                "block": [
-                  "Heading",
-                  [
-                    {
-                      "layout": [
-                        "Atx",
-                        { "indent": 1, "after_opening": "", "closing": "" },
-                      ],
-                      "level": 2,
-                      "inline": ["Text", ["Further tests"]],
-                    },
-                  ],
-                ],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "Paragraph",
-            [
-              {
-                "leading_indent": 2,
-                "inline": ["Text", ["We need a little quote here"]],
-                "trailing_blanks": "",
-              },
-            ],
-          ],
-          [
-            "BlockQuote",
-            [
-              {
-                "indent": 0,
-                "block": [
-                  "Paragraph",
-                  [
-                    {
-                      "leading_indent": 1,
-                      "inline": ["Text", ["It's warranted."]],
-                      "trailing_blanks": "",
-                    },
-                  ],
-                ],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          ["BlankLine", [""]],
-          [
-            "Heading",
-            [
-              {
-                "layout": [
-                  "Atx",
-                  { "indent": 0, "after_opening": "", "closing": "" },
-                ],
-                "level": 2,
-                "inline": ["Text", ["Testing code blocks"]],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "CodeBlock",
-            [
-              {
-                "layout": [
-                  "Fenced",
-                  { "indent": 0, "opening_fence": [""], "closing_fence": [""] },
-                ],
-                "info_string": ["layout after info is not kept"],
-                "code": [],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "CodeBlock",
-            [
-              {
-                "layout": [
-                  "Fenced",
-                  { "indent": 1, "opening_fence": [""], "closing_fence": [""] },
-                ],
-                "info_string": ["ocaml module M"],
-                "code": [
-                  [""],
-                  ["type t = "],
-                  ["| A of int"],
-                  ["| B of string"],
-                  [""],
-                  ["let square x = x *. x"],
-                ],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "Paragraph",
-            [
-              {
-                "leading_indent": 0,
-                "inline": ["Text", ["The indented code block:"]],
-                "trailing_blanks": "",
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "CodeBlock",
-            [
-              {
-                "layout": "Indented",
-                "code": [
-                  ["a b c d "],
-                  [" a b c d"],
-                  [" a b c d"],
-                  ["  "],
-                  [""],
-                  ["a"],
-                  ["   a b c"],
-                ],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          ["BlankLine", [""]],
-          [
-            "BlockQuote",
-            [
-              {
-                "indent": 0,
-                "block": [
-                  "CodeBlock",
-                  [
-                    {
-                      "layout": [
-                        "Fenced",
-                        {
-                          "indent": 0,
-                          "opening_fence": [""],
-                          "closing_fence": [""],
-                        },
-                      ],
-                      "info_string": ["ocaml module M"],
-                      "code": [
-                        [""],
-                        ["type t = "],
-                        ["| A of int"],
-                        ["| B of string"],
-                        [""],
-                        ["let square x = x *. x"],
-                      ],
-                    },
-                  ],
-                ],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          ["BlankLine", [""]],
-          [
-            "Heading",
-            [
-              {
-                "layout": [
-                  "Atx",
-                  { "indent": 0, "after_opening": "", "closing": "" },
-                ],
-                "level": 2,
-                "inline": ["Text", ["Testing headings"]],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "Heading",
-            [
-              {
-                "layout": [
-                  "Setext",
-                  {
-                    "leading_indent": 0,
-                    "trailing_blanks": "",
-                    "underline_indent": 0,
-                    "underline_count": [8],
-                    "underline_blanks": "",
-                  },
-                ],
-                "level": 1,
-                "inline": [
-                  "Inlines",
-                  [
-                    [
-                      ["Text", ["aaa"]],
-                      [
-                        "Break",
-                        [
-                          {
-                            "layout_before": [""],
-                            "ty": "Soft",
-                            "layout_after": [""],
-                          },
-                        ],
-                      ],
-                      ["Text", ["aaaa"]],
-                    ],
-                  ],
-                ],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "BlockQuote",
-            [
-              {
-                "indent": 0,
-                "block": [
-                  "Heading",
-                  [
-                    {
-                      "layout": [
-                        "Setext",
-                        {
-                          "leading_indent": 0,
-                          "trailing_blanks": "",
-                          "underline_indent": 0,
-                          "underline_count": [8],
-                          "underline_blanks": "",
-                        },
-                      ],
-                      "level": 2,
-                      "inline": [
-                        "Inlines",
-                        [
-                          [
-                            ["Text", ["bbb "]],
-                            [
-                              "CodeSpan",
-                              [
-                                {
-                                  "backticks": 1,
-                                  "code_layout": [
-                                    { "blanks": "", "node": ["hey"] },
-                                  ],
-                                },
-                              ],
-                            ],
-                            [
-                              "Break",
-                              [
-                                {
-                                  "layout_before": [""],
-                                  "ty": "Soft",
-                                  "layout_after": [""],
-                                },
-                              ],
-                            ],
-                            ["Text", ["bbbb"]],
-                          ],
-                        ],
-                      ],
-                    },
-                  ],
-                ],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "Heading",
-            [
-              {
-                "layout": [
-                  "Atx",
-                  { "indent": 2, "after_opening": "", "closing": "" },
-                ],
-                "level": 1,
-                "inline": ["Text", ["That's one way"]],
-              },
-            ],
-          ],
-          ["BlankLine", ["  "]],
-          [
-            "Heading",
-            [
-              {
-                "layout": [
-                  "Atx",
-                  { "indent": 3, "after_opening": "", "closing": "" },
-                ],
-                "level": 3,
-                "inline": ["Text", ["It's a long way to the heading"]],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "Heading",
-            [
-              {
-                "layout": [
-                  "Atx",
-                  { "indent": 0, "after_opening": "", "closing": "" },
-                ],
-                "level": 2,
-                "inline": ["Text", ["Testing HTML block"]],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "HtmlBlock",
-            [
-              [
-                "HtmlBlock",
-                [["<aside>"], ["<p>There is no aside</p>"], ["</aside>"]],
-              ],
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "List",
-            [
-              {
-                "ty": ["Unordered", "*"],
-                "tight": true,
-                "items": [
-                  [
-                    {
-                      "before_marker": 0,
-                      "marker": ["*"],
-                      "after_marker": 1,
-                      "block": [
-                        "HtmlBlock",
-                        [
-                          [
-                            "HtmlBlock",
-                            [
-                              ["<aside>"],
-                              ["<p>There is no aside</p>"],
-                              ["</aside>"],
-                            ],
-                          ],
-                        ],
-                      ],
-                    },
-                  ],
-                ],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "Heading",
-            [
-              {
-                "layout": [
-                  "Atx",
-                  { "indent": 0, "after_opening": "", "closing": "" },
-                ],
-                "level": 2,
-                "inline": ["Text", ["Testing lists"]],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "Paragraph",
-            [
-              {
-                "leading_indent": 0,
-                "inline": [
-                  "Inlines",
-                  [
-                    [
-                      ["Text", ["The "]],
-                      [
-                        "CodeSpan",
-                        [
-                          {
-                            "backticks": 1,
-                            "code_layout": [
-                              { "blanks": "", "node": ["square"] },
-                            ],
-                          },
-                        ],
-                      ],
-                      [
-                        "Text",
-                        [" function is the root. There are reasons for this:"],
-                      ],
-                    ],
-                  ],
-                ],
-                "trailing_blanks": "",
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "List",
-            [
-              {
-                "ty": ["Ordered", 1, "."],
-                "tight": true,
-                "items": [
-                  [
-                    {
-                      "before_marker": 1,
-                      "marker": ["1."],
-                      "after_marker": 1,
-                      "block": [
-                        "Paragraph",
-                        [
-                          {
-                            "leading_indent": 0,
-                            "inline": [
-                              "Inlines",
-                              [
-                                [
-                                  [
-                                    "Text",
-                                    [
-                                      "There is no reason. There should be a reason or an ",
-                                    ],
-                                  ],
-                                  [
-                                    "Autolink",
-                                    [
-                                      {
-                                        "is_email": false,
-                                        "link": ["http://example.org"],
-                                      },
-                                    ],
-                                  ],
-                                ],
-                              ],
-                            ],
-                            "trailing_blanks": "",
-                          },
-                        ],
-                      ],
-                    },
-                  ],
-                  [
-                    {
-                      "before_marker": 0,
-                      "marker": ["2."],
-                      "after_marker": 1,
-                      "block": [
-                        "Paragraph",
-                        [
-                          {
-                            "leading_indent": 0,
-                            "inline": [
-                              "Text",
-                              [
-                                "Maybe that's the reason. But it may not be the reason.",
-                              ],
-                            ],
-                            "trailing_blanks": "",
-                          },
-                        ],
-                      ],
-                    },
-                  ],
-                  [
-                    {
-                      "before_marker": 1,
-                      "marker": ["3."],
-                      "after_marker": 1,
-                      "block": [
-                        "Paragraph",
-                        [
-                          {
-                            "leading_indent": 0,
-                            "inline": ["Text", ["Is reason the only tool ?"]],
-                            "trailing_blanks": "",
-                          },
-                        ],
-                      ],
-                    },
-                  ],
-                ],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "BlockQuote",
-            [
-              {
-                "indent": 0,
-                "block": [
-                  "Blocks",
-                  [
-                    [
-                      [
-                        "Paragraph",
-                        [
-                          {
-                            "leading_indent": 0,
-                            "inline": ["Text", ["Quoted bullets"]],
-                            "trailing_blanks": "",
-                          },
-                        ],
-                      ],
-                      [
-                        "List",
-                        [
-                          {
-                            "ty": ["Unordered", "*"],
-                            "tight": true,
-                            "items": [
-                              [
-                                {
-                                  "before_marker": 0,
-                                  "marker": ["*"],
-                                  "after_marker": 1,
-                                  "block": [
-                                    "Paragraph",
-                                    [
-                                      {
-                                        "leading_indent": 0,
-                                        "inline": [
-                                          "Text",
-                                          ["Is this important ?"],
-                                        ],
-                                        "trailing_blanks": "",
-                                      },
-                                    ],
-                                  ],
-                                },
-                              ],
-                            ],
-                          },
-                        ],
-                      ],
-                    ],
-                  ],
-                ],
-              },
-            ],
-          ],
-          [
-            "List",
-            [
-              {
-                "ty": ["Unordered", "*"],
-                "tight": true,
-                "items": [
-                  [
-                    {
-                      "before_marker": 0,
-                      "marker": ["*"],
-                      "after_marker": 1,
-                      "block": [
-                        "List",
-                        [
-                          {
-                            "ty": ["Unordered", "*"],
-                            "tight": true,
-                            "items": [
-                              [
-                                {
-                                  "before_marker": 0,
-                                  "marker": ["*"],
-                                  "after_marker": 1,
-                                  "block": [
-                                    "Paragraph",
-                                    [
-                                      {
-                                        "leading_indent": 0,
-                                        "inline": [
-                                          "Text",
-                                          ["Well it's in the spec"],
-                                        ],
-                                        "trailing_blanks": "",
-                                      },
-                                    ],
-                                  ],
-                                },
-                              ],
-                            ],
-                          },
-                        ],
-                      ],
-                    },
-                  ],
-                  [
-                    {
-                      "before_marker": 0,
-                      "marker": ["*"],
-                      "after_marker": 1,
-                      "block": ["BlankLine", [""]],
-                    },
-                  ],
-                ],
-              },
-            ],
-          ],
-          [
-            "Paragraph",
-            [
-              {
-                "leading_indent": 0,
-                "inline": ["Text", ["Empty list item above"]],
-                "trailing_blanks": "",
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "Heading",
-            [
-              {
-                "layout": [
-                  "Atx",
-                  { "indent": 0, "after_opening": "", "closing": "" },
-                ],
-                "level": 2,
-                "inline": ["Text", ["Testing paragraphs"]],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          [
-            "Paragraph",
-            [
-              {
-                "leading_indent": 3,
-                "inline": [
-                  "Inlines",
-                  [
-                    [
-                      [
-                        "Text",
-                        ["We really want your paragraph layout preserved."],
-                      ],
-                      [
-                        "Break",
-                        [
-                          {
-                            "layout_before": [""],
-                            "ty": "Soft",
-                            "layout_after": [""],
-                          },
-                        ],
-                      ],
-                      ["Text", ["Really ?"]],
-                      [
-                        "Break",
-                        [
-                          {
-                            "layout_before": [""],
-                            "ty": "Soft",
-                            "layout_after": [""],
-                          },
-                        ],
-                      ],
-                      ["Text", ["Really."]],
-                      [
-                        "Break",
-                        [
-                          {
-                            "layout_before": [""],
-                            "ty": "Soft",
-                            "layout_after": [""],
-                          },
-                        ],
-                      ],
-                      ["Text", ["Really."]],
-                      [
-                        "Break",
-                        [
-                          {
-                            "layout_before": [""],
-                            "ty": "Soft",
-                            "layout_after": [""],
-                          },
-                        ],
-                      ],
-                      ["Text", ["Really."]],
-                    ],
-                  ],
-                ],
-                "trailing_blanks": "",
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          ["BlankLine", [""]],
-          [
-            "BlockQuote",
-            [
-              {
-                "indent": 0,
-                "block": [
-                  "Paragraph",
-                  [
-                    {
-                      "leading_indent": 2,
-                      "inline": [
-                        "Inlines",
-                        [
-                          [
-                            [
-                              "Text",
-                              [
-                                "We really want your paragraph layout preserved.",
-                              ],
-                            ],
-                            [
-                              "Break",
-                              [
-                                {
-                                  "layout_before": [""],
-                                  "ty": "Soft",
-                                  "layout_after": [""],
-                                },
-                              ],
-                            ],
-                            ["Text", ["Really ?"]],
-                            [
-                              "Break",
-                              [
-                                {
-                                  "layout_before": [""],
-                                  "ty": "Soft",
-                                  "layout_after": [""],
-                                },
-                              ],
-                            ],
-                            ["Text", ["Really."]],
-                            [
-                              "Break",
-                              [
-                                {
-                                  "layout_before": [""],
-                                  "ty": "Soft",
-                                  "layout_after": [""],
-                                },
-                              ],
-                            ],
-                            ["Text", ["Really."]],
-                            [
-                              "Break",
-                              [
-                                {
-                                  "layout_before": [""],
-                                  "ty": "Soft",
-                                  "layout_after": [""],
-                                },
-                              ],
-                            ],
-                            ["Text", ["Really."]],
-                          ],
-                        ],
-                      ],
-                      "trailing_blanks": "",
-                    },
-                  ],
-                ],
-              },
-            ],
-          ],
-          ["BlankLine", [" "]],
-          ["BlankLine", [""]],
-          ["BlankLine", [""]],
-          [
-            "Heading",
-            [
-              {
-                "layout": [
-                  "Atx",
-                  { "indent": 0, "after_opening": "", "closing": "" },
-                ],
-                "level": 2,
-                "inline": ["Text", ["Testing thematic breaks"]],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-          ["ThematicBreak", [{ "indent": 1, "layout": "***" }]],
-          ["ThematicBreak", [{ "indent": 2, "layout": "---" }]],
-          ["ThematicBreak", [{ "indent": 3, "layout": "___" }]],
-          ["BlankLine", [""]],
-          ["ThematicBreak", [{ "indent": 0, "layout": "_ _ _ _ _ " }]],
-          ["BlankLine", [""]],
-          [
-            "BlockQuote",
-            [
-              {
-                "indent": 0,
-                "block": [
-                  "ThematicBreak",
-                  [{ "indent": 1, "layout": "*******" }],
-                ],
-              },
-            ],
-          ],
-          ["BlankLine", [""]],
-        ],
-      ],
-    ],
-    "defs": {
-      "colla psed": [
-        "LinkDef",
-        [
-          {
-            "layout": {
-              "indent": 0,
-              "angled_dest": false,
-              "before_dest": [[" "]],
-              "after_dest": [[" "]],
-              "title_open_delim": "\"",
-              "after_title": [[""]],
-            },
-            "label": {
-              "meta": {},
-              "key": "colla psed",
-              "text": [{ "blanks": "", "node": ["colla psed"] }],
-            },
-            "defined_label": {
-              "meta": {},
-              "key": "colla psed",
-              "text": [{ "blanks": "", "node": ["colla psed"] }],
-            },
-            "dest": ["/hohoho"],
-            "title": [
-              { "blanks": "", "node": ["And again these "] },
-              { "blanks": "", "node": ["multi"] },
-              { "blanks": "", "node": ["line titles"] },
-            ],
-          },
-        ],
-      ],
-      "`short cuted`": [
-        "LinkDef",
-        [
-          {
-            "layout": {
-              "indent": 1,
-              "angled_dest": false,
-              "before_dest": [["    "]],
-              "after_dest": [["   "]],
-              "title_open_delim": "\"",
-              "after_title": [[""]],
-            },
-            "label": {
-              "meta": {},
-              "key": "`short cuted`",
-              "text": [{ "blanks": "", "node": ["`short cuted`"] }],
-            },
-            "defined_label": {
-              "meta": {},
-              "key": "`short cuted`",
-              "text": [{ "blanks": "", "node": ["`short cuted`"] }],
-            },
-            "dest": ["/veryshort"],
-            "title": [
-              { "blanks": "", "node": ["But very"] },
-              { "blanks": "", "node": ["important"] },
-            ],
-          },
-        ],
-      ],
-    },
-  })
+  debug_inspect(
+    rendered,
+    content=(
+      #|{
+      #|  nl: "\n",
+      #|  block: Blocks(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          Heading(
+      #|            {
+      #|              v: {
+      #|                layout: Setext(
+      #|                  {
+      #|                    leading_indent: 0,
+      #|                    trailing_blanks: "",
+      #|                    underline_indent: 0,
+      #|                    underline_count: {
+      #|                      v: 11,
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    underline_blanks: "",
+      #|                  },
+      #|                ),
+      #|                level: 1,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "Basic tests",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                id: None,
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Paragraph(
+      #|            {
+      #|              v: {
+      #|                leading_indent: 0,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "Basic tests for all CommonMark constructs.",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                trailing_blanks: "",
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Heading(
+      #|            {
+      #|              v: {
+      #|                layout: Atx({ indent: 0, after_opening: "", closing: "" }),
+      #|                level: 2,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "Testing autolinks",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                id: None,
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Paragraph(
+      #|            {
+      #|              v: {
+      #|                leading_indent: 0,
+      #|                inline: Inlines(
+      #|                  {
+      #|                    v: Seq(
+      #|                      [
+      #|                        Text(
+      #|                          {
+      #|                            v: "This is an ",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Autolink(
+      #|                          {
+      #|                            v: { is_email: false, link: { v: "http://example.org", meta: ... } },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: " and another one ",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Autolink(
+      #|                          {
+      #|                            v: { is_email: true, link: { v: "you@example.org", meta: ... } },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: ".",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                      ],
+      #|                    ),
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                trailing_blanks: "",
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Heading(
+      #|            {
+      #|              v: {
+      #|                layout: Atx({ indent: 0, after_opening: "", closing: "" }),
+      #|                level: 2,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "Testing breaks",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                id: None,
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Paragraph(
+      #|            {
+      #|              v: {
+      #|                leading_indent: 0,
+      #|                inline: Inlines(
+      #|                  {
+      #|                    v: Seq(
+      #|                      [
+      #|                        Text(
+      #|                          {
+      #|                            v: "A line ending (not in a code span or HTML tag) that is preceded by two",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Break(
+      #|                          {
+      #|                            v: {
+      #|                              layout_before: { v: "", meta: ... },
+      #|                              ty: Soft,
+      #|                              layout_after: { v: "", meta: ... },
+      #|                            },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: "or more spaces and does not occur at the end of a block is parsed as a",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Break(
+      #|                          {
+      #|                            v: {
+      #|                              layout_before: { v: "", meta: ... },
+      #|                              ty: Soft,
+      #|                              layout_after: { v: "", meta: ... },
+      #|                            },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: "hard line break.",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                      ],
+      #|                    ),
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                trailing_blanks: "",
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Paragraph(
+      #|            {
+      #|              v: {
+      #|                leading_indent: 0,
+      #|                inline: Inlines(
+      #|                  {
+      #|                    v: Seq(
+      #|                      [
+      #|                        Text(
+      #|                          {
+      #|                            v: "So this means we had softbreaks so far and now we get  ",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Break(
+      #|                          {
+      #|                            v: {
+      #|                              layout_before: { v: "", meta: ... },
+      #|                              ty: Hard,
+      #|                              layout_after: { v: "", meta: ... },
+      #|                            },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: "a hard break",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Break(
+      #|                          {
+      #|                            v: {
+      #|                              layout_before: { v: "", meta: ... },
+      #|                              ty: Hard,
+      #|                              layout_after: { v: "", meta: ... },
+      #|                            },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: "and another one.",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                      ],
+      #|                    ),
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                trailing_blanks: "",
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlockQuote(
+      #|            {
+      #|              v: {
+      #|                indent: 0,
+      #|                block: Paragraph(
+      #|                  {
+      #|                    v: {
+      #|                      leading_indent: 0,
+      #|                      inline: Inlines(
+      #|                        {
+      #|                          v: Seq(
+      #|                            [
+      #|                              Text(...),
+      #|                              Break(...),
+      #|                              Text(...),
+      #|                              Break(...),
+      #|                              Text(...),
+      #|                              Break(...),
+      #|                              Text(...),
+      #|                            ],
+      #|                          ),
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                        },
+      #|                      ),
+      #|                      trailing_blanks: "",
+      #|                    },
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Heading(
+      #|            {
+      #|              v: {
+      #|                layout: Atx({ indent: 0, after_opening: "", closing: "" }),
+      #|                level: 2,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "Testing code spans",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                id: None,
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Paragraph(
+      #|            {
+      #|              v: {
+      #|                leading_indent: 0,
+      #|                inline: Inlines(
+      #|                  {
+      #|                    v: Seq(
+      #|                      [
+      #|                        Text(
+      #|                          {
+      #|                            v: "This is a multi-line code",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        CodeSpan(
+      #|                          {
+      #|                            v: { backticks: 1, code_layout: Seq(...) },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                      ],
+      #|                    ),
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                trailing_blanks: "",
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Paragraph(
+      #|            {
+      #|              v: {
+      #|                leading_indent: 0,
+      #|                inline: Inlines(
+      #|                  {
+      #|                    v: Seq(
+      #|                      [
+      #|                        Text(
+      #|                          {
+      #|                            v: "Sometimes code spans ",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        CodeSpan(
+      #|                          {
+      #|                            v: { backticks: 2, code_layout: Seq(...) },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: ". Do you fancy ",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        CodeSpan(
+      #|                          {
+      #|                            v: { backticks: 2, code_layout: Seq(...) },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: " ?",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                      ],
+      #|                    ),
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                trailing_blanks: "",
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Heading(
+      #|            {
+      #|              v: {
+      #|                layout: Atx({ indent: 0, after_opening: "", closing: "" }),
+      #|                level: 2,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "Testing emphasis",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                id: None,
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Paragraph(
+      #|            {
+      #|              v: {
+      #|                leading_indent: 0,
+      #|                inline: Inlines(
+      #|                  {
+      #|                    v: Seq(
+      #|                      [
+      #|                        Text(
+      #|                          {
+      #|                            v: "There is ",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Emphasis(
+      #|                          {
+      #|                            v: { delim: '_', inline: Text(...) },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: " than ",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Emphasis(
+      #|                          {
+      #|                            v: { delim: '*', inline: Text(...) },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: " for ",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        StrongEmphasis(
+      #|                          {
+      #|                            v: { delim: '_', inline: Text(...) },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: " and ",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        StrongEmphasis(
+      #|                          {
+      #|                            v: { delim: '*', inline: Inlines(...) },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: ".  We should be careful about ",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        StrongEmphasis(
+      #|                          {
+      #|                            v: { delim: '*', inline: Text(...) },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: ". This",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Break(
+      #|                          {
+      #|                            v: {
+      #|                              layout_before: { v: "", meta: ... },
+      #|                              ty: Soft,
+      #|                              layout_after: { v: "", meta: ... },
+      #|                            },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: "will be ",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        StrongEmphasis(
+      #|                          {
+      #|                            v: { delim: '*', inline: Text(...) },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: ". This ",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Emphasis(
+      #|                          {
+      #|                            v: { delim: '*', inline: Text(...) },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: " you want ?",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                      ],
+      #|                    ),
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                trailing_blanks: "",
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Heading(
+      #|            {
+      #|              v: {
+      #|                layout: Atx({ indent: 0, after_opening: "", closing: "" }),
+      #|                level: 2,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "Testing links, images and link reference definitions",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                id: None,
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Paragraph(
+      #|            {
+      #|              v: {
+      #|                leading_indent: 0,
+      #|                inline: Inlines(
+      #|                  {
+      #|                    v: Seq(
+      #|                      [
+      #|                        Text(
+      #|                          {
+      #|                            v: "This is an ",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Image(
+      #|                          {
+      #|                            v: { text: Text(...), reference: Inline(...) },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                      ],
+      #|                    ),
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                trailing_blanks: "",
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Paragraph(
+      #|            {
+      #|              v: {
+      #|                leading_indent: 2,
+      #|                inline: Inlines(
+      #|                  {
+      #|                    v: Seq(
+      #|                      [
+      #|                        Text(
+      #|                          {
+      #|                            v: "That is totally ",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Link(
+      #|                          {
+      #|                            v: { text: Text(...), reference: Ref(Collapsed, ..., ...) },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: " and",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Break(
+      #|                          {
+      #|                            v: {
+      #|                              layout_before: { v: "", meta: ... },
+      #|                              ty: Soft,
+      #|                              layout_after: { v: "", meta: ... },
+      #|                            },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: "that is ",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Link(
+      #|                          {
+      #|                            v: { text: CodeSpan(...), reference: Ref(Shortcut, ..., ...) },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                      ],
+      #|                    ),
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                trailing_blanks: "",
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Paragraph(
+      #|            {
+      #|              v: {
+      #|                leading_indent: 0,
+      #|                inline: Inlines(
+      #|                  {
+      #|                    v: Seq(
+      #|                      [
+      #|                        Text(
+      #|                          {
+      #|                            v: "Shortcuts can be better than ",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Link(
+      #|                          {
+      #|                            v: { text: Text(...), reference: Ref(Full, ..., ...) },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: " but not",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Break(
+      #|                          {
+      #|                            v: {
+      #|                              layout_before: { v: "", meta: ... },
+      #|                              ty: Soft,
+      #|                              layout_after: { v: "", meta: ... },
+      #|                            },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: "always and we'd like to trip their ",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Link(
+      #|                          {
+      #|                            v: { text: Text(...), reference: Ref(Full, ..., ...) },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: ".",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                      ],
+      #|                    ),
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                trailing_blanks: "",
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlockQuote(
+      #|            {
+      #|              v: {
+      #|                indent: 0,
+      #|                block: LinkRefDefinition(
+      #|                  {
+      #|                    v: {
+      #|                      layout: {
+      #|                        indent: 0,
+      #|                        angled_dest: false,
+      #|                        before_dest: Seq([{ v: " ", meta: { id: 0, loc: ..., extra: None } }]),
+      #|                        after_dest: Seq([{ v: " ", meta: { id: 0, loc: ..., extra: None } }]),
+      #|                        title_open_delim: '"',
+      #|                        after_title: Seq([{ v: "", meta: { id: 0, loc: ..., extra: None } }]),
+      #|                      },
+      #|                      label: Some(
+      #|                        {
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                          key: "colla psed",
+      #|                          text: Seq([{ blanks: "", node: ... }]),
+      #|                        },
+      #|                      ),
+      #|                      defined_label: Some(
+      #|                        {
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                          key: "colla psed",
+      #|                          text: Seq([{ blanks: "", node: ... }]),
+      #|                        },
+      #|                      ),
+      #|                      dest: Some(
+      #|                        {
+      #|                          v: "/hohoho",
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                        },
+      #|                      ),
+      #|                      title: Some(
+      #|                        Seq(
+      #|                          [
+      #|                            { blanks: "", node: { v: "And again these ", meta: ... } },
+      #|                            { blanks: "", node: { v: "multi", meta: ... } },
+      #|                            { blanks: "", node: { v: "line titles", meta: ... } },
+      #|                          ],
+      #|                        ),
+      #|                      ),
+      #|                    },
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          LinkRefDefinition(
+      #|            {
+      #|              v: {
+      #|                layout: {
+      #|                  indent: 1,
+      #|                  angled_dest: false,
+      #|                  before_dest: Seq(
+      #|                    [
+      #|                      {
+      #|                        v: "    ",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    ],
+      #|                  ),
+      #|                  after_dest: Seq(
+      #|                    [
+      #|                      {
+      #|                        v: "   ",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    ],
+      #|                  ),
+      #|                  title_open_delim: '"',
+      #|                  after_title: Seq(
+      #|                    [
+      #|                      {
+      #|                        v: "",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    ],
+      #|                  ),
+      #|                },
+      #|                label: Some(
+      #|                  {
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                    key: "`short cuted`",
+      #|                    text: Seq(
+      #|                      [
+      #|                        {
+      #|                          blanks: "",
+      #|                          node: {
+      #|                            v: "`short cuted`",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        },
+      #|                      ],
+      #|                    ),
+      #|                  },
+      #|                ),
+      #|                defined_label: Some(
+      #|                  {
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                    key: "`short cuted`",
+      #|                    text: Seq(
+      #|                      [
+      #|                        {
+      #|                          blanks: "",
+      #|                          node: {
+      #|                            v: "`short cuted`",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        },
+      #|                      ],
+      #|                    ),
+      #|                  },
+      #|                ),
+      #|                dest: Some(
+      #|                  {
+      #|                    v: "/veryshort",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                title: Some(
+      #|                  Seq(
+      #|                    [
+      #|                      {
+      #|                        blanks: "",
+      #|                        node: {
+      #|                          v: "But very",
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                        },
+      #|                      },
+      #|                      {
+      #|                        blanks: "",
+      #|                        node: {
+      #|                          v: "important",
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                        },
+      #|                      },
+      #|                    ],
+      #|                  ),
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "  ",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Heading(
+      #|            {
+      #|              v: {
+      #|                layout: Atx({ indent: 0, after_opening: "", closing: "" }),
+      #|                level: 2,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "Testing raw HTML",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                id: None,
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Paragraph(
+      #|            {
+      #|              v: {
+      #|                leading_indent: 0,
+      #|                inline: Inlines(
+      #|                  {
+      #|                    v: Seq(
+      #|                      [
+      #|                        Text(
+      #|                          {
+      #|                            v: "Haha ",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        RawHtml(
+      #|                          {
+      #|                            v: InlineRawHtml(Seq(...)),
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: "a",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        RawHtml(
+      #|                          {
+      #|                            v: InlineRawHtml(Seq(...)),
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        RawHtml(
+      #|                          {
+      #|                            v: InlineRawHtml(Seq(...)),
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: " hihi this is not the end yet.",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                      ],
+      #|                    ),
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                trailing_blanks: "",
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Paragraph(
+      #|            {
+      #|              v: {
+      #|                leading_indent: 0,
+      #|                inline: Inlines(
+      #|                  {
+      #|                    v: Seq(
+      #|                      [
+      #|                        Text(
+      #|                          {
+      #|                            v: "foo ",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        RawHtml(
+      #|                          {
+      #|                            v: InlineRawHtml(Seq(...)),
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: "u",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        RawHtml(
+      #|                          {
+      #|                            v: InlineRawHtml(Seq(...)),
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                      ],
+      #|                    ),
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                trailing_blanks: "",
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlockQuote(
+      #|            {
+      #|              v: {
+      #|                indent: 0,
+      #|                block: Paragraph(
+      #|                  {
+      #|                    v: {
+      #|                      leading_indent: 1,
+      #|                      inline: Inlines(
+      #|                        {
+      #|                          v: Seq(
+      #|                            [
+      #|                              Text(...),
+      #|                              RawHtml(...),
+      #|                              Text(...),
+      #|                              RawHtml(...),
+      #|                              RawHtml(...),
+      #|                              Text(...),
+      #|                            ],
+      #|                          ),
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                        },
+      #|                      ),
+      #|                      trailing_blanks: "",
+      #|                    },
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Heading(
+      #|            {
+      #|              v: {
+      #|                layout: Atx({ indent: 0, after_opening: "", closing: "" }),
+      #|                level: 2,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "Testing blank lines",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                id: None,
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "    ",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "     ",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Paragraph(
+      #|            {
+      #|              v: {
+      #|                leading_indent: 0,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "Impressive isn't it ?",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                trailing_blanks: "",
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Heading(
+      #|            {
+      #|              v: {
+      #|                layout: Atx({ indent: 0, after_opening: "", closing: "" }),
+      #|                level: 2,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "Testing block quotes",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                id: None,
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlockQuote(
+      #|            {
+      #|              v: {
+      #|                indent: 2,
+      #|                block: BlockQuote(
+      #|                  {
+      #|                    v: {
+      #|                      indent: 2,
+      #|                      block: Paragraph(
+      #|                        {
+      #|                          v: {
+      #|                            leading_indent: 0,
+      #|                            inline: Inlines({ v: ..., meta: ... }),
+      #|                            trailing_blanks: "",
+      #|                          },
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                        },
+      #|                      ),
+      #|                    },
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlockQuote(
+      #|            {
+      #|              v: {
+      #|                indent: 0,
+      #|                block: Heading(
+      #|                  {
+      #|                    v: {
+      #|                      layout: Atx({ indent: 1, after_opening: "", closing: "" }),
+      #|                      level: 2,
+      #|                      inline: Text(
+      #|                        {
+      #|                          v: "Further tests",
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                        },
+      #|                      ),
+      #|                      id: None,
+      #|                    },
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Paragraph(
+      #|            {
+      #|              v: {
+      #|                leading_indent: 2,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "We need a little quote here",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                trailing_blanks: "",
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlockQuote(
+      #|            {
+      #|              v: {
+      #|                indent: 0,
+      #|                block: Paragraph(
+      #|                  {
+      #|                    v: {
+      #|                      leading_indent: 1,
+      #|                      inline: Text(
+      #|                        {
+      #|                          v: "It's warranted.",
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                        },
+      #|                      ),
+      #|                      trailing_blanks: "",
+      #|                    },
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Heading(
+      #|            {
+      #|              v: {
+      #|                layout: Atx({ indent: 0, after_opening: "", closing: "" }),
+      #|                level: 2,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "Testing code blocks",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                id: None,
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          CodeBlock(
+      #|            {
+      #|              v: {
+      #|                layout: Fenced(
+      #|                  {
+      #|                    indent: 0,
+      #|                    opening_fence: {
+      #|                      v: "",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    closing_fence: Some(
+      #|                      {
+      #|                        v: "",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    ),
+      #|                  },
+      #|                ),
+      #|                info_string: Some(
+      #|                  {
+      #|                    v: "layout after info is not kept",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                code: Seq([]),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          CodeBlock(
+      #|            {
+      #|              v: {
+      #|                layout: Fenced(
+      #|                  {
+      #|                    indent: 1,
+      #|                    opening_fence: {
+      #|                      v: "",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    closing_fence: Some(
+      #|                      {
+      #|                        v: "",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    ),
+      #|                  },
+      #|                ),
+      #|                info_string: Some(
+      #|                  {
+      #|                    v: "ocaml module M",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                code: Seq(
+      #|                  [
+      #|                    {
+      #|                      v: "",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: "type t = ",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: "| A of int",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: "| B of string",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: "",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: "let square x = x *. x",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Paragraph(
+      #|            {
+      #|              v: {
+      #|                leading_indent: 0,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "The indented code block:",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                trailing_blanks: "",
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          CodeBlock(
+      #|            {
+      #|              v: {
+      #|                layout: Indented,
+      #|                info_string: None,
+      #|                code: Seq(
+      #|                  [
+      #|                    {
+      #|                      v: "a b c d ",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: " a b c d",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: " a b c d",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: "  ",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: "",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: "a",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: "   a b c",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlockQuote(
+      #|            {
+      #|              v: {
+      #|                indent: 0,
+      #|                block: CodeBlock(
+      #|                  {
+      #|                    v: {
+      #|                      layout: Fenced(
+      #|                        {
+      #|                          indent: 0,
+      #|                          opening_fence: {
+      #|                            v: "",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                          closing_fence: Some({ v: "", meta: { id: 0, loc: ..., extra: None } }),
+      #|                        },
+      #|                      ),
+      #|                      info_string: Some(
+      #|                        {
+      #|                          v: "ocaml module M",
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                        },
+      #|                      ),
+      #|                      code: Seq(
+      #|                        [
+      #|                          {
+      #|                            v: "",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                          {
+      #|                            v: "type t = ",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                          {
+      #|                            v: "| A of int",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                          {
+      #|                            v: "| B of string",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                          {
+      #|                            v: "",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                          {
+      #|                            v: "let square x = x *. x",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ],
+      #|                      ),
+      #|                    },
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Heading(
+      #|            {
+      #|              v: {
+      #|                layout: Atx({ indent: 0, after_opening: "", closing: "" }),
+      #|                level: 2,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "Testing headings",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                id: None,
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Heading(
+      #|            {
+      #|              v: {
+      #|                layout: Setext(
+      #|                  {
+      #|                    leading_indent: 0,
+      #|                    trailing_blanks: "",
+      #|                    underline_indent: 0,
+      #|                    underline_count: {
+      #|                      v: 8,
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    underline_blanks: "",
+      #|                  },
+      #|                ),
+      #|                level: 1,
+      #|                inline: Inlines(
+      #|                  {
+      #|                    v: Seq(
+      #|                      [
+      #|                        Text(
+      #|                          {
+      #|                            v: "aaa",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Break(
+      #|                          {
+      #|                            v: {
+      #|                              layout_before: { v: "", meta: ... },
+      #|                              ty: Soft,
+      #|                              layout_after: { v: "", meta: ... },
+      #|                            },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: "aaaa",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                      ],
+      #|                    ),
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                id: None,
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlockQuote(
+      #|            {
+      #|              v: {
+      #|                indent: 0,
+      #|                block: Heading(
+      #|                  {
+      #|                    v: {
+      #|                      layout: Setext(
+      #|                        {
+      #|                          leading_indent: 0,
+      #|                          trailing_blanks: "",
+      #|                          underline_indent: 0,
+      #|                          underline_count: {
+      #|                            v: 8,
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                          underline_blanks: "",
+      #|                        },
+      #|                      ),
+      #|                      level: 2,
+      #|                      inline: Inlines(
+      #|                        {
+      #|                          v: Seq([Text(...), CodeSpan(...), Break(...), Text(...)]),
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                        },
+      #|                      ),
+      #|                      id: None,
+      #|                    },
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Heading(
+      #|            {
+      #|              v: {
+      #|                layout: Atx({ indent: 2, after_opening: "", closing: "" }),
+      #|                level: 1,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "That's one way",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                id: None,
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "  ",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Heading(
+      #|            {
+      #|              v: {
+      #|                layout: Atx({ indent: 3, after_opening: "", closing: "" }),
+      #|                level: 3,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "It's a long way to the heading",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                id: None,
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Heading(
+      #|            {
+      #|              v: {
+      #|                layout: Atx({ indent: 0, after_opening: "", closing: "" }),
+      #|                level: 2,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "Testing HTML block",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                id: None,
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          HtmlBlock(
+      #|            {
+      #|              v: HtmlBlock(
+      #|                Seq(
+      #|                  [
+      #|                    {
+      #|                      v: "<aside>",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: "<p>There is no aside</p>",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: "</aside>",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|              ),
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          List(
+      #|            {
+      #|              v: {
+      #|                ty: Unordered('*'),
+      #|                tight: true,
+      #|                items: Seq(
+      #|                  [
+      #|                    {
+      #|                      v: {
+      #|                        before_marker: 0,
+      #|                        marker: {
+      #|                          v: "*",
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                        },
+      #|                        after_marker: 1,
+      #|                        block: HtmlBlock(
+      #|                          {
+      #|                            v: HtmlBlock(Seq(...)),
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        ext_task_marker: None,
+      #|                      },
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Heading(
+      #|            {
+      #|              v: {
+      #|                layout: Atx({ indent: 0, after_opening: "", closing: "" }),
+      #|                level: 2,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "Testing lists",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                id: None,
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Paragraph(
+      #|            {
+      #|              v: {
+      #|                leading_indent: 0,
+      #|                inline: Inlines(
+      #|                  {
+      #|                    v: Seq(
+      #|                      [
+      #|                        Text(
+      #|                          {
+      #|                            v: "The ",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        CodeSpan(
+      #|                          {
+      #|                            v: { backticks: 1, code_layout: Seq(...) },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: " function is the root. There are reasons for this:",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                      ],
+      #|                    ),
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                trailing_blanks: "",
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          List(
+      #|            {
+      #|              v: {
+      #|                ty: Ordered(1, '.'),
+      #|                tight: true,
+      #|                items: Seq(
+      #|                  [
+      #|                    {
+      #|                      v: {
+      #|                        before_marker: 1,
+      #|                        marker: {
+      #|                          v: "1.",
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                        },
+      #|                        after_marker: 1,
+      #|                        block: Paragraph(
+      #|                          {
+      #|                            v: { leading_indent: 0, inline: Inlines(...), trailing_blanks: "" },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        ext_task_marker: None,
+      #|                      },
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: {
+      #|                        before_marker: 0,
+      #|                        marker: {
+      #|                          v: "2.",
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                        },
+      #|                        after_marker: 1,
+      #|                        block: Paragraph(
+      #|                          {
+      #|                            v: { leading_indent: 0, inline: Text(...), trailing_blanks: "" },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        ext_task_marker: None,
+      #|                      },
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: {
+      #|                        before_marker: 1,
+      #|                        marker: {
+      #|                          v: "3.",
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                        },
+      #|                        after_marker: 1,
+      #|                        block: Paragraph(
+      #|                          {
+      #|                            v: { leading_indent: 0, inline: Text(...), trailing_blanks: "" },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        ext_task_marker: None,
+      #|                      },
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlockQuote(
+      #|            {
+      #|              v: {
+      #|                indent: 0,
+      #|                block: Blocks(
+      #|                  {
+      #|                    v: Seq(
+      #|                      [
+      #|                        Paragraph(
+      #|                          {
+      #|                            v: { leading_indent: 0, inline: Text(...), trailing_blanks: "" },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        List(
+      #|                          {
+      #|                            v: { ty: Unordered('*'), tight: true, items: Seq(...) },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                      ],
+      #|                    ),
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          List(
+      #|            {
+      #|              v: {
+      #|                ty: Unordered('*'),
+      #|                tight: true,
+      #|                items: Seq(
+      #|                  [
+      #|                    {
+      #|                      v: {
+      #|                        before_marker: 0,
+      #|                        marker: {
+      #|                          v: "*",
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                        },
+      #|                        after_marker: 1,
+      #|                        block: List(
+      #|                          {
+      #|                            v: { ty: Unordered('*'), tight: true, items: Seq(...) },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        ext_task_marker: None,
+      #|                      },
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      v: {
+      #|                        before_marker: 0,
+      #|                        marker: {
+      #|                          v: "*",
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                        },
+      #|                        after_marker: 1,
+      #|                        block: BlankLine(
+      #|                          {
+      #|                            v: "",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        ext_task_marker: None,
+      #|                      },
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Paragraph(
+      #|            {
+      #|              v: {
+      #|                leading_indent: 0,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "Empty list item above",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                trailing_blanks: "",
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Heading(
+      #|            {
+      #|              v: {
+      #|                layout: Atx({ indent: 0, after_opening: "", closing: "" }),
+      #|                level: 2,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "Testing paragraphs",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                id: None,
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Paragraph(
+      #|            {
+      #|              v: {
+      #|                leading_indent: 3,
+      #|                inline: Inlines(
+      #|                  {
+      #|                    v: Seq(
+      #|                      [
+      #|                        Text(
+      #|                          {
+      #|                            v: "We really want your paragraph layout preserved.",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Break(
+      #|                          {
+      #|                            v: {
+      #|                              layout_before: { v: "", meta: ... },
+      #|                              ty: Soft,
+      #|                              layout_after: { v: "", meta: ... },
+      #|                            },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: "Really ?",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Break(
+      #|                          {
+      #|                            v: {
+      #|                              layout_before: { v: "", meta: ... },
+      #|                              ty: Soft,
+      #|                              layout_after: { v: "", meta: ... },
+      #|                            },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: "Really.",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Break(
+      #|                          {
+      #|                            v: {
+      #|                              layout_before: { v: "", meta: ... },
+      #|                              ty: Soft,
+      #|                              layout_after: { v: "", meta: ... },
+      #|                            },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: "Really.",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Break(
+      #|                          {
+      #|                            v: {
+      #|                              layout_before: { v: "", meta: ... },
+      #|                              ty: Soft,
+      #|                              layout_after: { v: "", meta: ... },
+      #|                            },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: "Really.",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                      ],
+      #|                    ),
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                trailing_blanks: "",
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlockQuote(
+      #|            {
+      #|              v: {
+      #|                indent: 0,
+      #|                block: Paragraph(
+      #|                  {
+      #|                    v: {
+      #|                      leading_indent: 2,
+      #|                      inline: Inlines(
+      #|                        {
+      #|                          v: Seq(
+      #|                            [
+      #|                              Text(...),
+      #|                              Break(...),
+      #|                              Text(...),
+      #|                              Break(...),
+      #|                              Text(...),
+      #|                              Break(...),
+      #|                              Text(...),
+      #|                              Break(...),
+      #|                              Text(...),
+      #|                            ],
+      #|                          ),
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                        },
+      #|                      ),
+      #|                      trailing_blanks: "",
+      #|                    },
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: " ",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Heading(
+      #|            {
+      #|              v: {
+      #|                layout: Atx({ indent: 0, after_opening: "", closing: "" }),
+      #|                level: 2,
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "Testing thematic breaks",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                id: None,
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          ThematicBreak(
+      #|            {
+      #|              v: { indent: 1, layout: "***" },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          ThematicBreak(
+      #|            {
+      #|              v: { indent: 2, layout: "---" },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          ThematicBreak(
+      #|            {
+      #|              v: { indent: 3, layout: "___" },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          ThematicBreak(
+      #|            {
+      #|              v: { indent: 0, layout: "_ _ _ _ _ " },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlockQuote(
+      #|            {
+      #|              v: {
+      #|                indent: 0,
+      #|                block: ThematicBreak(
+      #|                  {
+      #|                    v: { indent: 1, layout: "*******" },
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|  defs: {
+      #|    "colla psed": LinkDef(
+      #|      {
+      #|        v: {
+      #|          layout: {
+      #|            indent: 0,
+      #|            angled_dest: false,
+      #|            before_dest: Seq(
+      #|              [
+      #|                {
+      #|                  v: " ",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|              ],
+      #|            ),
+      #|            after_dest: Seq(
+      #|              [
+      #|                {
+      #|                  v: " ",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|              ],
+      #|            ),
+      #|            title_open_delim: '"',
+      #|            after_title: Seq(
+      #|              [
+      #|                {
+      #|                  v: "",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|              ],
+      #|            ),
+      #|          },
+      #|          label: Some(
+      #|            {
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|              key: "colla psed",
+      #|              text: Seq(
+      #|                [
+      #|                  {
+      #|                    blanks: "",
+      #|                    node: {
+      #|                      v: "colla psed",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                  },
+      #|                ],
+      #|              ),
+      #|            },
+      #|          ),
+      #|          defined_label: Some(
+      #|            {
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|              key: "colla psed",
+      #|              text: Seq(
+      #|                [
+      #|                  {
+      #|                    blanks: "",
+      #|                    node: {
+      #|                      v: "colla psed",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                  },
+      #|                ],
+      #|              ),
+      #|            },
+      #|          ),
+      #|          dest: Some(
+      #|            {
+      #|              v: "/hohoho",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          title: Some(
+      #|            Seq(
+      #|              [
+      #|                {
+      #|                  blanks: "",
+      #|                  node: {
+      #|                    v: "And again these ",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                },
+      #|                {
+      #|                  blanks: "",
+      #|                  node: {
+      #|                    v: "multi",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                },
+      #|                {
+      #|                  blanks: "",
+      #|                  node: {
+      #|                    v: "line titles",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                },
+      #|              ],
+      #|            ),
+      #|          ),
+      #|        },
+      #|        meta: {
+      #|          id: 0,
+      #|          loc: {
+      #|            file: "-",
+      #|            first_ccode: -1,
+      #|            last_ccode: -1,
+      #|            first_line: LinePos(-1, -1),
+      #|            last_line: LinePos(-1, -1),
+      #|          },
+      #|          extra: None,
+      #|        },
+      #|      },
+      #|    ),
+      #|    "`short cuted`": LinkDef(
+      #|      {
+      #|        v: {
+      #|          layout: {
+      #|            indent: 1,
+      #|            angled_dest: false,
+      #|            before_dest: Seq(
+      #|              [
+      #|                {
+      #|                  v: "    ",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|              ],
+      #|            ),
+      #|            after_dest: Seq(
+      #|              [
+      #|                {
+      #|                  v: "   ",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|              ],
+      #|            ),
+      #|            title_open_delim: '"',
+      #|            after_title: Seq(
+      #|              [
+      #|                {
+      #|                  v: "",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|              ],
+      #|            ),
+      #|          },
+      #|          label: Some(
+      #|            {
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|              key: "`short cuted`",
+      #|              text: Seq(
+      #|                [
+      #|                  {
+      #|                    blanks: "",
+      #|                    node: {
+      #|                      v: "`short cuted`",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                  },
+      #|                ],
+      #|              ),
+      #|            },
+      #|          ),
+      #|          defined_label: Some(
+      #|            {
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|              key: "`short cuted`",
+      #|              text: Seq(
+      #|                [
+      #|                  {
+      #|                    blanks: "",
+      #|                    node: {
+      #|                      v: "`short cuted`",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                  },
+      #|                ],
+      #|              ),
+      #|            },
+      #|          ),
+      #|          dest: Some(
+      #|            {
+      #|              v: "/veryshort",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          title: Some(
+      #|            Seq(
+      #|              [
+      #|                {
+      #|                  blanks: "",
+      #|                  node: {
+      #|                    v: "But very",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                },
+      #|                {
+      #|                  blanks: "",
+      #|                  node: {
+      #|                    v: "important",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                },
+      #|              ],
+      #|            ),
+      #|          ),
+      #|        },
+      #|        meta: {
+      #|          id: 0,
+      #|          loc: {
+      #|            file: "-",
+      #|            first_ccode: -1,
+      #|            last_ccode: -1,
+      #|            first_line: LinePos(-1, -1),
+      #|            last_line: LinePos(-1, -1),
+      #|          },
+      #|          extra: None,
+      #|        },
+      #|      },
+      #|    ),
+      #|  },
+      #|}
+    ),
+  )
 }

--- a/src/cmark/error.mbt
+++ b/src/cmark/error.mbt
@@ -1,9 +1,31 @@
 ///|
 pub(all) suberror FolderError {
   FolderError(String)
-} derive(Show)
+} derive(Debug)
+
+///|
+pub impl Show for FolderError with output(self, logger) {
+  match self {
+    FolderError(message) => {
+      logger.write_string("FolderError(")
+      logger.write_object(message)
+      logger.write_char(')')
+    }
+  }
+}
 
 ///|
 pub(all) suberror MapperError {
   MapperError(String)
-} derive(Show)
+} derive(Debug)
+
+///|
+pub impl Show for MapperError with output(self, logger) {
+  match self {
+    MapperError(message) => {
+      logger.write_string("MapperError(")
+      logger.write_object(message)
+      logger.write_char(')')
+    }
+  }
+}

--- a/src/cmark/folder.mbt
+++ b/src/cmark/folder.mbt
@@ -18,7 +18,7 @@ pub(all) struct FolderFn[A, B]((Folder[B], B, A) -> FolderResult[B])
 pub(all) enum FolderResult[A] {
   Default
   Fold(A)
-} derive(Eq, Show, ToJson)
+} derive(Eq, Debug)
 
 ///|
 pub impl[A] Default for FolderResult[A] with default() {

--- a/src/cmark/folder_test.mbt
+++ b/src/cmark/folder_test.mbt
@@ -1,14 +1,14 @@
 ///|
 test "folder_none" {
   let folder = @cmark.Folder::new()
-  inspect(@cmark.Folder::none(folder, 1, "test"), content="Default")
+  debug_inspect(@cmark.Folder::none(folder, 1, "test"), content="Default")
 }
 
 ///|
 test "fold_block with blank line" {
   let folder = @cmark.Folder::new()
   let block = @cmark.Block::BlankLine(@cmark.Node::new(""))
-  inspect(folder.fold_block(0, block), content="0")
+  debug_inspect(folder.fold_block(0, block), content="0")
 }
 
 ///|
@@ -21,7 +21,7 @@ test "fold_block with paragraph" {
       trailing_blanks: "",
     }),
   )
-  inspect(folder.fold_block(0, block), content="0")
+  debug_inspect(folder.fold_block(0, block), content="0")
 }
 
 ///|
@@ -37,7 +37,7 @@ test "fold_block with heading" {
       id: None,
     }),
   )
-  inspect(folder.fold_block(0, heading), content="0")
+  debug_inspect(folder.fold_block(0, heading), content="0")
 }
 
 ///|
@@ -55,7 +55,7 @@ test "fold_block with blockquote" {
       ),
     }),
   )
-  inspect(folder.fold_block(0, quote), content="0")
+  debug_inspect(folder.fold_block(0, quote), content="0")
 }
 
 ///|
@@ -81,7 +81,7 @@ test "fold_block with blocks" {
       ]),
     ),
   )
-  inspect(folder.fold_block(0, blocks), content="0")
+  debug_inspect(folder.fold_block(0, blocks), content="0")
 }
 
 ///|
@@ -146,7 +146,7 @@ test "folder block with table" {
     }),
   )
   let result = folder.fold_block(0, table)
-  inspect(result, content="0")
+  debug_inspect(result, content="0")
 }
 
 ///|
@@ -165,7 +165,7 @@ test "folder block with footnote definition" {
     }),
   )
   let result = folder.fold_block(0, footnote)
-  inspect(result, content="0")
+  debug_inspect(result, content="0")
 }
 
 ///|
@@ -174,5 +174,5 @@ test "folder fold_block with default block handler" {
     @cmark.Folder::ret(acc)
   })
   let block = @cmark.Block::empty()
-  inspect(folder.fold_block(0, block), content="0")
+  debug_inspect(folder.fold_block(0, block), content="0")
 }

--- a/src/cmark/inline.mbt
+++ b/src/cmark/inline.mbt
@@ -15,7 +15,7 @@ pub(all) enum Inline {
   Text(Node[InlineText])
   ExtStrikethrough(Node[InlineStrikethrough])
   ExtMathSpan(Node[InlineMathSpan])
-} derive(Eq, Show, ToJson)
+} derive(Eq, Debug)
 
 ///|
 pub fn Inline::empty() -> Inline {
@@ -217,7 +217,7 @@ pub(all) struct InlineAutolink {
   /// https://spec.commonmark.org/0.30/#absolute-uri
   /// https://spec.commonmark.org/0.30/#email-address
   link : StringNode
-} derive(Eq, Show, ToJson)
+} derive(Eq, Debug)
 
 ///|
 pub fn InlineAutolink::new(link : StringNode) -> InlineAutolink {
@@ -230,7 +230,7 @@ pub(all) struct InlineBreak {
   layout_before : BlanksNode
   ty : InlineBreakType
   layout_after : BlanksNode
-} derive(Eq, Show, ToJson)
+} derive(Eq, Debug)
 
 ///|
 pub fn InlineBreak::new(
@@ -245,14 +245,14 @@ pub fn InlineBreak::new(
 pub(all) enum InlineBreakType {
   Hard
   Soft
-} derive(Eq, Compare, Show, FromJson, ToJson)
+} derive(Eq, Compare, Debug, FromJson, ToJson)
 
 ///|
 /// The type for [code spans](https://spec.commonmark.org/0.30/#code-spans).
 pub(all) struct InlineCodeSpan {
   backticks : Count
   code_layout : Seq[Tight]
-} derive(Eq, Show, ToJson)
+} derive(Eq, Debug)
 
 ///|
 pub fn InlineCodeSpan::new(
@@ -344,7 +344,7 @@ pub fn InlineCodeSpan::code(self : InlineCodeSpan) -> String {
 pub(all) struct InlineEmphasis {
   delim : Char
   inline : Inline
-} derive(Eq, Show, ToJson)
+} derive(Eq, Debug)
 
 ///|
 pub fn InlineEmphasis::new(
@@ -358,7 +358,7 @@ pub fn InlineEmphasis::new(
 pub(all) struct InlineLink {
   text : Inline
   reference : ReferenceKind
-} derive(Eq, Show, ToJson)
+} derive(Eq, Debug)
 
 ///|
 pub(all) enum ReferenceKind {
@@ -367,7 +367,7 @@ pub(all) enum ReferenceKind {
   /// https://spec.commonmark.org/0.30/#reference-link
   /// First label is the label of the reference, second label is the label of the referenced definition.
   Ref(ReferenceLayout, Label, Label)
-} derive(Eq, Show, ToJson)
+} derive(Eq, Debug)
 
 ///|
 /// The type for reference link layouts.
@@ -378,7 +378,7 @@ pub(all) enum ReferenceLayout {
   Full
   /// https://spec.commonmark.org/0.30/#shortcut-reference-link
   Shortcut
-} derive(Eq, Show, FromJson, ToJson)
+} derive(Eq, Debug, FromJson, ToJson)
 
 ///|
 pub fn InlineLink::new(text : Inline, reference : ReferenceKind) -> InlineLink {
@@ -442,7 +442,7 @@ pub fn InlineLink::is_unsafe(l : String) -> Bool {
 
 ///|
 /// The type for [inline raw HTML](https://spec.commonmark.org/0.30/#raw-html) (can span multiple lines).
-pub(all) struct InlineRawHtml(Seq[Tight]) derive(Eq, Show, ToJson)
+pub(all) struct InlineRawHtml(Seq[Tight]) derive(Eq, Debug)
 
 ///|
 /// The type for [textual content](https://spec.commonmark.org/0.30/#textual-content).
@@ -455,13 +455,13 @@ pub type InlineText = String
 // Extensions
 
 ///|
-pub(all) struct InlineStrikethrough(Inline) derive(Eq, Show, ToJson)
+pub(all) struct InlineStrikethrough(Inline) derive(Eq, Debug)
 
 ///|
 pub(all) struct InlineMathSpan {
   display : Bool
   tex_layout : Seq[Tight]
-} derive(Eq, Show, ToJson)
+} derive(Eq, Debug)
 
 ///|
 pub fn InlineMathSpan::tex(self : Self) -> String {

--- a/src/cmark/inline_struct.mbt
+++ b/src/cmark/inline_struct.mbt
@@ -23,19 +23,19 @@ priv enum Token {
   RightParen(TokenStart)
   StrikethroughMarks(TokenStrikethroughMarks)
   MathSpanMarks(TokenMathSpanMarks)
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 priv struct TokenStart {
   start : CharCodePos
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 priv struct TokenBackticks {
   start : CharCodePos
   count : Int
   escaped : Bool
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 priv struct TokenEmphasisMarks {
@@ -44,7 +44,7 @@ priv struct TokenEmphasisMarks {
   count : Int
   may_open : Bool
   may_close : Bool
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 priv struct TokenInline {
@@ -52,13 +52,13 @@ priv struct TokenInline {
   inline : Inline
   endline : LineSpan
   next : CharCodePos
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 priv struct TokenLinkStart {
   start : CharCodePos
   image : Bool
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 priv struct TokenNewline {
@@ -66,14 +66,14 @@ priv struct TokenNewline {
   start : CharCodePos
   break_ty : InlineBreakType
   newline : LineSpan
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 priv struct TokenStrikethroughMarks {
   start : CharCodePos
   may_open : Bool
   may_close : Bool
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 priv struct TokenMathSpanMarks {
@@ -81,7 +81,7 @@ priv struct TokenMathSpanMarks {
   count : Int
   may_open : Bool
   may_close : Bool
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 fn Token::start(self : Token) -> CharCodePos {
@@ -1587,13 +1587,6 @@ fn Parser::start_col(
 priv enum StartColResult {
   Col((Inline, TableCellLayout), CharCodePos)
   Start(String, Array[Inline])
-} derive(Show, ToJson)
-
-///|
-test {
-  // Prevent warning about unused Show and ToJson
-  (fn(s : StartColResult) { s.to_string() }) |> ignore()
-  (fn(s : StartColResult) { s.to_json() }) |> ignore()
 }
 
 ///|

--- a/src/cmark/inline_struct_wbtest.mbt
+++ b/src/cmark/inline_struct_wbtest.mbt
@@ -46,50 +46,151 @@ fn tokenize_only(
 
 ///|
 test "should parse entity and numeric char references" {
-  json_inspect(
+  debug_inspect(
     parse_only(
       (
         #|&nbsp; &amp; &copy; &AElig; &Dcaron; &frac34; &HilbertSpace; &DifferentialD; &ClockwiseContourIntegral; &ngE; &#35; &#1234; &#992; &#0; &#X22; &#XD06; &#xcab;
       ),
     ),
-    content=[
-      [0, ""],
-      ["Text", ["  & © Æ Ď ¾ ℋ ⅆ ∲ ≧̸ # Ӓ Ϡ � \" ആ ಫ"]],
-    ],
+    content=(
+      #|(
+      #|  (0, ""),
+      #|  Text(
+      #|    {
+      #|      v: "  & © Æ Ď ¾ ℋ ⅆ ∲ ≧̸ # Ӓ Ϡ � \" ആ ಫ",
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
   )
-  json_inspect(
+  debug_inspect(
     parse_only(
       (
         #|&nbsp &x; &#; &#x; &#87654321; &#abcdef0; &ThisIsNotDefined; &hi?; &copy &MadeUpEntity;
       ),
     ),
-    content=[
-      [0, ""],
-      [
-        "Text",
-        [
-          "&nbsp &x; &#; &#x; &#87654321; &#abcdef0; &ThisIsNotDefined; &hi?; &copy &MadeUpEntity;",
-        ],
-      ],
-    ],
+    content=(
+      #|(
+      #|  (0, ""),
+      #|  Text(
+      #|    {
+      #|      v: "&nbsp &x; &#; &#x; &#87654321; &#abcdef0; &ThisIsNotDefined; &hi?; &copy &MadeUpEntity;",
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
   )
 }
 
 ///|
 test "should parse autolinks" {
-  json_inspect(parse_only("<http://example.org>"), content=[
-    [0, ""],
-    ["Autolink", [{ "is_email": false, "link": ["http://example.org"] }]],
-  ])
-  json_inspect(parse_only("<you@example.org>"), content=[
-    [0, ""],
-    ["Autolink", [{ "is_email": true, "link": ["you@example.org"] }]],
-  ])
+  debug_inspect(
+    parse_only("<http://example.org>"),
+    content=(
+      #|(
+      #|  (0, ""),
+      #|  Autolink(
+      #|    {
+      #|      v: {
+      #|        is_email: false,
+      #|        link: {
+      #|          v: "http://example.org",
+      #|          meta: {
+      #|            id: 0,
+      #|            loc: {
+      #|              file: "-",
+      #|              first_ccode: -1,
+      #|              last_ccode: -1,
+      #|              first_line: LinePos(-1, -1),
+      #|              last_line: LinePos(-1, -1),
+      #|            },
+      #|            extra: None,
+      #|          },
+      #|        },
+      #|      },
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
+  )
+  debug_inspect(
+    parse_only("<you@example.org>"),
+    content=(
+      #|(
+      #|  (0, ""),
+      #|  Autolink(
+      #|    {
+      #|      v: {
+      #|        is_email: true,
+      #|        link: {
+      #|          v: "you@example.org",
+      #|          meta: {
+      #|            id: 0,
+      #|            loc: {
+      #|              file: "-",
+      #|              first_ccode: -1,
+      #|              last_ccode: -1,
+      #|              first_line: LinePos(-1, -1),
+      #|              last_line: LinePos(-1, -1),
+      #|            },
+      #|            extra: None,
+      #|          },
+      #|        },
+      #|      },
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
+  )
 }
 
 ///|
 test "should parse breaks" {
-  json_inspect(
+  debug_inspect(
     parse_only(
       (
         #|A line ending (not in a code span or HTML tag) that is preceded by two
@@ -97,39 +198,172 @@ test "should parse breaks" {
         #| hard line break.
       ),
     ),
-    content=[
-      [0, ""],
-      [
-        "Inlines",
-        [
-          [
-            [
-              "Text",
-              [
-                "A line ending (not in a code span or HTML tag) that is preceded by two",
-              ],
-            ],
-            [
-              "Break",
-              [{ "layout_before": [""], "ty": "Soft", "layout_after": [""] }],
-            ],
-            [
-              "Text",
-              [
-                "or more spaces and does not occur at the end of a block is parsed as a",
-              ],
-            ],
-            [
-              "Break",
-              [{ "layout_before": [""], "ty": "Soft", "layout_after": [""] }],
-            ],
-            ["Text", ["hard line break."]],
-          ],
-        ],
-      ],
-    ],
+    content=(
+      #|(
+      #|  (0, ""),
+      #|  Inlines(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          Text(
+      #|            {
+      #|              v: "A line ending (not in a code span or HTML tag) that is preceded by two",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Break(
+      #|            {
+      #|              v: {
+      #|                layout_before: {
+      #|                  v: "",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|                ty: Soft,
+      #|                layout_after: {
+      #|                  v: "",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Text(
+      #|            {
+      #|              v: "or more spaces and does not occur at the end of a block is parsed as a",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Break(
+      #|            {
+      #|              v: {
+      #|                layout_before: {
+      #|                  v: "",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|                ty: Soft,
+      #|                layout_after: {
+      #|                  v: "",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Text(
+      #|            {
+      #|              v: "hard line break.",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
   )
-  json_inspect(
+  debug_inspect(
     parse_only(
       (
         #|So this means we had softbreaks so far and now we get  \
@@ -137,36 +371,176 @@ test "should parse breaks" {
         #| and another one.
       ),
     ),
-    content=[
-      [0, ""],
-      [
-        "Inlines",
-        [
-          [
-            [
-              "Text",
-              ["So this means we had softbreaks so far and now we get  "],
-            ],
-            [
-              "Break",
-              [{ "layout_before": [""], "ty": "Hard", "layout_after": [""] }],
-            ],
-            ["Text", ["a hard break"]],
-            [
-              "Break",
-              [{ "layout_before": [""], "ty": "Hard", "layout_after": [""] }],
-            ],
-            ["Text", ["and another one."]],
-          ],
-        ],
-      ],
-    ],
+    content=(
+      #|(
+      #|  (0, ""),
+      #|  Inlines(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          Text(
+      #|            {
+      #|              v: "So this means we had softbreaks so far and now we get  ",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Break(
+      #|            {
+      #|              v: {
+      #|                layout_before: {
+      #|                  v: "",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|                ty: Hard,
+      #|                layout_after: {
+      #|                  v: "",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Text(
+      #|            {
+      #|              v: "a hard break",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Break(
+      #|            {
+      #|              v: {
+      #|                layout_before: {
+      #|                  v: "",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|                ty: Hard,
+      #|                layout_after: {
+      #|                  v: "",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Text(
+      #|            {
+      #|              v: "and another one.",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
   )
 }
 
 ///|
 test "should tokenize codespans" {
-  json_inspect(
+  debug_inspect(
     tokenize_only(
       (
         #|This is a multi-line code`
@@ -174,94 +548,262 @@ test "should tokenize codespans" {
         #|  in there`
       ),
     ),
-    content=[
-      ["CloserIndex", { "Backticks(1)": [25, 71], "Backticks(2)": [41] }],
-      [
-        ["Backticks", { "start": 25, "count": 1, "escaped": false }],
-        [
-          "Newline",
-          {
-            "start": 26,
-            "break_ty": "Soft",
-            "newline": { "pos": ["LinePos", 2, 0], "first": 27, "last": 59 },
-          },
-        ],
-        ["Backticks", { "start": 41, "count": 2, "escaped": false }],
-        [
-          "Newline",
-          {
-            "start": 60,
-            "break_ty": "Soft",
-            "newline": { "pos": ["LinePos", 3, 0], "first": 61, "last": 71 },
-          },
-        ],
-        ["Backticks", { "start": 71, "count": 1, "escaped": false }],
-      ],
-      { "pos": ["LinePos", 1, 0], "first": 0, "last": 25 },
-    ],
+    content=(
+      #|(
+      #|  CloserIndex({ Backticks(1): <Set: [25, 71]>, Backticks(2): <Set: [41]> }),
+      #|  Tokens(
+      #|    <Deque:
+      #|      [
+      #|        Backticks({ start: 25, count: 1, escaped: false }),
+      #|        Newline(
+      #|          {
+      #|            start: 26,
+      #|            break_ty: Soft,
+      #|            newline: { pos: LinePos(2, 0), first: 27, last: 59 },
+      #|          },
+      #|        ),
+      #|        Backticks({ start: 41, count: 2, escaped: false }),
+      #|        Newline(
+      #|          {
+      #|            start: 60,
+      #|            break_ty: Soft,
+      #|            newline: { pos: LinePos(3, 0), first: 61, last: 71 },
+      #|          },
+      #|        ),
+      #|        Backticks({ start: 71, count: 1, escaped: false }),
+      #|      ]>,
+      #|  ),
+      #|  { pos: LinePos(1, 0), first: 0, last: 25 },
+      #|)
+    ),
   )
 }
 
 ///|
 test "should parse codespans on a single line" {
-  json_inspect(parse_only("Wow, we have `code spans` now!"), content=[
-    [0, ""],
-    [
-      "Inlines",
-      [
-        [
-          ["Text", ["Wow, we have "]],
-          [
-            "CodeSpan",
-            [
-              {
-                "backticks": 1,
-                "code_layout": [{ "blanks": "", "node": ["code spans"] }],
-              },
-            ],
-          ],
-          ["Text", [" now!"]],
-        ],
-      ],
-    ],
-  ])
+  debug_inspect(
+    parse_only("Wow, we have `code spans` now!"),
+    content=(
+      #|(
+      #|  (0, ""),
+      #|  Inlines(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          Text(
+      #|            {
+      #|              v: "Wow, we have ",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          CodeSpan(
+      #|            {
+      #|              v: {
+      #|                backticks: 1,
+      #|                code_layout: Seq(
+      #|                  [
+      #|                    {
+      #|                      blanks: "",
+      #|                      node: {
+      #|                        v: "code spans",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Text(
+      #|            {
+      #|              v: " now!",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
+  )
 }
 
 ///|
 test "should parse codespans across multiple lines" {
-  json_inspect(
+  debug_inspect(
     parse_only(
       (
         #|wow code`
         #|    stuff` !
       ),
     ),
-    content=[
-      [0, ""],
-      [
-        "Inlines",
-        [
-          [
-            ["Text", ["wow code"]],
-            [
-              "CodeSpan",
-              [
-                {
-                  "backticks": 1,
-                  "code_layout": [
-                    { "blanks": "", "node": [""] },
-                    { "blanks": "", "node": ["stuff"] },
-                  ],
-                },
-              ],
-            ],
-            ["Text", [" !"]],
-          ],
-        ],
-      ],
-    ],
+    content=(
+      #|(
+      #|  (0, ""),
+      #|  Inlines(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          Text(
+      #|            {
+      #|              v: "wow code",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          CodeSpan(
+      #|            {
+      #|              v: {
+      #|                backticks: 1,
+      #|                code_layout: Seq(
+      #|                  [
+      #|                    {
+      #|                      blanks: "",
+      #|                      node: {
+      #|                        v: "",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      blanks: "",
+      #|                      node: {
+      #|                        v: "stuff",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Text(
+      #|            {
+      #|              v: " !",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
   )
-  json_inspect(
+  debug_inspect(
     parse_only(
       (
         #|This is a multi-line code`
@@ -269,32 +811,121 @@ test "should parse codespans across multiple lines" {
         #|  in there`
       ),
     ),
-    content=[
-      [0, ""],
-      [
-        "Inlines",
-        [
-          [
-            ["Text", ["This is a multi-line code"]],
-            [
-              "CodeSpan",
-              [
-                {
-                  "backticks": 1,
-                  "code_layout": [
-                    { "blanks": "", "node": [""] },
-                    { "blanks": "", "node": ["code span `` it has backticks"] },
-                    { "blanks": "", "node": ["in there"] },
-                  ],
-                },
-              ],
-            ],
-          ],
-        ],
-      ],
-    ],
+    content=(
+      #|(
+      #|  (0, ""),
+      #|  Inlines(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          Text(
+      #|            {
+      #|              v: "This is a multi-line code",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          CodeSpan(
+      #|            {
+      #|              v: {
+      #|                backticks: 1,
+      #|                code_layout: Seq(
+      #|                  [
+      #|                    {
+      #|                      blanks: "",
+      #|                      node: {
+      #|                        v: "",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      blanks: "",
+      #|                      node: {
+      #|                        v: "code span `` it has backticks",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      blanks: "",
+      #|                      node: {
+      #|                        v: "in there",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
   )
-  json_inspect(
+  debug_inspect(
     parse_only(
       (
         #|Sometimes code spans `` `can have
@@ -303,261 +934,1082 @@ test "should parse codespans across multiple lines" {
         #|      layout ``. Do you fancy `` `A_polymorphic_variant `` ? 
       ),
     ),
-    content=[
-      [0, ""],
-      [
-        "Inlines",
-        [
-          [
-            ["Text", ["Sometimes code spans "]],
-            [
-              "CodeSpan",
-              [
-                {
-                  "backticks": 2,
-                  "code_layout": [
-                    { "blanks": "", "node": [" `can have"] },
-                    { "blanks": "", "node": ["really ```"] },
-                    { "blanks": "", "node": ["strange"] },
-                    { "blanks": "", "node": ["layout "] },
-                  ],
-                },
-              ],
-            ],
-            ["Text", [". Do you fancy "]],
-            [
-              "CodeSpan",
-              [
-                {
-                  "backticks": 2,
-                  "code_layout": [
-                    { "blanks": "", "node": [" `A_polymorphic_variant "] },
-                  ],
-                },
-              ],
-            ],
-            ["Text", [" ?"]],
-          ],
-        ],
-      ],
-    ],
+    content=(
+      #|(
+      #|  (0, ""),
+      #|  Inlines(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          Text(
+      #|            {
+      #|              v: "Sometimes code spans ",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          CodeSpan(
+      #|            {
+      #|              v: {
+      #|                backticks: 2,
+      #|                code_layout: Seq(
+      #|                  [
+      #|                    {
+      #|                      blanks: "",
+      #|                      node: {
+      #|                        v: " `can have",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      blanks: "",
+      #|                      node: {
+      #|                        v: "really ```",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      blanks: "",
+      #|                      node: {
+      #|                        v: "strange",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      blanks: "",
+      #|                      node: {
+      #|                        v: "layout ",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Text(
+      #|            {
+      #|              v: ". Do you fancy ",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          CodeSpan(
+      #|            {
+      #|              v: {
+      #|                backticks: 2,
+      #|                code_layout: Seq(
+      #|                  [
+      #|                    {
+      #|                      blanks: "",
+      #|                      node: {
+      #|                        v: " `A_polymorphic_variant ",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Text(
+      #|            {
+      #|              v: " ?",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
   )
 }
 
 ///|
 test "should parse emphases" {
-  json_inspect(parse_only("*it's just emph*"), content=[
-    [0, ""],
-    ["Emphasis", [{ "delim": "*", "inline": ["Text", ["it's just emph"]] }]],
-  ])
-  json_inspect(parse_only("_and another emph_"), content=[
-    [0, ""],
-    ["Emphasis", [{ "delim": "_", "inline": ["Text", ["and another emph"]] }]],
-  ])
-  json_inspect(parse_only("**and strong emph**"), content=[
-    [0, ""],
-    [
-      "StrongEmphasis",
-      [{ "delim": "*", "inline": ["Text", ["and strong emph"]] }],
-    ],
-  ])
-  json_inspect(parse_only("__and another strong emph__"), content=[
-    [0, ""],
-    [
-      "StrongEmphasis",
-      [{ "delim": "_", "inline": ["Text", ["and another strong emph"]] }],
-    ],
-  ])
-  json_inspect(parse_only("be careful about **embedded * markers**!"), content=[
-    [0, ""],
-    [
-      "Inlines",
-      [
-        [
-          ["Text", ["be careful about "]],
-          [
-            "StrongEmphasis",
-            [{ "delim": "*", "inline": ["Text", ["embedded * markers"]] }],
-          ],
-          ["Text", ["!"]],
-        ],
-      ],
-    ],
-  ])
-  json_inspect(parse_only("This *is not ** what* you want?"), content=[
-    [0, ""],
-    [
-      "Inlines",
-      [
-        [
-          ["Text", ["This "]],
-          [
-            "Emphasis",
-            [{ "delim": "*", "inline": ["Text", ["is not ** what"]] }],
-          ],
-          ["Text", [" you want?"]],
-        ],
-      ],
-    ],
-  ])
-  json_inspect(parse_only("**许可证**：GPL-v3.0"), content=[
-    [0, ""],
-    [
-      "Inlines",
-      [
-        [
-          [
-            "StrongEmphasis",
-            [{ "delim": "*", "inline": ["Text", ["许可证"]] }],
-          ],
-          ["Text", ["：GPL-v3.0"]],
-        ],
-      ],
-    ],
-  ])
+  debug_inspect(
+    parse_only("*it's just emph*"),
+    content=(
+      #|(
+      #|  (0, ""),
+      #|  Emphasis(
+      #|    {
+      #|      v: {
+      #|        delim: '*',
+      #|        inline: Text(
+      #|          {
+      #|            v: "it's just emph",
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|      },
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
+  )
+  debug_inspect(
+    parse_only("_and another emph_"),
+    content=(
+      #|(
+      #|  (0, ""),
+      #|  Emphasis(
+      #|    {
+      #|      v: {
+      #|        delim: '_',
+      #|        inline: Text(
+      #|          {
+      #|            v: "and another emph",
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|      },
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
+  )
+  debug_inspect(
+    parse_only("**and strong emph**"),
+    content=(
+      #|(
+      #|  (0, ""),
+      #|  StrongEmphasis(
+      #|    {
+      #|      v: {
+      #|        delim: '*',
+      #|        inline: Text(
+      #|          {
+      #|            v: "and strong emph",
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|      },
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
+  )
+  debug_inspect(
+    parse_only("__and another strong emph__"),
+    content=(
+      #|(
+      #|  (0, ""),
+      #|  StrongEmphasis(
+      #|    {
+      #|      v: {
+      #|        delim: '_',
+      #|        inline: Text(
+      #|          {
+      #|            v: "and another strong emph",
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|      },
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
+  )
+  debug_inspect(
+    parse_only("be careful about **embedded * markers**!"),
+    content=(
+      #|(
+      #|  (0, ""),
+      #|  Inlines(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          Text(
+      #|            {
+      #|              v: "be careful about ",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          StrongEmphasis(
+      #|            {
+      #|              v: {
+      #|                delim: '*',
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "embedded * markers",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Text(
+      #|            {
+      #|              v: "!",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
+  )
+  debug_inspect(
+    parse_only("This *is not ** what* you want?"),
+    content=(
+      #|(
+      #|  (0, ""),
+      #|  Inlines(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          Text(
+      #|            {
+      #|              v: "This ",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Emphasis(
+      #|            {
+      #|              v: {
+      #|                delim: '*',
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "is not ** what",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Text(
+      #|            {
+      #|              v: " you want?",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
+  )
+  debug_inspect(
+    parse_only("**许可证**：GPL-v3.0"),
+    content=(
+      #|(
+      #|  (0, ""),
+      #|  Inlines(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          StrongEmphasis(
+      #|            {
+      #|              v: {
+      #|                delim: '*',
+      #|                inline: Text(
+      #|                  {
+      #|                    v: "许可证",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Text(
+      #|            {
+      #|              v: "：GPL-v3.0",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
+  )
 }
 
 ///|
 test "should parse links/images/refs" {
-  json_inspect(
+  debug_inspect(
     parse_only(
       (
         #|[a link](http://example.org)
       ),
     ),
-    content=[
-      [0, ""],
-      [
-        "Link",
-        [
-          {
-            "text": ["Text", ["a link"]],
-            "reference": [
-              "Inline",
-              [
-                {
-                  "layout": {
-                    "indent": 0,
-                    "angled_dest": false,
-                    "before_dest": [],
-                    "after_dest": [],
-                    "title_open_delim": "\"",
-                    "after_title": [],
-                  },
-                  "dest": ["http://example.org"],
-                },
-              ],
-            ],
-          },
-        ],
-      ],
-    ],
+    content=(
+      #|(
+      #|  (0, ""),
+      #|  Link(
+      #|    {
+      #|      v: {
+      #|        text: Text(
+      #|          {
+      #|            v: "a link",
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|        reference: Inline(
+      #|          {
+      #|            v: {
+      #|              layout: {
+      #|                indent: 0,
+      #|                angled_dest: false,
+      #|                before_dest: Seq([]),
+      #|                after_dest: Seq([]),
+      #|                title_open_delim: '"',
+      #|                after_title: Seq([]),
+      #|              },
+      #|              label: None,
+      #|              defined_label: None,
+      #|              dest: Some(
+      #|                {
+      #|                  v: "http://example.org",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|              ),
+      #|              title: None,
+      #|            },
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|      },
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
   )
-  json_inspect(
+  debug_inspect(
     parse_only(
       (
         #|![an image](http://example.org)
       ),
     ),
-    content=[
-      [0, ""],
-      [
-        "Image",
-        [
-          {
-            "text": ["Text", ["an image"]],
-            "reference": [
-              "Inline",
-              [
-                {
-                  "layout": {
-                    "indent": 0,
-                    "angled_dest": false,
-                    "before_dest": [],
-                    "after_dest": [],
-                    "title_open_delim": "\"",
-                    "after_title": [],
-                  },
-                  "dest": ["http://example.org"],
-                },
-              ],
-            ],
-          },
-        ],
-      ],
-    ],
+    content=(
+      #|(
+      #|  (0, ""),
+      #|  Image(
+      #|    {
+      #|      v: {
+      #|        text: Text(
+      #|          {
+      #|            v: "an image",
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|        reference: Inline(
+      #|          {
+      #|            v: {
+      #|              layout: {
+      #|                indent: 0,
+      #|                angled_dest: false,
+      #|                before_dest: Seq([]),
+      #|                after_dest: Seq([]),
+      #|                title_open_delim: '"',
+      #|                after_title: Seq([]),
+      #|              },
+      #|              label: None,
+      #|              defined_label: None,
+      #|              dest: Some(
+      #|                {
+      #|                  v: "http://example.org",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|              ),
+      #|              title: None,
+      #|            },
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|      },
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
   )
-  json_inspect(
+  debug_inspect(
     parse_only(
       (
         #|[a link](http://example.org "a title")
       ),
     ),
-    content=[
-      [0, ""],
-      [
-        "Link",
-        [
-          {
-            "text": ["Text", ["a link"]],
-            "reference": [
-              "Inline",
-              [
-                {
-                  "layout": {
-                    "indent": 0,
-                    "angled_dest": false,
-                    "before_dest": [],
-                    "after_dest": [[" "]],
-                    "title_open_delim": "\"",
-                    "after_title": [],
-                  },
-                  "dest": ["http://example.org"],
-                  "title": [{ "blanks": "", "node": ["a title"] }],
-                },
-              ],
-            ],
-          },
-        ],
-      ],
-    ],
+    content=(
+      #|(
+      #|  (0, ""),
+      #|  Link(
+      #|    {
+      #|      v: {
+      #|        text: Text(
+      #|          {
+      #|            v: "a link",
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|        reference: Inline(
+      #|          {
+      #|            v: {
+      #|              layout: {
+      #|                indent: 0,
+      #|                angled_dest: false,
+      #|                before_dest: Seq([]),
+      #|                after_dest: Seq(
+      #|                  [
+      #|                    {
+      #|                      v: " ",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|                title_open_delim: '"',
+      #|                after_title: Seq([]),
+      #|              },
+      #|              label: None,
+      #|              defined_label: None,
+      #|              dest: Some(
+      #|                {
+      #|                  v: "http://example.org",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|              ),
+      #|              title: Some(
+      #|                Seq(
+      #|                  [
+      #|                    {
+      #|                      blanks: "",
+      #|                      node: {
+      #|                        v: "a title",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|              ),
+      #|            },
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|      },
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
   )
-  json_inspect(
+  debug_inspect(
     parse_only(
       (
         #|![an image](http://example.org "a title")
       ),
     ),
-    content=[
-      [0, ""],
-      [
-        "Image",
-        [
-          {
-            "text": ["Text", ["an image"]],
-            "reference": [
-              "Inline",
-              [
-                {
-                  "layout": {
-                    "indent": 0,
-                    "angled_dest": false,
-                    "before_dest": [],
-                    "after_dest": [[" "]],
-                    "title_open_delim": "\"",
-                    "after_title": [],
-                  },
-                  "dest": ["http://example.org"],
-                  "title": [{ "blanks": "", "node": ["a title"] }],
-                },
-              ],
-            ],
-          },
-        ],
-      ],
-    ],
+    content=(
+      #|(
+      #|  (0, ""),
+      #|  Image(
+      #|    {
+      #|      v: {
+      #|        text: Text(
+      #|          {
+      #|            v: "an image",
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|        reference: Inline(
+      #|          {
+      #|            v: {
+      #|              layout: {
+      #|                indent: 0,
+      #|                angled_dest: false,
+      #|                before_dest: Seq([]),
+      #|                after_dest: Seq(
+      #|                  [
+      #|                    {
+      #|                      v: " ",
+      #|                      meta: {
+      #|                        id: 0,
+      #|                        loc: {
+      #|                          file: "-",
+      #|                          first_ccode: -1,
+      #|                          last_ccode: -1,
+      #|                          first_line: LinePos(-1, -1),
+      #|                          last_line: LinePos(-1, -1),
+      #|                        },
+      #|                        extra: None,
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|                title_open_delim: '"',
+      #|                after_title: Seq([]),
+      #|              },
+      #|              label: None,
+      #|              defined_label: None,
+      #|              dest: Some(
+      #|                {
+      #|                  v: "http://example.org",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|              ),
+      #|              title: Some(
+      #|                Seq(
+      #|                  [
+      #|                    {
+      #|                      blanks: "",
+      #|                      node: {
+      #|                        v: "a title",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|              ),
+      #|            },
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|      },
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
   )
-  json_inspect(
+  debug_inspect(
     parse_only(
       (
         #|This is an ![inline image](
@@ -565,212 +2017,834 @@ test "should parse links/images/refs" {
         #|    multiline title))
       ),
     ),
-    content=[
-      [0, ""],
-      [
-        "Inlines",
-        [
-          [
-            ["Text", ["This is an "]],
-            [
-              "Image",
-              [
-                {
-                  "text": ["Text", ["inline image"]],
-                  "reference": [
-                    "Inline",
-                    [
-                      {
-                        "layout": {
-                          "indent": 0,
-                          "angled_dest": false,
-                          "before_dest": [[""], ["  "]],
-                          "after_dest": [["    "]],
-                          "title_open_delim": "(",
-                          "after_title": [],
-                        },
-                        "dest": ["/heyho"],
-                        "title": [
-                          { "blanks": "", "node": ["The"] },
-                          { "blanks": "", "node": ["multiline title"] },
-                        ],
-                      },
-                    ],
-                  ],
-                },
-              ],
-            ],
-          ],
-        ],
-      ],
-    ],
+    content=(
+      #|(
+      #|  (0, ""),
+      #|  Inlines(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          Text(
+      #|            {
+      #|              v: "This is an ",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Image(
+      #|            {
+      #|              v: {
+      #|                text: Text(
+      #|                  {
+      #|                    v: "inline image",
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|                reference: Inline(
+      #|                  {
+      #|                    v: {
+      #|                      layout: {
+      #|                        indent: 0,
+      #|                        angled_dest: false,
+      #|                        before_dest: Seq(
+      #|                          [
+      #|                            { v: "", meta: { id: 0, loc: ..., extra: None } },
+      #|                            { v: "  ", meta: { id: 0, loc: ..., extra: None } },
+      #|                          ],
+      #|                        ),
+      #|                        after_dest: Seq([{ v: "    ", meta: { id: 0, loc: ..., extra: None } }]),
+      #|                        title_open_delim: '(',
+      #|                        after_title: Seq([]),
+      #|                      },
+      #|                      label: None,
+      #|                      defined_label: None,
+      #|                      dest: Some(
+      #|                        {
+      #|                          v: "/heyho",
+      #|                          meta: {
+      #|                            id: 0,
+      #|                            loc: {
+      #|                              file: "-",
+      #|                              first_ccode: -1,
+      #|                              last_ccode: -1,
+      #|                              first_line: LinePos(-1, -1),
+      #|                              last_line: LinePos(-1, -1),
+      #|                            },
+      #|                            extra: None,
+      #|                          },
+      #|                        },
+      #|                      ),
+      #|                      title: Some(
+      #|                        Seq(
+      #|                          [
+      #|                            { blanks: "", node: { v: "The", meta: ... } },
+      #|                            { blanks: "", node: { v: "multiline title", meta: ... } },
+      #|                          ],
+      #|                        ),
+      #|                      ),
+      #|                    },
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
   )
 }
 
 ///|
 test "should tokenize broken links across lines" {
-  json_inspect(
+  debug_inspect(
     tokenize_only(
       (
         #|and the [end
         #|condition], wow
       ),
     ),
-    content=[
-      ["CloserIndex", { "RightBrack": [22] }],
-      [
-        ["LinkStart", { "start": 8, "image": false }],
-        [
-          "Newline",
-          {
-            "start": 12,
-            "break_ty": "Soft",
-            "newline": { "pos": ["LinePos", 2, 0], "first": 13, "last": 27 },
-          },
-        ],
-        ["RightBrack", { "start": 22 }],
-      ],
-      { "pos": ["LinePos", 1, 0], "first": 0, "last": 11 },
-    ],
+    content=(
+      #|(
+      #|  CloserIndex({ RightBrack: <Set: [22]> }),
+      #|  Tokens(
+      #|    <Deque:
+      #|      [
+      #|        LinkStart({ start: 8, image: false }),
+      #|        Newline(
+      #|          {
+      #|            start: 12,
+      #|            break_ty: Soft,
+      #|            newline: { pos: LinePos(2, 0), first: 13, last: 27 },
+      #|          },
+      #|        ),
+      #|        RightBrack({ start: 22 }),
+      #|      ]>,
+      #|  ),
+      #|  { pos: LinePos(1, 0), first: 0, last: 11 },
+      #|)
+    ),
   )
 }
 
 ///|
 test "should parse broken links across lines" {
-  json_inspect(
+  debug_inspect(
     parse_only(
       (
         #|and the [end
         #|condition], wow
       ),
     ),
-    content=[
-      [0, ""],
-      [
-        "Inlines",
-        [
-          [
-            ["Text", ["and the [end"]],
-            [
-              "Break",
-              [{ "layout_before": [""], "ty": "Soft", "layout_after": [""] }],
-            ],
-            ["Text", ["condition], wow"]],
-          ],
-        ],
-      ],
-    ],
+    content=(
+      #|(
+      #|  (0, ""),
+      #|  Inlines(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          Text(
+      #|            {
+      #|              v: "and the [end",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Break(
+      #|            {
+      #|              v: {
+      #|                layout_before: {
+      #|                  v: "",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|                ty: Soft,
+      #|                layout_after: {
+      #|                  v: "",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Text(
+      #|            {
+      #|              v: "condition], wow",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
   )
 }
 
 ///|
 test "should parse raw HTML" {
-  json_inspect(
+  debug_inspect(
     parse_only(
       (
         #|<div><p>Some text</p></div>
       ),
     ),
-    content=[
-      [0, ""],
-      [
-        "Inlines",
-        [
-          [
-            [
-              "RawHtml",
-              [["InlineRawHtml", [{ "blanks": "", "node": ["<div>"] }]]],
-            ],
-            [
-              "RawHtml",
-              [["InlineRawHtml", [{ "blanks": "", "node": ["<p>"] }]]],
-            ],
-            ["Text", ["Some text"]],
-            [
-              "RawHtml",
-              [["InlineRawHtml", [{ "blanks": "", "node": ["</p>"] }]]],
-            ],
-            [
-              "RawHtml",
-              [["InlineRawHtml", [{ "blanks": "", "node": ["</div>"] }]]],
-            ],
-          ],
-        ],
-      ],
-    ],
+    content=(
+      #|(
+      #|  (0, ""),
+      #|  Inlines(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          RawHtml(
+      #|            {
+      #|              v: InlineRawHtml(
+      #|                Seq(
+      #|                  [
+      #|                    {
+      #|                      blanks: "",
+      #|                      node: {
+      #|                        v: "<div>",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|              ),
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          RawHtml(
+      #|            {
+      #|              v: InlineRawHtml(
+      #|                Seq(
+      #|                  [
+      #|                    {
+      #|                      blanks: "",
+      #|                      node: {
+      #|                        v: "<p>",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|              ),
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Text(
+      #|            {
+      #|              v: "Some text",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          RawHtml(
+      #|            {
+      #|              v: InlineRawHtml(
+      #|                Seq(
+      #|                  [
+      #|                    {
+      #|                      blanks: "",
+      #|                      node: {
+      #|                        v: "</p>",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|              ),
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          RawHtml(
+      #|            {
+      #|              v: InlineRawHtml(
+      #|                Seq(
+      #|                  [
+      #|                    {
+      #|                      blanks: "",
+      #|                      node: {
+      #|                        v: "</div>",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|              ),
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
   )
-  json_inspect(
+  debug_inspect(
     parse_only(
       (
         #|foo <a href="\*" />u</a>
       ),
     ),
-    content=[
-      [0, ""],
-      [
-        "Inlines",
-        [
-          [
-            ["Text", ["foo "]],
-            [
-              "RawHtml",
-              [
-                [
-                  "InlineRawHtml",
-                  [{ "blanks": "", "node": ["<a href=\"\\*\" />"] }],
-                ],
-              ],
-            ],
-            ["Text", ["u"]],
-            [
-              "RawHtml",
-              [["InlineRawHtml", [{ "blanks": "", "node": ["</a>"] }]]],
-            ],
-          ],
-        ],
-      ],
-    ],
+    content=(
+      #|(
+      #|  (0, ""),
+      #|  Inlines(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          Text(
+      #|            {
+      #|              v: "foo ",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          RawHtml(
+      #|            {
+      #|              v: InlineRawHtml(
+      #|                Seq(
+      #|                  [
+      #|                    {
+      #|                      blanks: "",
+      #|                      node: {
+      #|                        v: "<a href=\"\\*\" />",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|              ),
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Text(
+      #|            {
+      #|              v: "u",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          RawHtml(
+      #|            {
+      #|              v: InlineRawHtml(
+      #|                Seq(
+      #|                  [
+      #|                    {
+      #|                      blanks: "",
+      #|                      node: {
+      #|                        v: "</a>",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|              ),
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
   )
-  json_inspect(
+  debug_inspect(
     parse_only(
       (
         #|Haha <a>a</a><b2
         #|       data="foo" > hihi this is not the end yet.
       ),
     ),
-    content=[
-      [0, ""],
-      [
-        "Inlines",
-        [
-          [
-            ["Text", ["Haha "]],
-            [
-              "RawHtml",
-              [["InlineRawHtml", [{ "blanks": "", "node": ["<a>"] }]]],
-            ],
-            ["Text", ["a"]],
-            [
-              "RawHtml",
-              [["InlineRawHtml", [{ "blanks": "", "node": ["</a>"] }]]],
-            ],
-            [
-              "RawHtml",
-              [
-                [
-                  "InlineRawHtml",
-                  [
-                    { "blanks": "", "node": ["<b2"] },
-                    { "blanks": "", "node": ["data=\"foo\" >"] },
-                  ],
-                ],
-              ],
-            ],
-            ["Text", [" hihi this is not the end yet."]],
-          ],
-        ],
-      ],
-    ],
+    content=(
+      #|(
+      #|  (0, ""),
+      #|  Inlines(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          Text(
+      #|            {
+      #|              v: "Haha ",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          RawHtml(
+      #|            {
+      #|              v: InlineRawHtml(
+      #|                Seq(
+      #|                  [
+      #|                    {
+      #|                      blanks: "",
+      #|                      node: {
+      #|                        v: "<a>",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|              ),
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Text(
+      #|            {
+      #|              v: "a",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          RawHtml(
+      #|            {
+      #|              v: InlineRawHtml(
+      #|                Seq(
+      #|                  [
+      #|                    {
+      #|                      blanks: "",
+      #|                      node: {
+      #|                        v: "</a>",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|              ),
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          RawHtml(
+      #|            {
+      #|              v: InlineRawHtml(
+      #|                Seq(
+      #|                  [
+      #|                    {
+      #|                      blanks: "",
+      #|                      node: {
+      #|                        v: "<b2",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    },
+      #|                    {
+      #|                      blanks: "",
+      #|                      node: {
+      #|                        v: "data=\"foo\" >",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|              ),
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Text(
+      #|            {
+      #|              v: " hihi this is not the end yet.",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
   )
 }
 
@@ -778,235 +2852,334 @@ test "should parse raw HTML" {
 test "should tokenize nested strikethroughs and emphases" {
   let doc =
     #|Nesting the nest ~~*emph2* ~~stroke~~ *emph3 **emph4  ~~strikeagain~~***~~
-  json_inspect(tokenize_only(doc, strict=false), content=[
-    [
-      "CloserIndex",
-      { "EmphasisMarks('*')": [19, 25, 69], "StrikethroughMarks": [35, 67, 72] },
-    ],
-    [
-      [
-        "StrikethroughMarks",
-        { "start": 17, "may_open": true, "may_close": false },
-      ],
-      [
-        "EmphasisMarks",
-        {
-          "start": 19,
-          "char": "*",
-          "count": 1,
-          "may_open": true,
-          "may_close": true,
-        },
-      ],
-      [
-        "EmphasisMarks",
-        {
-          "start": 25,
-          "char": "*",
-          "count": 1,
-          "may_open": false,
-          "may_close": true,
-        },
-      ],
-      [
-        "StrikethroughMarks",
-        { "start": 27, "may_open": true, "may_close": false },
-      ],
-      [
-        "StrikethroughMarks",
-        { "start": 35, "may_open": false, "may_close": true },
-      ],
-      [
-        "EmphasisMarks",
-        {
-          "start": 38,
-          "char": "*",
-          "count": 1,
-          "may_open": true,
-          "may_close": false,
-        },
-      ],
-      [
-        "EmphasisMarks",
-        {
-          "start": 45,
-          "char": "*",
-          "count": 2,
-          "may_open": true,
-          "may_close": false,
-        },
-      ],
-      [
-        "StrikethroughMarks",
-        { "start": 54, "may_open": true, "may_close": false },
-      ],
-      [
-        "StrikethroughMarks",
-        { "start": 67, "may_open": true, "may_close": true },
-      ],
-      [
-        "EmphasisMarks",
-        {
-          "start": 69,
-          "char": "*",
-          "count": 3,
-          "may_open": true,
-          "may_close": true,
-        },
-      ],
-      [
-        "StrikethroughMarks",
-        { "start": 72, "may_open": false, "may_close": true },
-      ],
-    ],
-    { "pos": ["LinePos", 1, 0], "first": 0, "last": 73 },
-  ])
+  debug_inspect(
+    tokenize_only(doc, strict=false),
+    content=(
+      #|(
+      #|  CloserIndex(
+      #|    {
+      #|      EmphasisMarks('*'): <Set: [19, 25, 69]>,
+      #|      StrikethroughMarks: <Set: [35, 67, 72]>,
+      #|    },
+      #|  ),
+      #|  Tokens(
+      #|    <Deque:
+      #|      [
+      #|        StrikethroughMarks({ start: 17, may_open: true, may_close: false }),
+      #|        EmphasisMarks({ start: 19, char: '*', count: 1, may_open: true, may_close: true }),
+      #|        EmphasisMarks({ start: 25, char: '*', count: 1, may_open: false, may_close: true }),
+      #|        StrikethroughMarks({ start: 27, may_open: true, may_close: false }),
+      #|        StrikethroughMarks({ start: 35, may_open: false, may_close: true }),
+      #|        EmphasisMarks({ start: 38, char: '*', count: 1, may_open: true, may_close: false }),
+      #|        EmphasisMarks({ start: 45, char: '*', count: 2, may_open: true, may_close: false }),
+      #|        StrikethroughMarks({ start: 54, may_open: true, may_close: false }),
+      #|        StrikethroughMarks({ start: 67, may_open: true, may_close: true }),
+      #|        EmphasisMarks({ start: 69, char: '*', count: 3, may_open: true, may_close: true }),
+      #|        StrikethroughMarks({ start: 72, may_open: false, may_close: true }),
+      #|      ]>,
+      #|  ),
+      #|  { pos: LinePos(1, 0), first: 0, last: 73 },
+      #|)
+    ),
+  )
 }
 
 ///|
 test "should parse strikethroughs" {
-  json_inspect(
+  debug_inspect(
     parse_only(
       strict=false,
       (
         #|Nesting the nest ~~*emph2* ~~stroke~~ *emph3 **emph4  ~~strikeagain~~***~~
       ),
     ),
-    content=[
-      [0, ""],
-      [
-        "Inlines",
-        [
-          [
-            ["Text", ["Nesting the nest "]],
-            [
-              "ExtStrikethrough",
-              [
-                [
-                  "InlineStrikethrough",
-                  [
-                    "Inlines",
-                    [
-                      [
-                        [
-                          "Emphasis",
-                          [{ "delim": "*", "inline": ["Text", ["emph2"]] }],
-                        ],
-                        ["Text", [" "]],
-                        [
-                          "ExtStrikethrough",
-                          [["InlineStrikethrough", ["Text", ["stroke"]]]],
-                        ],
-                        ["Text", [" "]],
-                        [
-                          "Emphasis",
-                          [
-                            {
-                              "delim": "*",
-                              "inline": [
-                                "Inlines",
-                                [
-                                  [
-                                    ["Text", ["emph3 "]],
-                                    [
-                                      "StrongEmphasis",
-                                      [
-                                        {
-                                          "delim": "*",
-                                          "inline": [
-                                            "Inlines",
-                                            [
-                                              [
-                                                ["Text", ["emph4  "]],
-                                                [
-                                                  "ExtStrikethrough",
-                                                  [
-                                                    [
-                                                      "InlineStrikethrough",
-                                                      ["Text", ["strikeagain"]],
-                                                    ],
-                                                  ],
-                                                ],
-                                              ],
-                                            ],
-                                          ],
-                                        },
-                                      ],
-                                    ],
-                                  ],
-                                ],
-                              ],
-                            },
-                          ],
-                        ],
-                      ],
-                    ],
-                  ],
-                ],
-              ],
-            ],
-          ],
-        ],
-      ],
-    ],
+    content=(
+      #|(
+      #|  (0, ""),
+      #|  Inlines(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          Text(
+      #|            {
+      #|              v: "Nesting the nest ",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          ExtStrikethrough(
+      #|            {
+      #|              v: InlineStrikethrough(
+      #|                Inlines(
+      #|                  {
+      #|                    v: Seq(
+      #|                      [
+      #|                        Emphasis(
+      #|                          {
+      #|                            v: { delim: '*', inline: Text(...) },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: " ",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        ExtStrikethrough(
+      #|                          {
+      #|                            v: InlineStrikethrough(Text(...)),
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Text(
+      #|                          {
+      #|                            v: " ",
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                        Emphasis(
+      #|                          {
+      #|                            v: { delim: '*', inline: Inlines(...) },
+      #|                            meta: {
+      #|                              id: 0,
+      #|                              loc: {
+      #|                                file: "-",
+      #|                                first_ccode: -1,
+      #|                                last_ccode: -1,
+      #|                                first_line: ...,
+      #|                                last_line: ...,
+      #|                              },
+      #|                              extra: None,
+      #|                            },
+      #|                          },
+      #|                        ),
+      #|                      ],
+      #|                    ),
+      #|                    meta: {
+      #|                      id: 0,
+      #|                      loc: {
+      #|                        file: "-",
+      #|                        first_ccode: -1,
+      #|                        last_ccode: -1,
+      #|                        first_line: LinePos(-1, -1),
+      #|                        last_line: LinePos(-1, -1),
+      #|                      },
+      #|                      extra: None,
+      #|                    },
+      #|                  },
+      #|                ),
+      #|              ),
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
   )
 }
 
 ///|
 test "should tokenize inline math" {
-  json_inspect(
+  debug_inspect(
     tokenize_only(
       strict=false,
       (
         #| This is $\LaTeX$ !!
       ),
     ),
-    content=[
-      ["CloserIndex", { "MathSpanMarks(1)": [16] }],
-      [
-        [
-          "MathSpanMarks",
-          { "start": 9, "count": 1, "may_open": true, "may_close": false },
-        ],
-        [
-          "MathSpanMarks",
-          { "start": 16, "count": 1, "may_open": false, "may_close": true },
-        ],
-      ],
-      { "pos": ["LinePos", 1, 0], "first": 1, "last": 19 },
-    ],
+    content=(
+      #|(
+      #|  CloserIndex({ MathSpanMarks(1): <Set: [16]> }),
+      #|  Tokens(
+      #|    <Deque:
+      #|      [
+      #|        MathSpanMarks({ start: 9, count: 1, may_open: true, may_close: false }),
+      #|        MathSpanMarks({ start: 16, count: 1, may_open: false, may_close: true }),
+      #|      ]>,
+      #|  ),
+      #|  { pos: LinePos(1, 0), first: 1, last: 19 },
+      #|)
+    ),
   )
 }
 
 ///|
 test "should parse inline math" {
-  json_inspect(
+  debug_inspect(
     parse_only(
       strict=false,
       (
         #| This is $\LaTeX$ !!
       ),
     ),
-    content=[
-      [1, ""],
-      [
-        "Inlines",
-        [
-          [
-            ["Text", ["This is "]],
-            [
-              "ExtMathSpan",
-              [
-                {
-                  "display": false,
-                  "tex_layout": [{ "blanks": "", "node": ["\\LaTeX"] }],
-                },
-              ],
-            ],
-            ["Text", [" !!"]],
-          ],
-        ],
-      ],
-    ],
+    content=(
+      #|(
+      #|  (1, ""),
+      #|  Inlines(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          Text(
+      #|            {
+      #|              v: "This is ",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          ExtMathSpan(
+      #|            {
+      #|              v: {
+      #|                display: false,
+      #|                tex_layout: Seq(
+      #|                  [
+      #|                    {
+      #|                      blanks: "",
+      #|                      node: {
+      #|                        v: "\\LaTeX",
+      #|                        meta: {
+      #|                          id: 0,
+      #|                          loc: {
+      #|                            file: "-",
+      #|                            first_ccode: -1,
+      #|                            last_ccode: -1,
+      #|                            first_line: LinePos(-1, -1),
+      #|                            last_line: LinePos(-1, -1),
+      #|                          },
+      #|                          extra: None,
+      #|                        },
+      #|                      },
+      #|                    },
+      #|                  ],
+      #|                ),
+      #|              },
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Text(
+      #|            {
+      #|              v: " !!",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
   )
 }

--- a/src/cmark/inline_test.mbt
+++ b/src/cmark/inline_test.mbt
@@ -3,8 +3,13 @@ test "InlineAutolink::new with link" {
   let meta = @cmark_base.Meta::none()
   let link = @cmark.Node::new("example.com", meta~)
   let autolink = @cmark.InlineAutolink::new(link)
-  inspect(autolink.is_email, content="false")
-  inspect(autolink.link.v, content="example.com")
+  debug_inspect(autolink.is_email, content="false")
+  debug_inspect(
+    autolink.link.v,
+    content=(
+      #|"example.com"
+    ),
+  )
 }
 
 ///|
@@ -13,7 +18,7 @@ test "Inline::is_empty checks if inline content is empty" {
 
   // Test empty inlines list
   let empty_inlines = @cmark.Inline::Inlines({ v: @cmark.Seq::empty(), meta })
-  inspect(empty_inlines.is_empty(), content="true")
+  debug_inspect(empty_inlines.is_empty(), content="true")
 
   // Test non-empty inlines list
   let text_node = @cmark.Inline::Text(@cmark.Node::new("text", meta~))
@@ -21,15 +26,15 @@ test "Inline::is_empty checks if inline content is empty" {
     v: @cmark.Seq::from_array([text_node]),
     meta,
   })
-  inspect(non_empty_inlines.is_empty(), content="false")
+  debug_inspect(non_empty_inlines.is_empty(), content="false")
 
   // Test empty text
   let empty_text = @cmark.Inline::Text(@cmark.Node::new("", meta~))
-  inspect(empty_text.is_empty(), content="true")
+  debug_inspect(empty_text.is_empty(), content="true")
 
   // Test non-empty text
   let non_empty_text = @cmark.Inline::Text(@cmark.Node::new("Some text", meta~))
-  inspect(non_empty_text.is_empty(), content="false")
+  debug_inspect(non_empty_text.is_empty(), content="false")
 
   // Test other cases which always return false
   let al_node = @cmark.Node::new(
@@ -37,28 +42,33 @@ test "Inline::is_empty checks if inline content is empty" {
     meta~,
   )
   let autolink = @cmark.Inline::Autolink(al_node)
-  inspect(autolink.is_empty(), content="false")
+  debug_inspect(autolink.is_empty(), content="false")
 }
 
 ///|
 test "InlineCodeSpan::code with empty content" {
   let empty_code = @cmark.InlineCodeSpan::from_string("")
-  inspect(empty_code.code(), content="")
+  debug_inspect(
+    empty_code.code(),
+    content=(
+      #|""
+    ),
+  )
 }
 
 ///|
 test "is_unsafe for data URLs" {
   // Test data URL with image/gif
   let data_url = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-  inspect(@cmark.InlineLink::is_unsafe(data_url), content="false")
+  debug_inspect(@cmark.InlineLink::is_unsafe(data_url), content="false")
 
   // Test data URL with missing comma after base64
   let invalid_data = "data:image/gif;base64"
-  inspect(@cmark.InlineLink::is_unsafe(invalid_data), content="true")
+  debug_inspect(@cmark.InlineLink::is_unsafe(invalid_data), content="true")
 
   // Test data URL with no semicolon
   let data_no_semi = "data:image/gif,content"
-  inspect(@cmark.InlineLink::is_unsafe(data_no_semi), content="false")
+  debug_inspect(@cmark.InlineLink::is_unsafe(data_no_semi), content="false")
 }
 
 ///|
@@ -68,10 +78,10 @@ test "is_unsafe for data URLs with various media types" {
   let data_png = "data:image/png,iVBOR"
   let data_jpeg = "data:image/jpeg,/9j/4"
   let data_webp = "data:image/webp,UklGR"
-  inspect(@cmark.InlineLink::is_unsafe(data_gif), content="false")
-  inspect(@cmark.InlineLink::is_unsafe(data_png), content="false")
-  inspect(@cmark.InlineLink::is_unsafe(data_jpeg), content="false")
-  inspect(@cmark.InlineLink::is_unsafe(data_webp), content="false")
+  debug_inspect(@cmark.InlineLink::is_unsafe(data_gif), content="false")
+  debug_inspect(@cmark.InlineLink::is_unsafe(data_png), content="false")
+  debug_inspect(@cmark.InlineLink::is_unsafe(data_jpeg), content="false")
+  debug_inspect(@cmark.InlineLink::is_unsafe(data_webp), content="false")
 }
 
 ///|
@@ -80,7 +90,7 @@ test "referenced_label with inline reference" {
   let link_def = @cmark.Node::new(@cmark.LinkDefinition::new())
   let inline_ref = @cmark.ReferenceKind::Inline(link_def)
   let link = @cmark.InlineLink::new(text, inline_ref)
-  inspect(link.referenced_label(), content="None")
+  debug_inspect(link.referenced_label(), content="None")
 }
 
 ///|
@@ -93,28 +103,48 @@ test "inline id with text containing backticks" {
       ]),
     }),
   )
-  inspect(inline.id(), content="text")
+  debug_inspect(
+    inline.id(),
+    content=(
+      #|"text"
+    ),
+  )
 }
 
 ///|
 test "inline id with whitespace and punctuation" {
   let text = " Hello, World! \t"
   let inline = @cmark.Inline::Text(@cmark.Node::new(text))
-  inspect(inline.id(), content="hello-world")
+  debug_inspect(
+    inline.id(),
+    content=(
+      #|"hello-world"
+    ),
+  )
 }
 
 ///|
 test "inline id with underscore and dash" {
   let text = "hello_world-test"
   let inline = @cmark.Inline::Text(@cmark.Node::new(text))
-  inspect(inline.id(), content="hello_world-test")
+  debug_inspect(
+    inline.id(),
+    content=(
+      #|"hello_world-test"
+    ),
+  )
 }
 
 ///|
 test "inline id with mixed case and punctuation" {
   let text = "Hello, World! This is a Test."
   let inline = @cmark.Inline::Text(@cmark.Node::new(text))
-  inspect(inline.id(), content="hello-world-this-is-a-test")
+  debug_inspect(
+    inline.id(),
+    content=(
+      #|"hello-world-this-is-a-test"
+    ),
+  )
 }
 
 ///|
@@ -129,10 +159,45 @@ test "Inline::normalize with Emphasis type" {
 
   // Normalize and check result
   let normalized = emphasis.normalize()
-  json_inspect(normalized, content=[
-    "Emphasis",
-    [{ "delim": "*", "inline": ["Text", ["emphasized text"]] }],
-  ])
+  debug_inspect(
+    normalized,
+    content=(
+      #|Emphasis(
+      #|  {
+      #|    v: {
+      #|      delim: '*',
+      #|      inline: Text(
+      #|        {
+      #|          v: "emphasized text",
+      #|          meta: {
+      #|            id: 0,
+      #|            loc: {
+      #|              file: "-",
+      #|              first_ccode: -1,
+      #|              last_ccode: -1,
+      #|              first_line: LinePos(-1, -1),
+      #|              last_line: LinePos(-1, -1),
+      #|            },
+      #|            extra: None,
+      #|          },
+      #|        },
+      #|      ),
+      #|    },
+      #|    meta: {
+      #|      id: 0,
+      #|      loc: {
+      #|        file: "-",
+      #|        first_ccode: -1,
+      #|        last_ccode: -1,
+      #|        first_line: LinePos(-1, -1),
+      #|        last_line: LinePos(-1, -1),
+      #|      },
+      #|      extra: None,
+      #|    },
+      #|  },
+      #|)
+    ),
+  )
 }
 
 ///|
@@ -147,10 +212,45 @@ test "Inline::normalize with StrongEmphasis type" {
 
   // Normalize and check result
   let normalized = strong.normalize()
-  json_inspect(normalized, content=[
-    "StrongEmphasis",
-    [{ "delim": "*", "inline": ["Text", ["strong text"]] }],
-  ])
+  debug_inspect(
+    normalized,
+    content=(
+      #|StrongEmphasis(
+      #|  {
+      #|    v: {
+      #|      delim: '*',
+      #|      inline: Text(
+      #|        {
+      #|          v: "strong text",
+      #|          meta: {
+      #|            id: 0,
+      #|            loc: {
+      #|              file: "-",
+      #|              first_ccode: -1,
+      #|              last_ccode: -1,
+      #|              first_line: LinePos(-1, -1),
+      #|              last_line: LinePos(-1, -1),
+      #|            },
+      #|            extra: None,
+      #|          },
+      #|        },
+      #|      ),
+      #|    },
+      #|    meta: {
+      #|      id: 0,
+      #|      loc: {
+      #|        file: "-",
+      #|        first_ccode: -1,
+      #|        last_ccode: -1,
+      #|        first_line: LinePos(-1, -1),
+      #|        last_line: LinePos(-1, -1),
+      #|      },
+      #|      extra: None,
+      #|    },
+      #|  },
+      #|)
+    ),
+  )
 }
 
 ///|
@@ -164,9 +264,19 @@ test "InlineBreak::new creates a break with specified parameters" {
     layout_after~,
     break_type,
   )
-  inspect(line_break.ty, content="Hard")
-  inspect(line_break.layout_before.v, content="  ")
-  inspect(line_break.layout_after.v, content="   ")
+  debug_inspect(line_break.ty, content="Hard")
+  debug_inspect(
+    line_break.layout_before.v,
+    content=(
+      #|"  "
+    ),
+  )
+  debug_inspect(
+    line_break.layout_after.v,
+    content=(
+      #|"   "
+    ),
+  )
 }
 
 ///|
@@ -178,7 +288,12 @@ test "Inline::id with null character" {
 
   // Should replace null with replacement character in output
   let id = text.id()
-  inspect(id, content="text�more")
+  debug_inspect(
+    id,
+    content=(
+      #|"text�more"
+    ),
+  )
 }
 
 ///|
@@ -195,7 +310,7 @@ test "Inline::normalize with Link type" {
   let normalized = link.normalize()
 
   // Check that the result is correctly normalized
-  inspect(normalized.is_empty(), content="false")
+  debug_inspect(normalized.is_empty(), content="false")
 }
 
 ///|
@@ -216,7 +331,27 @@ test "Inline::normalize with more complex Inlines structure" {
 
   // The normalization should flatten the nested Inlines and concat consecutive texts
   let normalized = outer_inlines.normalize()
-  json_inspect(normalized, content=["Text", ["firstsecond"]])
+  debug_inspect(
+    normalized,
+    content=(
+      #|Text(
+      #|  {
+      #|    v: "firstsecond",
+      #|    meta: {
+      #|      id: 0,
+      #|      loc: {
+      #|        file: "-",
+      #|        first_ccode: -1,
+      #|        last_ccode: -1,
+      #|        first_line: LinePos(-1, -1),
+      #|        last_line: LinePos(-1, -1),
+      #|      },
+      #|      extra: None,
+      #|    },
+      #|  },
+      #|)
+    ),
+  )
 }
 
 ///|
@@ -232,29 +367,73 @@ test "Inline::normalize with nested structures" {
 
   // Normalize and check that it correctly processed nested elements
   let normalized = image.normalize()
-  json_inspect(normalized, content=[
-    "Image",
-    [
-      {
-        "text": ["Text", ["alt text"]],
-        "reference": [
-          "Inline",
-          [
-            {
-              "layout": {
-                "indent": 0,
-                "angled_dest": false,
-                "before_dest": [],
-                "after_dest": [],
-                "title_open_delim": "\"",
-                "after_title": [],
-              },
-            },
-          ],
-        ],
-      },
-    ],
-  ])
+  debug_inspect(
+    normalized,
+    content=(
+      #|Image(
+      #|  {
+      #|    v: {
+      #|      text: Text(
+      #|        {
+      #|          v: "alt text",
+      #|          meta: {
+      #|            id: 0,
+      #|            loc: {
+      #|              file: "-",
+      #|              first_ccode: -1,
+      #|              last_ccode: -1,
+      #|              first_line: LinePos(-1, -1),
+      #|              last_line: LinePos(-1, -1),
+      #|            },
+      #|            extra: None,
+      #|          },
+      #|        },
+      #|      ),
+      #|      reference: Inline(
+      #|        {
+      #|          v: {
+      #|            layout: {
+      #|              indent: 0,
+      #|              angled_dest: false,
+      #|              before_dest: Seq([]),
+      #|              after_dest: Seq([]),
+      #|              title_open_delim: '"',
+      #|              after_title: Seq([]),
+      #|            },
+      #|            label: None,
+      #|            defined_label: None,
+      #|            dest: None,
+      #|            title: None,
+      #|          },
+      #|          meta: {
+      #|            id: 0,
+      #|            loc: {
+      #|              file: "-",
+      #|              first_ccode: -1,
+      #|              last_ccode: -1,
+      #|              first_line: LinePos(-1, -1),
+      #|              last_line: LinePos(-1, -1),
+      #|            },
+      #|            extra: None,
+      #|          },
+      #|        },
+      #|      ),
+      #|    },
+      #|    meta: {
+      #|      id: 0,
+      #|      loc: {
+      #|        file: "-",
+      #|        first_ccode: -1,
+      #|        last_ccode: -1,
+      #|        first_line: LinePos(-1, -1),
+      #|        last_line: LinePos(-1, -1),
+      #|      },
+      #|      extra: None,
+      #|    },
+      #|  },
+      #|)
+    ),
+  )
 }
 
 ///|
@@ -271,10 +450,42 @@ test "Inline::normalize with ExtStrikethrough type" {
 
   // Normalize and check
   let normalized = strikethrough.normalize()
-  inspect(
+  debug_inspect(
     normalized,
     content=(
-      #|ExtStrikethrough(Node::new(InlineStrikethrough(Text(Node::new("strikethrough")))))
+      #|ExtStrikethrough(
+      #|  {
+      #|    v: InlineStrikethrough(
+      #|      Text(
+      #|        {
+      #|          v: "strikethrough",
+      #|          meta: {
+      #|            id: 0,
+      #|            loc: {
+      #|              file: "-",
+      #|              first_ccode: -1,
+      #|              last_ccode: -1,
+      #|              first_line: LinePos(-1, -1),
+      #|              last_line: LinePos(-1, -1),
+      #|            },
+      #|            extra: None,
+      #|          },
+      #|        },
+      #|      ),
+      #|    ),
+      #|    meta: {
+      #|      id: 0,
+      #|      loc: {
+      #|        file: "-",
+      #|        first_ccode: -1,
+      #|        last_ccode: -1,
+      #|        first_line: LinePos(-1, -1),
+      #|        last_line: LinePos(-1, -1),
+      #|      },
+      #|      extra: None,
+      #|    },
+      #|  },
+      #|)
     ),
   )
 }
@@ -295,21 +506,31 @@ test "Inline::normalize with complex structure - has nested inlines" {
 
   // Normalize should flatten nested Inlines
   let normalized = outer.normalize()
-  inspect(normalized.is_empty(), content="false")
+  debug_inspect(normalized.is_empty(), content="false")
 }
 
 ///|
 test "InlineCodeSpan::from_string with simple content" {
   // Test with string that needs spaces (contains backticks)
   let code_with_backticks = @cmark.InlineCodeSpan::from_string("`code`")
-  inspect(code_with_backticks.code(), content="`code`")
+  debug_inspect(
+    code_with_backticks.code(),
+    content=(
+      #|"`code`"
+    ),
+  )
 }
 
 ///|
 test "InlineCodeSpan::from_string with empty string" {
   // Test with empty string
   let empty_code = @cmark.InlineCodeSpan::from_string("")
-  inspect(empty_code.code(), content="")
+  debug_inspect(
+    empty_code.code(),
+    content=(
+      #|""
+    ),
+  )
 }
 
 ///|
@@ -320,14 +541,24 @@ test "InlineCodeSpan::from_string with newlines" {
     meta~,
     "code\nwith\nnewlines",
   )
-  inspect(code_with_newlines.code(), content="code with newlines")
+  debug_inspect(
+    code_with_newlines.code(),
+    content=(
+      #|"code with newlines"
+    ),
+  )
 
   // Test with CRLF
   let code_with_crlf = @cmark.InlineCodeSpan::from_string(
     meta~,
     "code\r\nwith\r\ncrlf",
   )
-  inspect(code_with_crlf.code(), content="code with crlf")
+  debug_inspect(
+    code_with_crlf.code(),
+    content=(
+      #|"code with crlf"
+    ),
+  )
 }
 
 ///|
@@ -341,8 +572,13 @@ test "InlineCodeSpan::new creates a code span directly" {
 
   // Create with explicit backtick count
   let code_span = @cmark.InlineCodeSpan::new(backticks=2, code_layout)
-  inspect(code_span.backticks, content="2")
-  inspect(code_span.code(), content="code")
+  debug_inspect(code_span.backticks, content="2")
+  debug_inspect(
+    code_span.code(),
+    content=(
+      #|"code"
+    ),
+  )
 }
 
 ///|
@@ -359,7 +595,7 @@ test "Inline::to_plain_text with hard line break" {
     ),
   )
   let result = hard_break.to_plain_text(break_on_soft=false)
-  inspect(result.length(), content="2")
+  debug_inspect(result.length(), content="2")
 }
 
 ///|
@@ -378,11 +614,11 @@ test "Inline::to_plain_text with soft line break" {
 
   // With break_on_soft=true
   let result_true = soft_break.to_plain_text(break_on_soft=true)
-  inspect(result_true.length(), content="2")
+  debug_inspect(result_true.length(), content="2")
 
   // With break_on_soft=false
   let result_false = soft_break.to_plain_text(break_on_soft=false)
-  inspect(result_false.length(), content="1")
+  debug_inspect(result_false.length(), content="1")
 }
 
 ///|
@@ -393,7 +629,7 @@ test "Inline::to_plain_text with autolink" {
     @cmark.Node::new(@cmark.InlineAutolink::new(link_node), meta~),
   )
   let result = autolink.to_plain_text(break_on_soft=false)
-  inspect(result.length(), content="1")
+  debug_inspect(result.length(), content="1")
 }
 
 ///|
@@ -406,14 +642,14 @@ test "Inline::to_plain_text with emphasis and strong emphasis" {
     @cmark.Node::new({ delim: '*', inline: text }, meta~),
   )
   let emphasis_result = emphasis.to_plain_text(break_on_soft=false)
-  inspect(emphasis_result.length(), content="1")
+  debug_inspect(emphasis_result.length(), content="1")
 
   // Test with StrongEmphasis
   let strong = @cmark.Inline::StrongEmphasis(
     @cmark.Node::new({ delim: '*', inline: text }, meta~),
   )
   let strong_result = strong.to_plain_text(break_on_soft=false)
-  inspect(strong_result.length(), content="1")
+  debug_inspect(strong_result.length(), content="1")
 }
 
 ///|
@@ -427,7 +663,7 @@ test "Inline::to_plain_text with inlines and link" {
     @cmark.Node::new(@cmark.Seq::from_array([text1, text2]), meta~),
   )
   let inlines_result = inlines.to_plain_text(break_on_soft=false)
-  inspect(inlines_result.length(), content="1")
+  debug_inspect(inlines_result.length(), content="1")
 
   // Test with Link
   let link_def = @cmark.Node::new(@cmark.LinkDefinition::new(), meta~)
@@ -436,7 +672,7 @@ test "Inline::to_plain_text with inlines and link" {
     @cmark.Node::new({ text: text1, reference }, meta~),
   )
   let link_result = link.to_plain_text(break_on_soft=false)
-  inspect(link_result.length(), content="1")
+  debug_inspect(link_result.length(), content="1")
 }
 
 ///|
@@ -447,7 +683,7 @@ test "Inline::to_plain_text with raw html and strikethrough" {
   let raw_content = @cmark.Seq::from_array([@cmark.Tight::empty(meta~)])
   let raw_html = @cmark.Inline::RawHtml(@cmark.Node::new(raw_content, meta~))
   let raw_html_result = raw_html.to_plain_text(break_on_soft=false)
-  inspect(raw_html_result.length(), content="1")
+  debug_inspect(raw_html_result.length(), content="1")
 
   // Test with Strikethrough
   let text = @cmark.Inline::Text(@cmark.Node::new("strikethrough", meta~))
@@ -455,7 +691,7 @@ test "Inline::to_plain_text with raw html and strikethrough" {
     @cmark.Node::new(text, meta~),
   )
   let strikethrough_result = strikethrough.to_plain_text(break_on_soft=false)
-  inspect(strikethrough_result.length(), content="1")
+  debug_inspect(strikethrough_result.length(), content="1")
 }
 
 ///|
@@ -469,7 +705,7 @@ test "Inline::to_plain_text with math span" {
     @cmark.Node::new({ display: false, tex_layout }, meta~),
   )
   let math_result = math_span.to_plain_text(break_on_soft=false)
-  inspect(math_result.length(), content="1")
+  debug_inspect(math_result.length(), content="1")
 }
 
 ///|
@@ -486,5 +722,25 @@ test "Inline::normalize with singleton list" {
 
   // Normalize should return just the inner item
   let normalized = inlines.normalize()
-  inspect(normalized, content="Text(Node::new(\"single item\"))")
+  debug_inspect(
+    normalized,
+    content=(
+      #|Text(
+      #|  {
+      #|    v: "single item",
+      #|    meta: {
+      #|      id: 0,
+      #|      loc: {
+      #|        file: "-",
+      #|        first_ccode: -1,
+      #|        last_ccode: -1,
+      #|        first_line: LinePos(-1, -1),
+      #|        last_line: LinePos(-1, -1),
+      #|      },
+      #|      extra: None,
+      #|    },
+      #|  },
+      #|)
+    ),
+  )
 }

--- a/src/cmark/label.mbt
+++ b/src/cmark/label.mbt
@@ -10,7 +10,7 @@ pub(all) struct Label {
   meta : Meta
   key : LabelKey
   text : Seq[Tight]
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 /// The type for label keys. These are
@@ -46,7 +46,7 @@ pub fn Label::compare(self : Label, other : Label) -> Int {
 pub(all) enum LabelDef {
   LinkDef(Node[LinkDefinition])
   FootnoteDef(Node[Footnote])
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 pub type LabelDefs = Map[LabelKey, LabelDef]

--- a/src/cmark/link_definition.mbt
+++ b/src/cmark/link_definition.mbt
@@ -9,7 +9,7 @@ pub(all) struct LinkDefinition {
   defined_label : Label?
   dest : StringNode?
   title : Seq[Tight]?
-} derive(Eq, Show, ToJson)
+} derive(Eq, Debug)
 
 ///|
 pub fn LinkDefinition::new(
@@ -30,7 +30,7 @@ pub(all) struct LinkDefinitionLayout {
   after_dest : Seq[BlockLineBlank]
   title_open_delim : Char
   after_title : Seq[BlockLineBlank]
-} derive(Eq, Show, ToJson)
+} derive(Eq, Debug)
 
 ///|
 pub fn LinkDefinitionLayout::default() -> LinkDefinitionLayout {

--- a/src/cmark/link_definition_test.mbt
+++ b/src/cmark/link_definition_test.mbt
@@ -2,19 +2,19 @@
 test "link definition layout for destination with space" {
   let dest = "hello world"
   let layout = @cmark.LinkDefinitionLayout::for_dest(dest)
-  inspect(layout.angled_dest, content="true")
+  debug_inspect(layout.angled_dest, content="true")
 }
 
 ///|
 test "link definition layout for destination with control character" {
   let dest = "hello\u{0}world"
   let layout = @cmark.LinkDefinitionLayout::for_dest(dest)
-  inspect(layout.angled_dest, content="true")
+  debug_inspect(layout.angled_dest, content="true")
 }
 
 ///|
 test "link definition layout for normal destination" {
   let dest = "hello-world"
   let layout = @cmark.LinkDefinitionLayout::for_dest(dest)
-  inspect(layout.angled_dest, content="false")
+  debug_inspect(layout.angled_dest, content="false")
 }

--- a/src/cmark/mapper.mbt
+++ b/src/cmark/mapper.mbt
@@ -30,7 +30,7 @@ pub(all) struct MapperFn[A]((Mapper, A) -> MapperResult[A])
 pub(all) enum MapperResult[A] {
   Default
   Map(A?)
-} derive(Eq, Show, ToJson)
+} derive(Eq, Debug)
 
 ///|
 pub impl[A] Default for MapperResult[A] with default() {

--- a/src/cmark/mapper_test.mbt
+++ b/src/cmark/mapper_test.mbt
@@ -2,25 +2,25 @@
 test "mapper ret function" {
   // Test ret function by passing in different types of values
   let int_result = @cmark.Mapper::ret(42)
-  inspect(int_result, content="Map(Some(42))")
+  debug_inspect(int_result, content="Map(Some(42))")
   let str_result = @cmark.Mapper::ret("hello")
-  inspect(str_result, content="Map(Some(\"hello\"))")
+  debug_inspect(str_result, content="Map(Some(\"hello\"))")
   let bool_result = @cmark.Mapper::ret(true)
-  inspect(bool_result, content="Map(Some(true))")
+  debug_inspect(bool_result, content="Map(Some(true))")
 }
 
 ///|
 test "mapper delete function" {
   // Test delete function to ensure it returns None
   let delete_result : @cmark.MapperResult[Unit] = @cmark.Mapper::delete()
-  inspect(delete_result, content="Map(None)")
+  debug_inspect(delete_result, content="Map(None)")
 }
 
 ///|
 test "Default for MapperResult" {
   // Test Default impl
   let default_result : @cmark.MapperResult[Int] = @cmark.MapperResult::default()
-  inspect(default_result, content="Default")
+  debug_inspect(default_result, content="Default")
 }
 
 ///|
@@ -28,7 +28,7 @@ test "mapper_none" {
   // Create a new Mapper with default parameters
   let mapper = @cmark.Mapper::new()
   // Call none with any value to trigger line 44
-  inspect(mapper.none(42), content="Default")
+  debug_inspect(mapper.none(42), content="Default")
 }
 
 ///|
@@ -48,7 +48,7 @@ test "map_inline with Link returns None when text is None" {
     @cmark.Node::new(@cmark.InlineLink::new(text, reference)),
   )
   let result = mapper.map_inline(link)
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -59,10 +59,45 @@ test "map_inline with StrongEmphasis" {
     @cmark.Node::new({ delim: '*', inline: text }),
   )
   let result = mapper.map_inline(strong)
-  inspect(
+  debug_inspect(
     result,
     content=(
-      #|Some(StrongEmphasis(Node::new({delim: '*', inline: Text(Node::new("strongly emphasized text"))})))
+      #|Some(
+      #|  StrongEmphasis(
+      #|    {
+      #|      v: {
+      #|        delim: '*',
+      #|        inline: Text(
+      #|          {
+      #|            v: "strongly emphasized text",
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|      },
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
     ),
   )
 }
@@ -82,7 +117,7 @@ test "map_inline with StrongEmphasis returns None when inner inline is None" {
     @cmark.Node::new({ delim: '*', inline: text }),
   )
   let result = mapper.map_inline(strong)
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -94,10 +129,45 @@ test "map_inline with Emphasis" {
     @cmark.Node::new({ delim: '*', inline: text }),
   )
   let result = mapper.map_inline(emphasis)
-  inspect(
+  debug_inspect(
     result,
     content=(
-      #|Some(Emphasis(Node::new({delim: '*', inline: Text(Node::new("emphasized text"))})))
+      #|Some(
+      #|  Emphasis(
+      #|    {
+      #|      v: {
+      #|        delim: '*',
+      #|        inline: Text(
+      #|          {
+      #|            v: "emphasized text",
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|      },
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
     ),
   )
 }
@@ -117,7 +187,7 @@ test "map_inline with Emphasis returns None when inner text is None" {
     @cmark.Node::new({ delim: '*', inline: text }),
   )
   let result = mapper.map_inline(emphasis)
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -138,7 +208,29 @@ test "panic inline_ext_none raises error" {
 test "map_inline default case" {
   let mapper = @cmark.Mapper::new()
   let text = @cmark.Inline::Text(@cmark.Node::new("hello"))
-  inspect(mapper.map_inline(text), content="Some(Text(Node::new(\"hello\")))")
+  debug_inspect(
+    mapper.map_inline(text),
+    content=(
+      #|Some(
+      #|  Text(
+      #|    {
+      #|      v: "hello",
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
+  )
 }
 
 ///|
@@ -146,7 +238,27 @@ test "map_doc with empty document" {
   let mapper = @cmark.Mapper::new()
   let doc = @cmark.Doc::empty()
   let result = mapper.map_doc(doc)
-  inspect(result.block, content="Blocks(Node::new(Seq([])))")
+  debug_inspect(
+    result.block,
+    content=(
+      #|Blocks(
+      #|  {
+      #|    v: Seq([]),
+      #|    meta: {
+      #|      id: 0,
+      #|      loc: {
+      #|        file: "-",
+      #|        first_ccode: -1,
+      #|        last_ccode: -1,
+      #|        first_line: LinePos(-1, -1),
+      #|        last_line: LinePos(-1, -1),
+      #|      },
+      #|      extra: None,
+      #|    },
+      #|  },
+      #|)
+    ),
+  )
 }
 
 ///|
@@ -154,7 +266,7 @@ test "map_block blocks" {
   // Test blocks mapping
   let mapper = @cmark.Mapper::new()
   let blocks = @cmark.Block::Blocks(@cmark.Node::new(@cmark.Seq::empty()))
-  inspect(mapper.map_block(blocks), content="None")
+  debug_inspect(mapper.map_block(blocks), content="None")
 }
 
 ///|
@@ -162,7 +274,29 @@ test "map_block with default case" {
   let mapper = @cmark.Mapper::new()
   let block = @cmark.Block::BlankLine(@cmark.Node::new(""))
   let result = mapper.map_block(block)
-  inspect(result, content="Some(BlankLine(Node::new(\"\")))")
+  debug_inspect(
+    result,
+    content=(
+      #|Some(
+      #|  BlankLine(
+      #|    {
+      #|      v: "",
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
+  )
 }
 
 ///|
@@ -174,10 +308,46 @@ test "map_block with blocks" {
     ),
   )
   let result = mapper.map_block(block)
-  inspect(
+  debug_inspect(
     result,
     content=(
-      #|Some(Blocks(Node::new(Seq([BlankLine(Node::new(""))]))))
+      #|Some(
+      #|  Blocks(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          BlankLine(
+      #|            {
+      #|              v: "",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
     ),
   )
 }
@@ -193,18 +363,48 @@ test "map_block with paragraph" {
     }),
   )
   let result = mapper.map_block(paragraph)
-  json_inspect(result, content=[
-    [
-      "Paragraph",
-      [
-        {
-          "leading_indent": 0,
-          "inline": ["Text", ["paragraph"]],
-          "trailing_blanks": "",
-        },
-      ],
-    ],
-  ])
+  debug_inspect(
+    result,
+    content=(
+      #|Some(
+      #|  Paragraph(
+      #|    {
+      #|      v: {
+      #|        leading_indent: 0,
+      #|        inline: Text(
+      #|          {
+      #|            v: "paragraph",
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|        trailing_blanks: "",
+      #|      },
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
+  )
 }
 
 ///|
@@ -226,17 +426,34 @@ test "map_block with paragraph with empty inline" {
   }
   let mapper = @cmark.Mapper::new(inline=inline_fn)
   let result = mapper.map_block(paragraph)
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
 test "mapper map_inline identity" {
   let text = @cmark.Inline::Text(@cmark.Node::new("text"))
   let mapper = @cmark.Mapper::new()
-  inspect(
+  debug_inspect(
     mapper.map_inline(text),
     content=(
-      #|Some(Text(Node::new("text")))
+      #|Some(
+      #|  Text(
+      #|    {
+      #|      v: "text",
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
     ),
   )
 }
@@ -245,10 +462,27 @@ test "mapper map_inline identity" {
 test "mapper map_block identity" {
   let block = @cmark.Block::BlankLine(@cmark.Node::new(""))
   let mapper = @cmark.Mapper::new()
-  inspect(
+  debug_inspect(
     mapper.map_block(block),
     content=(
-      #|Some(BlankLine(Node::new("")))
+      #|Some(
+      #|  BlankLine(
+      #|    {
+      #|      v: "",
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
     ),
   )
 }
@@ -264,10 +498,73 @@ test "map_inline with Image" {
     @cmark.Node::new(@cmark.InlineLink::new(text, reference)),
   )
   let result = mapper.map_inline(image)
-  inspect(
+  debug_inspect(
     result,
     content=(
-      #|Some(Image(Node::new({text: Text(Node::new("alt text")), reference: Inline(Node::new({layout: {indent: 0, angled_dest: false, before_dest: Seq([]), after_dest: Seq([]), title_open_delim: '"', after_title: Seq([])}, label: None, defined_label: None, dest: None, title: None}))})))
+      #|Some(
+      #|  Image(
+      #|    {
+      #|      v: {
+      #|        text: Text(
+      #|          {
+      #|            v: "alt text",
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|        reference: Inline(
+      #|          {
+      #|            v: {
+      #|              layout: {
+      #|                indent: 0,
+      #|                angled_dest: false,
+      #|                before_dest: Seq([]),
+      #|                after_dest: Seq([]),
+      #|                title_open_delim: '"',
+      #|                after_title: Seq([]),
+      #|              },
+      #|              label: None,
+      #|              defined_label: None,
+      #|              dest: None,
+      #|              title: None,
+      #|            },
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|      },
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
     ),
   )
 }
@@ -282,10 +579,73 @@ test "map_inline with Link" {
     @cmark.Node::new(@cmark.InlineLink::new(text, reference)),
   )
   let result = mapper.map_inline(link)
-  inspect(
+  debug_inspect(
     result,
     content=(
-      #|Some(Link(Node::new({text: Text(Node::new("link text")), reference: Inline(Node::new({layout: {indent: 0, angled_dest: false, before_dest: Seq([]), after_dest: Seq([]), title_open_delim: '"', after_title: Seq([])}, label: None, defined_label: None, dest: None, title: None}))})))
+      #|Some(
+      #|  Link(
+      #|    {
+      #|      v: {
+      #|        text: Text(
+      #|          {
+      #|            v: "link text",
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|        reference: Inline(
+      #|          {
+      #|            v: {
+      #|              layout: {
+      #|                indent: 0,
+      #|                angled_dest: false,
+      #|                before_dest: Seq([]),
+      #|                after_dest: Seq([]),
+      #|                title_open_delim: '"',
+      #|                after_title: Seq([]),
+      #|              },
+      #|              label: None,
+      #|              defined_label: None,
+      #|              dest: None,
+      #|              title: None,
+      #|            },
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|      },
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
     ),
   )
 }
@@ -299,10 +659,45 @@ test "map_inline with Emphasis (2)" {
     @cmark.Node::new({ delim: '*', inline: text }),
   )
   let result = mapper.map_inline(emphasis)
-  inspect(
+  debug_inspect(
     result,
     content=(
-      #|Some(Emphasis(Node::new({delim: '*', inline: Text(Node::new("emphasized text"))})))
+      #|Some(
+      #|  Emphasis(
+      #|    {
+      #|      v: {
+      #|        delim: '*',
+      #|        inline: Text(
+      #|          {
+      #|            v: "emphasized text",
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|      },
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
     ),
   )
 }
@@ -325,7 +720,7 @@ test "map_inline with StrongEmphasis with None inline result" {
   }
   let mapper = @cmark.Mapper::new(inline=inline_fn)
   let result = mapper.map_inline(strong)
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -337,9 +732,63 @@ test "map_inline with Inlines" {
   ])
   let inlines = @cmark.Inline::Inlines(@cmark.Node::new(seq))
   let result = mapper.map_inline(inlines)
-  inspect(
+  debug_inspect(
     result,
-    content="Some(Inlines(Node::new(Seq([Text(Node::new(\"text 1\")), Text(Node::new(\"text 2\"))]))))",
+    content=(
+      #|Some(
+      #|  Inlines(
+      #|    {
+      #|      v: Seq(
+      #|        [
+      #|          Text(
+      #|            {
+      #|              v: "text 1",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|          Text(
+      #|            {
+      #|              v: "text 2",
+      #|              meta: {
+      #|                id: 0,
+      #|                loc: {
+      #|                  file: "-",
+      #|                  first_ccode: -1,
+      #|                  last_ccode: -1,
+      #|                  first_line: LinePos(-1, -1),
+      #|                  last_line: LinePos(-1, -1),
+      #|                },
+      #|                extra: None,
+      #|              },
+      #|            },
+      #|          ),
+      #|        ],
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
   )
 }
 
@@ -360,7 +809,7 @@ test "map_inline with Inlines that becomes empty" {
   }
   let mapper = @cmark.Mapper::new(inline=inline_fn)
   let result = mapper.map_inline(inlines)
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -372,10 +821,44 @@ test "map_inline with ExtStrikethrough" {
     ),
   )
   let result = mapper.map_inline(strikethrough)
-  inspect(
+  debug_inspect(
     result,
     content=(
-      #|Some(ExtStrikethrough(Node::new(InlineStrikethrough(Text(Node::new("strikethrough text"))))))
+      #|Some(
+      #|  ExtStrikethrough(
+      #|    {
+      #|      v: InlineStrikethrough(
+      #|        Text(
+      #|          {
+      #|            v: "strikethrough text",
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|      ),
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
     ),
   )
 }
@@ -397,7 +880,7 @@ test "map_inline with ExtStrikethrough with None inline result" {
   }
   let mapper = @cmark.Mapper::new(inline=inline_fn)
   let result = mapper.map_inline(strikethrough)
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -417,10 +900,47 @@ test "map_block with Heading" {
     }),
   )
   let result = mapper.map_block(heading)
-  inspect(
+  debug_inspect(
     result,
     content=(
-      #|Some(Heading(Node::new({layout: Atx({indent: 0, after_opening: "", closing: ""}), level: 1, inline: Text(Node::new("Heading")), id: None})))
+      #|Some(
+      #|  Heading(
+      #|    {
+      #|      v: {
+      #|        layout: Atx({ indent: 0, after_opening: "", closing: "" }),
+      #|        level: 1,
+      #|        inline: Text(
+      #|          {
+      #|            v: "Heading",
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|        id: None,
+      #|      },
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
     ),
   )
 }
@@ -439,8 +959,64 @@ test "map_block with BlockQuote" {
     @cmark.Node::new({ indent: 0, block: para }),
   )
   let result = mapper.map_block(blockquote)
-  inspect(
+  debug_inspect(
     result,
-    content="Some(BlockQuote(Node::new({indent: 0, block: Paragraph(Node::new({leading_indent: 0, inline: Text(Node::new(\"quoted text\")), trailing_blanks: \"\"}))})))",
+    content=(
+      #|Some(
+      #|  BlockQuote(
+      #|    {
+      #|      v: {
+      #|        indent: 0,
+      #|        block: Paragraph(
+      #|          {
+      #|            v: {
+      #|              leading_indent: 0,
+      #|              inline: Text(
+      #|                {
+      #|                  v: "quoted text",
+      #|                  meta: {
+      #|                    id: 0,
+      #|                    loc: {
+      #|                      file: "-",
+      #|                      first_ccode: -1,
+      #|                      last_ccode: -1,
+      #|                      first_line: LinePos(-1, -1),
+      #|                      last_line: LinePos(-1, -1),
+      #|                    },
+      #|                    extra: None,
+      #|                  },
+      #|                },
+      #|              ),
+      #|              trailing_blanks: "",
+      #|            },
+      #|            meta: {
+      #|              id: 0,
+      #|              loc: {
+      #|                file: "-",
+      #|                first_ccode: -1,
+      #|                last_ccode: -1,
+      #|                first_line: LinePos(-1, -1),
+      #|                last_line: LinePos(-1, -1),
+      #|              },
+      #|              extra: None,
+      #|            },
+      #|          },
+      #|        ),
+      #|      },
+      #|      meta: {
+      #|        id: 0,
+      #|        loc: {
+      #|          file: "-",
+      #|          first_ccode: -1,
+      #|          last_ccode: -1,
+      #|          first_line: LinePos(-1, -1),
+      #|          last_line: LinePos(-1, -1),
+      #|        },
+      #|        extra: None,
+      #|      },
+      #|    },
+      #|  ),
+      #|)
+    ),
   )
 }

--- a/src/cmark/moon.pkg
+++ b/src/cmark/moon.pkg
@@ -4,6 +4,7 @@ import {
   "moonbit-community/cmark/char",
   "moonbit-community/cmark/cmark_base",
   "moonbitlang/core/cmp",
+  "moonbitlang/core/debug",
   "moonbitlang/core/deque",
   "moonbitlang/core/sorted_set",
   "moonbitlang/core/json",

--- a/src/cmark/node.mbt
+++ b/src/cmark/node.mbt
@@ -2,7 +2,7 @@
 pub(all) struct Node[A] {
   v : A
   meta : Meta
-} derive(Eq)
+} derive(Eq, Debug)
 
 ///|
 pub fn[A] Node::new(v : A, meta? : Meta = Meta::none()) -> Node[A] {
@@ -12,26 +12,6 @@ pub fn[A] Node::new(v : A, meta? : Meta = Meta::none()) -> Node[A] {
 ///|
 pub fn[A, B] Node::map(self : Node[A], f : (A) -> B) -> Node[B] {
   { v: f(self.v), meta: self.meta }
-}
-
-///|
-pub impl[A : Show] Show for Node[A] with output(self, logger) {
-  logger.write_string("Node::new(")
-  logger.write_object(self.v)
-  if !self.meta.is_none() {
-    logger.write_string(", meta=")
-    logger.write_object(self.meta)
-  }
-  logger.write_char(')')
-}
-
-///|
-pub impl[A : ToJson] ToJson for Node[A] with to_json(self) {
-  let jsons = [self.v.to_json()]
-  if !self.meta.is_none() {
-    jsons.push(self.meta.to_json())
-  }
-  Json::array(jsons)
 }
 
 ///|

--- a/src/cmark/node_test.mbt
+++ b/src/cmark/node_test.mbt
@@ -3,6 +3,11 @@ test "node_map" {
   let meta = @cmark_base.Meta::new()
   let node = @cmark.Node::new("test", meta~)
   let mapped = node.map(fn(s) { s + "!" })
-  inspect(mapped.v, content="test!")
-  inspect(mapped.meta.is_none(), content="false")
+  debug_inspect(
+    mapped.v,
+    content=(
+      #|"test!"
+    ),
+  )
+  debug_inspect(mapped.meta.is_none(), content="false")
 }

--- a/src/cmark/pkg.generated.mbti
+++ b/src/cmark/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "moonbit-community/cmark/cmark"
 
 import {
   "moonbit-community/cmark/cmark_base",
+  "moonbitlang/core/debug",
   "moonbitlang/core/json",
 }
 
@@ -18,11 +19,13 @@ pub fn layout_of_string(meta? : @cmark_base.Meta, String) -> Node[String]
 // Errors
 pub(all) suberror FolderError {
   FolderError(String)
-} derive(Show)
+} derive(@debug.Debug)
+pub impl Show for FolderError
 
 pub(all) suberror MapperError {
   MapperError(String)
-} derive(Show)
+} derive(@debug.Debug)
+pub impl Show for MapperError
 
 // Types and methods
 pub(all) enum Block {
@@ -39,7 +42,7 @@ pub(all) enum Block {
   ExtMathBlock(Node[CodeBlock])
   ExtTable(Node[Table])
   ExtFootnoteDefinition(Node[Footnote])
-} derive(Show, ToJson)
+} derive(@debug.Debug)
 pub fn Block::defs(Self, init? : Map[String, LabelDef]) -> Map[String, LabelDef]
 pub fn Block::empty() -> Self
 pub fn Block::meta(Self) -> @cmark_base.Meta
@@ -50,25 +53,25 @@ pub(all) struct BlockHeading {
   level : Int
   inline : Inline
   id : BlockHeadingId?
-} derive(Show, ToJson)
+} derive(@debug.Debug)
 pub fn BlockHeading::new(id? : BlockHeadingId?, layout? : BlockHeadingLayout, level~ : Int, Inline) -> Self
 
 pub(all) struct BlockHeadingAtxLayout {
   indent : Int
   after_opening : String
   closing : String
-} derive(Show, ToJson, @json.FromJson)
+} derive(ToJson, @debug.Debug, @json.FromJson)
 pub fn BlockHeadingAtxLayout::default() -> Self
 
 pub(all) enum BlockHeadingId {
   Auto(String)
   Id(String)
-} derive(Show, ToJson, @json.FromJson)
+} derive(ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) enum BlockHeadingLayout {
   Atx(BlockHeadingAtxLayout)
   Setext(BlockHeadingSetextLayout)
-} derive(Show, ToJson)
+} derive(@debug.Debug)
 
 pub(all) struct BlockHeadingSetextLayout {
   leading_indent : Int
@@ -76,7 +79,7 @@ pub(all) struct BlockHeadingSetextLayout {
   underline_indent : Int
   underline_count : Node[Int]
   underline_blanks : String
-} derive(Show, ToJson)
+} derive(@debug.Debug)
 
 pub(all) struct BlockLine(Node[String])
 pub fn BlockLine::list_text_loc(Seq[Self]) -> @cmark_base.TextLoc
@@ -86,7 +89,7 @@ pub(all) struct BlockList {
   ty : @cmark_base.ListType
   tight : Bool
   items : Seq[Node[ListItem]]
-} derive(Show, ToJson)
+} derive(@debug.Debug)
 pub fn BlockList::map_items(Self, (ListItem) -> ListItem) -> Self
 pub fn BlockList::normalize_items(Self) -> Self
 
@@ -94,13 +97,13 @@ pub(all) struct BlockParagraph {
   leading_indent : Int
   inline : Inline
   trailing_blanks : String
-} derive(Show, ToJson)
+} derive(@debug.Debug)
 pub fn BlockParagraph::new(leading_indent? : Int, trailing_blanks? : String, Inline) -> Self
 
 pub(all) struct BlockQuote {
   indent : Int
   block : Block
-} derive(Show, ToJson)
+} derive(@debug.Debug)
 pub fn BlockQuote::map_block(Self, (Block) -> Block) -> Self
 pub fn BlockQuote::new(indent? : Int, Block) -> Self
 pub fn BlockQuote::normalize_block(Self) -> Self
@@ -108,14 +111,14 @@ pub fn BlockQuote::normalize_block(Self) -> Self
 pub(all) struct BlockThematicBreak {
   indent : Int
   layout : String
-} derive(Show, ToJson, @json.FromJson)
+} derive(ToJson, @debug.Debug, @json.FromJson)
 pub fn BlockThematicBreak::new(indent? : Int, layout? : String) -> Self
 
 pub(all) struct CodeBlock {
   layout : CodeBlockLayout
   info_string : Node[String]?
   code : Seq[Node[String]]
-} derive(Show, ToJson)
+} derive(@debug.Debug)
 pub fn CodeBlock::language_of_info_string(String) -> (String, String)?
 pub fn CodeBlock::make_fence(Self) -> (Char, Int)
 pub fn CodeBlock::new(layout? : CodeBlockLayout, info_string? : Node[String]?, Seq[Node[String]]) -> Self
@@ -124,19 +127,19 @@ pub(all) struct CodeBlockFencedLayout {
   indent : Int
   opening_fence : Node[String]
   closing_fence : Node[String]?
-} derive(Show, ToJson)
+} derive(@debug.Debug)
 pub fn CodeBlockFencedLayout::default() -> Self
 
 pub(all) enum CodeBlockLayout {
   Indented
   Fenced(CodeBlockFencedLayout)
-} derive(Show, ToJson)
+} derive(@debug.Debug)
 
 pub(all) struct Doc {
   nl : String
   block : Block
   defs : Map[String, LabelDef]
-} derive(Show, ToJson)
+} derive(@debug.Debug)
 pub fn Doc::empty() -> Self
 pub fn Doc::from_string(defs? : Map[String, LabelDef], resolver? : LabelResolverFn, nested_links? : Bool, heading_auto_ids? : Bool, layout? : Bool, locs? : Bool, file? : String, strict? : Bool, String) -> Self
 pub fn Doc::new(nl? : String, defs? : Map[String, LabelDef], Block) -> Self
@@ -163,7 +166,7 @@ pub(all) struct FolderFn[A, B]((Folder[B], B, A) -> FolderResult[B])
 pub(all) enum FolderResult[A] {
   Default
   Fold(A)
-} derive(Eq, Show, ToJson)
+} derive(Eq, @debug.Debug)
 pub impl[A] Default for FolderResult[A]
 
 pub(all) struct Footnote {
@@ -171,12 +174,12 @@ pub(all) struct Footnote {
   label : Label
   defined_label : Label?
   block : Block
-} derive(Show, ToJson)
+} derive(@debug.Debug)
 pub fn Footnote::map_block(Self, (Block) -> Block) -> Self
 pub fn Footnote::new(indent? : Int, defined_label? : Label?, Label, Block) -> Self
 pub fn Footnote::normalize_block(Self) -> Self
 
-pub(all) struct HtmlBlock(Seq[Node[String]]) derive(Show, ToJson)
+pub(all) struct HtmlBlock(Seq[Node[String]]) derive(@debug.Debug)
 
 pub(all) enum Inline {
   Autolink(Node[InlineAutolink])
@@ -191,7 +194,7 @@ pub(all) enum Inline {
   Text(Node[String])
   ExtStrikethrough(Node[InlineStrikethrough])
   ExtMathSpan(Node[InlineMathSpan])
-} derive(Eq, Show, ToJson)
+} derive(Eq, @debug.Debug)
 pub fn Inline::empty() -> Self
 pub fn Inline::id(Self, buf? : StringBuilder) -> String
 pub fn Inline::is_empty(Self) -> Bool
@@ -202,25 +205,25 @@ pub fn Inline::to_plain_text(Self, break_on_soft~ : Bool) -> Seq[Seq[String]]
 pub(all) struct InlineAutolink {
   is_email : Bool
   link : Node[String]
-} derive(Eq, Show, ToJson)
+} derive(Eq, @debug.Debug)
 pub fn InlineAutolink::new(Node[String]) -> Self
 
 pub(all) struct InlineBreak {
   layout_before : Node[String]
   ty : InlineBreakType
   layout_after : Node[String]
-} derive(Eq, Show, ToJson)
+} derive(Eq, @debug.Debug)
 pub fn InlineBreak::new(layout_before? : Node[String], layout_after? : Node[String], InlineBreakType) -> Self
 
 pub(all) enum InlineBreakType {
   Hard
   Soft
-} derive(Compare, Eq, Show, ToJson, @json.FromJson)
+} derive(Compare, Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) struct InlineCodeSpan {
   backticks : Int
   code_layout : Seq[Tight]
-} derive(Eq, Show, ToJson)
+} derive(Eq, @debug.Debug)
 pub fn InlineCodeSpan::code(Self) -> String
 pub fn InlineCodeSpan::from_string(meta? : @cmark_base.Meta, String) -> Self
 pub fn InlineCodeSpan::new(backticks~ : Int, Seq[Tight]) -> Self
@@ -228,13 +231,13 @@ pub fn InlineCodeSpan::new(backticks~ : Int, Seq[Tight]) -> Self
 pub(all) struct InlineEmphasis {
   delim : Char
   inline : Inline
-} derive(Eq, Show, ToJson)
+} derive(Eq, @debug.Debug)
 pub fn InlineEmphasis::new(delim? : Char, Inline) -> Self
 
 pub(all) struct InlineLink {
   text : Inline
   reference : ReferenceKind
-} derive(Eq, Show, ToJson)
+} derive(Eq, @debug.Debug)
 pub fn InlineLink::is_unsafe(String) -> Bool
 pub fn InlineLink::new(Inline, ReferenceKind) -> Self
 pub fn InlineLink::reference_definition(Self, Map[String, LabelDef]) -> LabelDef?
@@ -243,18 +246,18 @@ pub fn InlineLink::referenced_label(Self) -> Label?
 pub(all) struct InlineMathSpan {
   display : Bool
   tex_layout : Seq[Tight]
-} derive(Eq, Show, ToJson)
+} derive(Eq, @debug.Debug)
 pub fn InlineMathSpan::tex(Self) -> String
 
-pub(all) struct InlineRawHtml(Seq[Tight]) derive(Eq, Show, ToJson)
+pub(all) struct InlineRawHtml(Seq[Tight]) derive(Eq, @debug.Debug)
 
-pub(all) struct InlineStrikethrough(Inline) derive(Eq, Show, ToJson)
+pub(all) struct InlineStrikethrough(Inline) derive(Eq, @debug.Debug)
 
 pub(all) struct Label {
   meta : @cmark_base.Meta
   key : String
   text : Seq[Tight]
-} derive(Show, ToJson)
+} derive(@debug.Debug)
 pub fn Label::compare(Self, Self) -> Int
 pub fn Label::new(meta? : @cmark_base.Meta, key~ : String, Seq[Tight]) -> Self
 pub fn Label::text_loc(Self) -> @cmark_base.TextLoc
@@ -269,7 +272,7 @@ pub fn LabelContext::default_resolver(Self) -> Label?
 pub(all) enum LabelDef {
   LinkDef(Node[LinkDefinition])
   FootnoteDef(Node[Footnote])
-} derive(Show, ToJson)
+} derive(@debug.Debug)
 
 pub(all) struct LabelResolverFn((LabelContext) -> Label?)
 
@@ -279,7 +282,7 @@ pub(all) struct LinkDefinition {
   defined_label : Label?
   dest : Node[String]?
   title : Seq[Tight]?
-} derive(Eq, Show, ToJson)
+} derive(Eq, @debug.Debug)
 pub fn LinkDefinition::new(layout? : LinkDefinitionLayout, label? : Label?, defined_label? : Label?, dest? : Node[String]?, title? : Seq[Tight]?) -> Self
 
 pub(all) struct LinkDefinitionLayout {
@@ -289,7 +292,7 @@ pub(all) struct LinkDefinitionLayout {
   after_dest : Seq[Node[String]]
   title_open_delim : Char
   after_title : Seq[Node[String]]
-} derive(Eq, Show, ToJson)
+} derive(Eq, @debug.Debug)
 pub fn LinkDefinitionLayout::default() -> Self
 pub fn LinkDefinitionLayout::for_dest(String) -> Self
 
@@ -305,7 +308,7 @@ pub(all) struct ListItem {
   after_marker : Int
   block : Block
   ext_task_marker : Node[Char]?
-} derive(Show, ToJson)
+} derive(@debug.Debug)
 pub fn ListItem::map_block(Self, (Block) -> Block) -> Self
 pub fn ListItem::new(before_marker? : Int, marker? : Node[String], after_marker? : Int, ext_task_marker~ : Node[Char]?, Block) -> Self
 pub fn ListItem::normalize_block(Self) -> Self
@@ -341,31 +344,29 @@ pub(all) struct MapperFn[A]((Mapper, A) -> MapperResult[A])
 pub(all) enum MapperResult[A] {
   Default
   Map(A?)
-} derive(Eq, Show, ToJson)
+} derive(Eq, @debug.Debug)
 pub impl[A] Default for MapperResult[A]
 
 pub(all) struct Node[A] {
   v : A
   meta : @cmark_base.Meta
-} derive(Eq)
+} derive(Eq, @debug.Debug)
 pub fn Node::empty(meta? : @cmark_base.Meta) -> Self[String]
 pub fn[A, B] Node::map(Self[A], (A) -> B) -> Self[B]
 pub fn[A] Node::new(A, meta? : @cmark_base.Meta) -> Self[A]
-pub impl[A : Show] Show for Node[A]
-pub impl[A : ToJson] ToJson for Node[A]
 
 pub(all) enum ReferenceKind {
   Inline(Node[LinkDefinition])
   Ref(ReferenceLayout, Label, Label)
-} derive(Eq, Show, ToJson)
+} derive(Eq, @debug.Debug)
 
 pub(all) enum ReferenceLayout {
   Collapsed
   Full
   Shortcut
-} derive(Eq, Show, ToJson, @json.FromJson)
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-type Seq[A] derive(Eq, Show)
+type Seq[A] derive(Eq, @debug.Debug)
 pub fn[A] Seq::empty() -> Self[A]
 pub fn[A, B] Seq::fold(Self[A], init~ : B, (B, A) -> B) -> B
 pub fn[A] Seq::from_array(Array[A]) -> Self[A]
@@ -379,39 +380,37 @@ pub fn[A] Seq::op_get(Self[A], Int) -> A
 pub fn[A] Seq::op_set(Self[A], Int, A) -> Unit
 pub fn[A, B] Seq::rev_fold(Self[A], init~ : B, (B, A) -> B) -> B
 pub fn[A] Seq::to_array(Self[A]) -> Array[A]
-pub impl[A : ToJson] ToJson for Seq[A]
 
 pub(all) struct Table {
   indent : Int
   col_count : Int
   rows : Seq[(Node[TableRow], String)]
-} derive(Show, ToJson)
+} derive(@debug.Debug)
 pub fn Table::new(indent? : Int, Seq[(Node[TableRow], String)]) -> Self
 
 pub(all) enum TableAlign {
   Left
   Center
   Right
-} derive(Show, ToJson, @json.FromJson)
+} derive(ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct TableCellLayout((String, String)) derive(Compare, Eq, Show, ToJson)
+pub(all) struct TableCellLayout((String, String)) derive(Compare, Eq, @debug.Debug)
 
 pub(all) enum TableRow {
   Header(Seq[(Inline, TableCellLayout)])
   Sep(Seq[Node[TableSep]])
   Data(Seq[(Inline, TableCellLayout)])
-} derive(Show, ToJson)
+} derive(@debug.Debug)
 
-pub(all) struct TableSep((TableAlign?, Int)) derive(Show, ToJson)
+pub(all) struct TableSep((TableAlign?, Int)) derive(@debug.Debug)
 
 pub(all) struct Tight {
   blanks : String
   node : Node[String]
-} derive(Eq, ToJson)
+} derive(Eq, @debug.Debug)
 pub fn Tight::empty(meta? : @cmark_base.Meta) -> Self
 pub fn Tight::list_text_loc(Seq[Self]) -> @cmark_base.TextLoc
 pub fn Tight::to_string(Self) -> String
-pub impl Show for Tight
 
 // Type aliases
 pub type Blanks = String

--- a/src/cmark/seq.mbt
+++ b/src/cmark/seq.mbt
@@ -1,10 +1,5 @@
 ///|
-struct Seq[A](Array[A]) derive(Eq, Show)
-
-///|
-pub impl[A : ToJson] ToJson for Seq[A] with to_json(self) -> Json {
-  self.0.to_json()
-}
+struct Seq[A](Array[A]) derive(Eq, Debug)
 
 ///|
 /// @coverage.skip

--- a/src/cmark_base/README.mbt.md
+++ b/src/cmark_base/README.mbt.md
@@ -17,14 +17,20 @@ test "text location handling" {
     last_line: LinePos(1, 10),
   }
   let after_loc = loc.after()
-  inspect(
+  debug_inspect(
     after_loc,
     content=(
-      #|{file: "test.md", first_ccode: 1, last_ccode: -1, first_line: LinePos(1, 10), last_line: LinePos(-1, -1)}
+      #|{
+      #|  file: "test.md",
+      #|  first_ccode: 1,
+      #|  last_ccode: -1,
+      #|  first_line: LinePos(1, 10),
+      #|  last_line: LinePos(-1, -1),
+      #|}
     ),
   )
   let none_loc = @cmark_base.TextLoc::none()
-  inspect(none_loc.is_none(), content="true")
+  debug_inspect(none_loc.is_none(), content="true")
 }
 ```
 
@@ -36,9 +42,9 @@ The package provides functions for parsing links, URIs and email addresses:
 ///|
 test "link parsing" {
   let txt = "Visit <https://mooncakes.io/>!"
-  inspect(@cmark_base.autolink_uri(txt, start=6), content="Some(28)")
+  debug_inspect(@cmark_base.autolink_uri(txt, start=6), content="Some(28)")
   let email = "Contact <user@example.com> today!"
-  inspect(@cmark_base.autolink_email(email, start=8), content="Some(25)")
+  debug_inspect(@cmark_base.autolink_email(email, start=8), content="Some(25)")
 }
 ```
 
@@ -52,10 +58,16 @@ test "string analysis" {
   let start = 0
 
   // Find first non-blank character
-  inspect(@cmark_base.first_non_blank("  hello", last=7, start~), content="2")
+  debug_inspect(
+    @cmark_base.first_non_blank("  hello", last=7, start~),
+    content="2",
+  )
 
   // Count repeated characters
-  inspect(@cmark_base.run_of(char='-', "---hello", last=8, start~), content="2")
+  debug_inspect(
+    @cmark_base.run_of(char='-', "---hello", last=8, start~),
+    content="2",
+  )
 }
 ```
 
@@ -69,23 +81,23 @@ test "line type detection" {
   let start = 0
 
   // ATX Heading
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::atx_heading("# Heading", last=8, start~),
     content="AtxHeadingLine(1, 1, 2, 8)",
   )
 
   // Thematic Break
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::thematic_break("---", last=2, start~),
     content="ThematicBreakLine(2)",
   )
 
   // List Items
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::list_marker("- Item", last=5, start~),
     content="ListMarkerLine(Unordered('-'), 0)",
   )
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::list_marker("1. Item", last=6, start~),
     content="ListMarkerLine(Ordered(1, '.'), 1)",
   )
@@ -103,8 +115,8 @@ test "list types" {
   let ordered = @cmark_base.ListType::Ordered(1, '.')
 
   // Check if lists are of same type
-  inspect(unordered.is_same_type(unordered), content="true")
-  inspect(unordered.is_same_type(ordered), content="false")
+  debug_inspect(unordered.is_same_type(unordered), content="true")
+  debug_inspect(unordered.is_same_type(ordered), content="false")
 }
 ```
 
@@ -116,11 +128,11 @@ Support for detecting and parsing HTML blocks:
 ///|
 test "html blocks" {
   let start = 0
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start("<div>", last=5, start~),
     content="HtmlBlockLine(EndBlank)",
   )
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_end(
       "</div></br>",
       end_cond=@cmark_base.HtmlBlockEndCond::EndStr("</div>"),
@@ -147,8 +159,8 @@ test "metadata handling" {
     last_line: LinePos(1, 10),
   }
   let meta = @cmark_base.Meta::new(loc~)
-  inspect(meta.is_none(), content="false")
+  debug_inspect(meta.is_none(), content="false")
   let none_meta = @cmark_base.Meta::none()
-  inspect(none_meta.is_none(), content="true")
+  debug_inspect(none_meta.is_none(), content="true")
 }
 ```

--- a/src/cmark_base/autolink_test.mbt
+++ b/src/cmark_base/autolink_test.mbt
@@ -1,41 +1,41 @@
 ///|
 test "autolink_email invalid label sequence with non-alphanumeric char" {
-  inspect(@cmark_base.autolink_email("<a@#>"), content="None")
+  debug_inspect(@cmark_base.autolink_email("<a@#>"), content="None")
 }
 
 ///|
 test "autolink_email label sequence with invalid end char" {
-  inspect(@cmark_base.autolink_email("<a@a#"), content="None")
+  debug_inspect(@cmark_base.autolink_email("<a@a#"), content="None")
 }
 
 ///|
 test "autolink_email invalid start" {
-  inspect(@cmark_base.autolink_email("hello"), content="None")
+  debug_inspect(@cmark_base.autolink_email("hello"), content="None")
 }
 
 ///|
 test "autolink_email label sequence ending with invalid char" {
-  inspect(@cmark_base.autolink_email("<a@abc$>"), content="None")
+  debug_inspect(@cmark_base.autolink_email("<a@abc$>"), content="None")
 }
 
 ///|
 test "email autolink - premature end" {
   let email = "<a@b"
-  inspect(@cmark_base.autolink_email(email), content="None")
+  debug_inspect(@cmark_base.autolink_email(email), content="None")
 }
 
 ///|
 test "email autolink - non-alphanum ending" {
   let email = "<a@b->"
-  inspect(@cmark_base.autolink_email(email), content="None")
+  debug_inspect(@cmark_base.autolink_email(email), content="None")
 }
 
 ///|
 test "autolink_uri - incomplete uri at end of string" {
-  inspect(@cmark_base.autolink_uri("<http://example.com"), content="None")
+  debug_inspect(@cmark_base.autolink_uri("<http://example.com"), content="None")
 }
 
 ///|
 test "autolink_uri - incomplete uri with empty content" {
-  inspect(@cmark_base.autolink_uri("<http:"), content="None")
+  debug_inspect(@cmark_base.autolink_uri("<http:"), content="None")
 }

--- a/src/cmark_base/leaf_blocks.mbt
+++ b/src/cmark_base/leaf_blocks.mbt
@@ -7,7 +7,7 @@ pub(all) enum HtmlBlockEndCond {
   EndCond1
   EndBlank
   EndBlank7
-} derive(Show, ToJson, Eq)
+} derive(Debug, Eq)
 
 ///|
 pub(all) enum ListType {
@@ -15,7 +15,7 @@ pub(all) enum ListType {
   Unordered(Char)
   /// Starting at given integer, markers ending with given character, i.e. ')' or '.'.
   Ordered(Int, Char)
-} derive(Show, FromJson, ToJson, Eq)
+} derive(Debug, FromJson, ToJson, Eq)
 
 ///|
 pub fn ListType::is_same_type(self : ListType, other : ListType) -> Bool {
@@ -39,7 +39,7 @@ pub(all) enum LineType {
   ExtTableRow(Last)
   ExtFootnoteLabel(Array[Span], Last, String)
   Nomatch
-} derive(Show, ToJson, Eq)
+} derive(Debug, Eq)
 
 ///|
 /// https://spec.commonmark.org/current/#thematic-breaks
@@ -249,7 +249,7 @@ pub fn LineType::fenced_code_block_start(
 pub(all) enum FencedCodeBlockContinue {
   Close(First, Last)
   Code
-} derive(Show, ToJson)
+} derive(Debug)
 
 ///|
 /// `fenced_code_block_continue(fence, s, last, start)` indicates

--- a/src/cmark_base/leaf_blocks_test.mbt
+++ b/src/cmark_base/leaf_blocks_test.mbt
@@ -1,7 +1,7 @@
 ///|
 test "thematic break with empty input" {
   // Test case where start > last
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::thematic_break("hello", last=3, start=4),
     content="Nomatch",
   )
@@ -9,7 +9,7 @@ test "thematic break with empty input" {
 
 ///|
 test "atx_heading empty" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::atx_heading("#", last=0, start=0),
     content="AtxHeadingLine(1, 1, 1, 0)",
   )
@@ -17,7 +17,7 @@ test "atx_heading empty" {
 
 ///|
 test "atx_heading too many hashes" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::atx_heading("#######", last=6, start=0),
     content="Nomatch",
   )
@@ -25,7 +25,7 @@ test "atx_heading too many hashes" {
 
 ///|
 test "atx_heading no blank after hash" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::atx_heading("#a", last=1, start=0),
     content="Nomatch",
   )
@@ -35,7 +35,7 @@ test "atx_heading no blank after hash" {
 test "setext_heading_underline empty string" {
   // Tests line 179: if start > last
   let s = ""
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::setext_heading_underline(s, last=0, start=1),
     content="Nomatch",
   )
@@ -44,7 +44,7 @@ test "setext_heading_underline empty string" {
 ///|
 test "setext_heading_underline invalid start char" {
   let s = "abc"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::setext_heading_underline(s, last=2, start=0),
     content="Nomatch",
   )
@@ -53,7 +53,7 @@ test "setext_heading_underline invalid start char" {
 ///|
 test "setext_heading_underline with non-marker char" {
   let s = "=x"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::setext_heading_underline(s, last=1, start=0),
     content="Nomatch",
   )
@@ -63,7 +63,7 @@ test "setext_heading_underline with non-marker char" {
 test "setext_heading_underline with trailing blank" {
   // Tests line 173: if end_blank > last
   let s = "=== \t"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::setext_heading_underline(s, last=4, start=0),
     content="SetextUnderlineLine(1, 2)",
   )
@@ -73,28 +73,28 @@ test "setext_heading_underline with trailing blank" {
 test "fenced_code_block_start empty input" {
   let s = ""
   let result = @cmark_base.LineType::fenced_code_block_start(s, last=0, start=1)
-  inspect(result, content="Nomatch")
+  debug_inspect(result, content="Nomatch")
 }
 
 ///|
 test "fenced_code_block_start with insufficient fence chars" {
   let s = "``"
   let result = @cmark_base.LineType::fenced_code_block_start(s, last=1, start=0)
-  inspect(result, content="Nomatch")
+  debug_inspect(result, content="Nomatch")
 }
 
 ///|
 test "fenced_code_block_start with indentation" {
   let s = "   ```"
   let result = @cmark_base.LineType::fenced_code_block_start(s, last=5, start=0)
-  inspect(result, content="FencedCodeBlockLine(3, 5, None)")
+  debug_inspect(result, content="FencedCodeBlockLine(3, 5, None)")
 }
 
 ///|
 test "fenced_code_block_start with non-fence char" {
   let s = "abc"
   let result = @cmark_base.LineType::fenced_code_block_start(s, last=2, start=0)
-  inspect(result, content="Nomatch")
+  debug_inspect(result, content="Nomatch")
 }
 
 ///|
@@ -102,7 +102,7 @@ test "fenced code block continue - not enough fence chars" {
   // This test covers line 277 - raise Exit when not enough fence chars
   let fence = ('`', 3) // Requiring 3 backticks
   let s = "``" // Only 2 backticks
-  inspect(
+  debug_inspect(
     @cmark_base.FencedCodeBlockContinue::new(s, fence~, last=1, start=0),
     content="Code",
   )
@@ -113,7 +113,7 @@ test "fenced code block continue - fence failure" {
   // This test covers line 300 - Exit => Code
   let fence = ('`', 3)
   let s = "```abc" // Valid fence but with extra content
-  inspect(
+  debug_inspect(
     @cmark_base.FencedCodeBlockContinue::new(s, fence~, last=5, start=0),
     content="Code",
   )
@@ -122,17 +122,17 @@ test "fenced code block continue - fence failure" {
 ///|
 test "html block start negative cases" {
   // Test case for invalid '!' tag (lines 409, 418)
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start("<!>", last=2, start=0),
     content="Nomatch",
   )
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start("<!1>", last=3, start=0),
     content="Nomatch",
   )
 
   // Test case for invalid regular tag (line 423)
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start("<1>", last=2, start=0),
     content="Nomatch",
   )
@@ -141,7 +141,7 @@ test "html block start negative cases" {
 ///|
 test "html block start with open tag" {
   // Test case for open tag (line 449)
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start("<custom>", last=7, start=0),
     content="HtmlBlockLine(EndBlank7)",
   )
@@ -151,12 +151,12 @@ test "html block start with open tag" {
 test "html_block_end with EndStr" {
   let s = "Hello -->World"
   let end_cond = @cmark_base.HtmlBlockEndCond::EndStr("-->")
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_end(s, end_cond~, last=11, start=0),
     content="true",
   )
   let s2 = "Hello World"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_end(s2, end_cond~, last=10, start=0),
     content="false",
   )
@@ -166,12 +166,12 @@ test "html_block_end with EndStr" {
 test "html_block_end with EndCond1" {
   let s = "Hello </pre>World"
   let end_cond = @cmark_base.HtmlBlockEndCond::EndCond1
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_end(s, end_cond~, last=12, start=0),
     content="true",
   )
   let s2 = "Hello World"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_end(s2, end_cond~, last=10, start=0),
     content="false",
   )
@@ -180,7 +180,7 @@ test "html_block_end with EndCond1" {
 ///|
 test "list_marker invalid bullet" {
   let s = "  hello"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::list_marker(s, last=6, start=2),
     content="Nomatch",
   )
@@ -189,7 +189,7 @@ test "list_marker invalid bullet" {
 ///|
 test "list_marker bullet without space" {
   let s = "  -hello"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::list_marker(s, last=7, start=2),
     content="Nomatch",
   )
@@ -198,7 +198,7 @@ test "list_marker bullet without space" {
 ///|
 test "list_marker long ordered list" {
   let s = "  1234567890. "
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::list_marker(s, last=13, start=2),
     content="Nomatch",
   )
@@ -207,7 +207,7 @@ test "list_marker long ordered list" {
 ///|
 test "list_marker ordered list without space" {
   let s = "  1.hello"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::list_marker(s, last=8, start=2),
     content="Nomatch",
   )
@@ -215,14 +215,20 @@ test "list_marker ordered list without space" {
 
 ///|
 test "ext_task_marker returns None when start >= last" {
-  inspect(@cmark_base.ext_task_marker("", last=0, start=1), content="None")
-  inspect(@cmark_base.ext_task_marker("", last=0, start=0), content="None")
+  debug_inspect(
+    @cmark_base.ext_task_marker("", last=0, start=1),
+    content="None",
+  )
+  debug_inspect(
+    @cmark_base.ext_task_marker("", last=0, start=0),
+    content="None",
+  )
 }
 
 ///|
 test "ext_task_marker returns None when the marker is too long" {
   let s = "[\u{d8}00]"
-  inspect(
+  debug_inspect(
     @cmark_base.ext_task_marker(s, last=s.length(), start=0),
     content="None",
   )
@@ -230,7 +236,7 @@ test "ext_task_marker returns None when the marker is too long" {
 
 ///|
 test "atx_heading: empty heading" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::atx_heading("#     ", last=5, start=0),
     content="AtxHeadingLine(1, 1, 6, 5)",
   )
@@ -238,7 +244,7 @@ test "atx_heading: empty heading" {
 
 ///|
 test "atx_heading: heading with trailing hashes" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::atx_heading("# test #", last=7, start=0),
     content="AtxHeadingLine(1, 1, 2, 5)",
   )
@@ -246,7 +252,7 @@ test "atx_heading: heading with trailing hashes" {
 
 ///|
 test "atx_heading: invalid start" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::atx_heading("test", last=3, start=4),
     content="Nomatch",
   )
@@ -255,7 +261,7 @@ test "atx_heading: invalid start" {
 ///|
 test "html_block_start_5 with CDATA" {
   let s = "<![CDATA[foo]]>"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start(s, last=s.length() - 1, start=0),
     content="HtmlBlockLine(EndStr(\"]]>\"))",
   )
@@ -264,7 +270,7 @@ test "html_block_start_5 with CDATA" {
 ///|
 test "html_block_start_5 with incomplete CDATA" {
   let s = "<![CDA"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start(s, last=s.length() - 1, start=0),
     content="Nomatch",
   )
@@ -272,7 +278,7 @@ test "html_block_start_5 with incomplete CDATA" {
 
 ///|
 test "table row - no opening pipe" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::ext_table_row("a | b |", last=6, start=0),
     content="Nomatch",
   )
@@ -280,7 +286,7 @@ test "table row - no opening pipe" {
 
 ///|
 test "table row - no closing pipe" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::ext_table_row("| a | b ", last=6, start=0),
     content="Nomatch",
   )
@@ -288,7 +294,7 @@ test "table row - no closing pipe" {
 
 ///|
 test "table row - escaped closing pipe" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::ext_table_row("| a | b \\|", last=8, start=0),
     content="Nomatch",
   )
@@ -296,7 +302,7 @@ test "table row - escaped closing pipe" {
 
 ///|
 test "list_marker: empty string" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::list_marker("", last=0, start=1),
     content="Nomatch",
   )
@@ -304,7 +310,7 @@ test "list_marker: empty string" {
 
 ///|
 test "list_marker: ordered list with invalid marker" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::list_marker("123x", last=3, start=0),
     content="Nomatch",
   )
@@ -315,7 +321,7 @@ test "html_block_start_7_open_tag - no match due to invalid open tag" {
   // Test case where open_tag returns None
   // This should trigger the uncovered line 361
   let s = "<invalid"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start(s, last=s.length() - 1, start=0),
     content="Nomatch",
   )
@@ -323,11 +329,11 @@ test "html_block_start_7_open_tag - no match due to invalid open tag" {
 
 ///|
 test "html block start nomatch" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start("", last=0, start=0),
     content="Nomatch",
   )
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start("abc", last=2, start=0),
     content="Nomatch",
   )
@@ -335,7 +341,7 @@ test "html block start nomatch" {
 
 ///|
 test "html block start type 3" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start("<?xml", last=4, start=0),
     content="HtmlBlockLine(EndStr(\"?>\"))",
   )
@@ -343,7 +349,7 @@ test "html block start type 3" {
 
 ///|
 test "html block start type 2" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start("<!--", last=4, start=0),
     content="HtmlBlockLine(EndStr(\"-->\"))",
   )
@@ -351,7 +357,7 @@ test "html block start type 2" {
 
 ///|
 test "html block start type 4" {
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start("<!abc>", last=5, start=0),
     content="HtmlBlockLine(EndStr(\">\"))",
   )
@@ -360,7 +366,7 @@ test "html block start type 4" {
 ///|
 test "ext_table_row with escaped pipe at the end" {
   // Test when there's a backslash before the closing pipe, should return Nomatch
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::ext_table_row("| a b c \\|", last=9, start=0),
     content="Nomatch",
   )
@@ -370,7 +376,7 @@ test "ext_table_row with escaped pipe at the end" {
 test "fenced code block with backtick in info string" {
   let s = "```rust`"
   // This should trigger line 197 by having a backtick in the info string
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::fenced_code_block_start(s, last=7, start=0),
     content="Nomatch",
   )
@@ -385,13 +391,13 @@ test "html_block_start_7_open_tag with non-blank after tag" {
     last=s.length() - 1,
     start=0,
   )
-  inspect(result, content="Nomatch")
+  debug_inspect(result, content="Nomatch")
 }
 
 ///|
 test "html_block_start empty after <!" {
   let s = "<!a"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start(s, last=1, start=0),
     content="Nomatch",
   )
@@ -400,22 +406,22 @@ test "html_block_start empty after <!" {
 ///|
 test "html_block_start with tags" {
   let s = "<pre>test</pre>"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start(s, last=13, start=0),
     content="HtmlBlockLine(EndCond1)",
   )
   let s2 = "</p test>"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start(s2, last=7, start=0),
     content="HtmlBlockLine(EndBlank)",
   )
   let s3 = "<p/>"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start(s3, last=3, start=0),
     content="HtmlBlockLine(EndBlank)",
   )
   let s4 = "</p>"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start(s4, last=3, start=0),
     content="HtmlBlockLine(EndBlank)",
   )
@@ -427,7 +433,7 @@ test "fenced code block continue - another short blank line" {
   let s = " " // Single space string represents another short blank line
   let last = 0
   let start = 0
-  inspect(
+  debug_inspect(
     @cmark_base.FencedCodeBlockContinue::new(s, fence~, last~, start~),
     content="Code",
   )
@@ -436,7 +442,7 @@ test "fenced code block continue - another short blank line" {
 ///|
 test "could_be_link_ref_definition empty input" {
   let s = ""
-  inspect(
+  debug_inspect(
     @cmark_base.could_be_link_ref_definition(s, last=0, start=1),
     content="false",
   )
@@ -445,7 +451,7 @@ test "could_be_link_ref_definition empty input" {
 ///|
 test "could_be_link_ref_definition exceed boundary" {
   let s = "   "
-  inspect(
+  debug_inspect(
     @cmark_base.could_be_link_ref_definition(s, last=2, start=3),
     content="false",
   )
@@ -454,7 +460,7 @@ test "could_be_link_ref_definition exceed boundary" {
 ///|
 test "html block start with closing tag that is not in cond 6 set - no whitespace" {
   let s = "</unknown>something"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start(s, last=s.length() - 1, start=0),
     content="Nomatch",
   )
@@ -462,7 +468,7 @@ test "html block start with closing tag that is not in cond 6 set - no whitespac
 
 ///|
 test "could_be_link_ref_definition no bracket" {
-  inspect(
+  debug_inspect(
     @cmark_base.could_be_link_ref_definition("   ", last=2, start=0),
     content="false",
   )
@@ -471,7 +477,7 @@ test "could_be_link_ref_definition no bracket" {
 ///|
 test "html block start with closing tag that is not in cond 6 set" {
   let s = "</foo>"
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start(s, last=s.length() - 1, start=0),
     content="HtmlBlockLine(EndBlank7)",
   )
@@ -480,7 +486,7 @@ test "html block start with closing tag that is not in cond 6 set" {
 ///|
 test "html block start with closing tag that is not in cond 6 set - longer" {
   let s = "</unknown> "
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::html_block_start(s, last=s.length() - 1, start=0),
     content="HtmlBlockLine(EndBlank7)",
   )
@@ -489,25 +495,25 @@ test "html block start with closing tag that is not in cond 6 set - longer" {
 ///|
 test "atx_heading with ending hashes" {
   // Test case where the heading ends with hashes preceded by a space
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::atx_heading("# Test #", last=7, start=0),
     content="AtxHeadingLine(1, 1, 2, 5)",
   )
 
   // Test case where the heading has multiple ending hashes
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::atx_heading("## Test ###", last=9, start=0),
     content="AtxHeadingLine(2, 2, 3, 6)",
   )
 
   // Test case where the heading has ending hashes with trailing spaces
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::atx_heading("### Test # ", last=9, start=0),
     content="AtxHeadingLine(3, 3, 4, 7)",
   )
 
   // Test case where the heading only has spaces between start and end hashes
-  inspect(
+  debug_inspect(
     @cmark_base.LineType::atx_heading("# #", last=2, start=0),
     content="AtxHeadingLine(1, 1, 2, 1)",
   )
@@ -519,5 +525,5 @@ test "test @cmark_base.LineType::fenced_code_block_start with uncovered section"
   let last = 2
   let start = 1
   let output = @cmark_base.LineType::fenced_code_block_start(s, last~, start~)
-  inspect(output, content="Nomatch")
+  debug_inspect(output, content="Nomatch")
 }

--- a/src/cmark_base/link_test.mbt
+++ b/src/cmark_base/link_test.mbt
@@ -3,7 +3,7 @@ test "link_destination start greater than last" {
   let s = "test"
   let last = 3
   let start = 4
-  inspect(@cmark_base.link_destination(s, last~, start~), content="None")
+  debug_inspect(@cmark_base.link_destination(s, last~, start~), content="None")
 }
 
 ///|
@@ -11,7 +11,7 @@ test "link_destination with angle bracket and early termination" {
   let s = "<test\n>"
   let last = 6
   let start = 0
-  inspect(@cmark_base.link_destination(s, last~, start~), content="None")
+  debug_inspect(@cmark_base.link_destination(s, last~, start~), content="None")
 }
 
 ///|
@@ -19,7 +19,7 @@ test "link_destination not delimited with unbalanced closing parenthesis" {
   let s = "(test(test)"
   let last = 10
   let start = 0
-  inspect(@cmark_base.link_destination(s, last~, start~), content="None")
+  debug_inspect(@cmark_base.link_destination(s, last~, start~), content="None")
 }
 
 ///|
@@ -27,7 +27,10 @@ test "link_destination test with no end delimiter" {
   let input = "<some_url"
   let last = 8
   let start = 0
-  inspect(@cmark_base.link_destination(input, last~, start~), content="None")
+  debug_inspect(
+    @cmark_base.link_destination(input, last~, start~),
+    content="None",
+  )
 }
 
 ///|
@@ -36,25 +39,25 @@ test "link_destination contains no space condition false" {
   let last = s.length() - 1
   let start = 0
   let result = @cmark_base.link_destination(s, last~, start~)
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
 test "test link_destination with escaped backslashes" {
   let result = @cmark_base.link_destination("<\\\\>", last=3, start=0)
-  inspect(result, content="Some((true, 1, 2))")
+  debug_inspect(result, content="Some((true, 1, 2))")
 }
 
 ///|
 test "test link_destination with matched angle brackets" {
   let result = @cmark_base.link_destination("<url>", last=4, start=0)
-  inspect(result, content="Some((true, 1, 3))")
+  debug_inspect(result, content="Some((true, 1, 3))")
 }
 
 ///|
 test "test link_destination with backslash before closing angle bracket" {
   let result = @cmark_base.link_destination("<url\\>", last=5, start=0)
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -62,7 +65,10 @@ test "trigger uncovered line 28 and 29" {
   let input : String = "<test<text"
   let last : Int = 10
   let start : Int = 0
-  inspect(@cmark_base.link_destination(input, last~, start~), content="None")
+  debug_inspect(
+    @cmark_base.link_destination(input, last~, start~),
+    content="None",
+  )
 }
 
 ///|
@@ -70,7 +76,7 @@ test "test escaped parenthesis in not delimited link destination" {
   let s = "Hello(\\)World"
   let last = s.length() - 1
   let start = 0
-  inspect(@cmark_base.link_destination(s, last~, start~), content="None")
+  debug_inspect(@cmark_base.link_destination(s, last~, start~), content="None")
 }
 
 ///|
@@ -78,5 +84,5 @@ test "test double backslash before less-than" {
   let s = "<\\<"
   let last = 2
   let start = 0
-  inspect(@cmark_base.link_destination(s, last~, start~), content="None")
+  debug_inspect(@cmark_base.link_destination(s, last~, start~), content="None")
 }

--- a/src/cmark_base/meta.mbt
+++ b/src/cmark_base/meta.mbt
@@ -3,7 +3,7 @@ pub(all) struct Meta {
   id : MetaId
   loc : TextLoc
   extra : Error?
-}
+} derive(Debug)
 
 ///|
 type MetaId = Int
@@ -39,36 +39,4 @@ pub fn Meta::compare(self : Meta, other : Meta) -> Int {
 ///|
 pub fn Meta::is_none(self : Meta) -> Bool {
   self == meta_none
-}
-
-///|
-pub impl Show for Meta with output(self, logger) {
-  if self.is_none() {
-    logger.write_string("Meta::none()")
-  } else {
-    logger.write_string("Meta::new(id=")
-    logger.write_object(self.id)
-    logger.write_string(", loc=")
-    logger.write_object(self.loc)
-    logger.write_string(", dict=")
-    logger.write_object(self.extra)
-    logger.write_string(")")
-  }
-}
-
-///|
-pub impl ToJson for Meta with to_json(self) {
-  if self.is_none() {
-    return {}
-  }
-  {
-    "id": self.id.to_json(),
-    "loc": self.loc.to_json(),
-    "dict": self.extra.to_string().to_json(),
-  }
-}
-
-///|
-pub fn Meta::to_json(self : Meta) -> Json {
-  ToJson::to_json(self)
 }

--- a/src/cmark_base/meta_test.mbt
+++ b/src/cmark_base/meta_test.mbt
@@ -2,23 +2,23 @@
 test "Meta compare" {
   let meta1 = @cmark_base.Meta::new()
   let meta2 = @cmark_base.Meta::new()
-  inspect(meta1.compare(meta2), content="-1")
+  debug_inspect(meta1.compare(meta2), content="-1")
 }
 
 ///|
 test "Meta compare with self" {
   let meta = @cmark_base.Meta::new()
-  inspect(meta.compare(meta), content="0")
+  debug_inspect(meta.compare(meta), content="0")
 }
 
 ///|
-test "show_implementation_for_meta_none" {
+test "Meta none sentinel" {
   let none_meta = @cmark_base.Meta::none()
-  inspect(Show::to_string(none_meta), content="Meta::none()")
+  debug_inspect(none_meta.is_none(), content="true")
 }
 
 ///|
-test "@cmark_base.Meta::to_json empty" {
+test "@cmark_base.Meta::none is empty" {
   let meta = @cmark_base.Meta::none()
-  inspect(meta.to_json(), content="Object({})")
+  debug_inspect(meta.is_none(), content="true")
 }

--- a/src/cmark_base/moon.pkg
+++ b/src/cmark_base/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "moonbit-community/cmark/char",
   "moonbitlang/core/cmp",
+  "moonbitlang/core/debug",
   "moonbitlang/core/json",
 }

--- a/src/cmark_base/pkg.generated.mbti
+++ b/src/cmark_base/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "moonbit-community/cmark/cmark_base"
 
 import {
+  "moonbitlang/core/debug",
   "moonbitlang/core/json",
 }
 
@@ -53,7 +54,7 @@ pub extenum ContextState {
 pub(all) enum FencedCodeBlockContinue {
   Close(Int, Int)
   Code
-} derive(Show, ToJson)
+} derive(@debug.Debug)
 pub fn FencedCodeBlockContinue::new(String, fence~ : (Char, Int), last~ : Int, start~ : Int) -> Self
 
 pub(all) enum HtmlBlockEndCond {
@@ -61,15 +62,15 @@ pub(all) enum HtmlBlockEndCond {
   EndCond1
   EndBlank
   EndBlank7
-} derive(Eq, Show, ToJson)
+} derive(Eq, @debug.Debug)
 
-pub(all) struct LinePos(Int, Int) derive(Compare, Eq, Show, ToJson, @json.FromJson)
+pub(all) struct LinePos(Int, Int) derive(Compare, Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) struct LineSpan {
   pos : LinePos
   first : Int
   last : Int
-} derive(Compare, Eq, Show, ToJson)
+} derive(Compare, Eq, @debug.Debug)
 
 pub(all) enum LineType {
   AtxHeadingLine(Int, Int, Int, Int)
@@ -85,7 +86,7 @@ pub(all) enum LineType {
   ExtTableRow(Int)
   ExtFootnoteLabel(Array[Span], Int, String)
   Nomatch
-} derive(Eq, Show, ToJson)
+} derive(Eq, @debug.Debug)
 pub fn LineType::atx_heading(String, last~ : Int, start~ : Int) -> Self
 pub fn LineType::ext_footnote_label(StringBuilder, String, line_pos~ : LinePos, last~ : Int, start~ : Int) -> Self
 pub fn LineType::ext_table_row(String, last~ : Int, start~ : Int) -> Self
@@ -99,34 +100,31 @@ pub fn LineType::thematic_break(String, last~ : Int, start~ : Int) -> Self
 pub(all) enum ListType {
   Unordered(Char)
   Ordered(Int, Char)
-} derive(Eq, Show, ToJson, @json.FromJson)
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn ListType::is_same_type(Self, Self) -> Bool
 
 pub(all) struct Meta {
   id : Int
   loc : TextLoc
   extra : Error?
-}
+} derive(@debug.Debug)
 pub fn Meta::compare(Self, Self) -> Int
 pub fn Meta::is_none(Self) -> Bool
 pub fn Meta::new(loc? : TextLoc) -> Self
 pub fn Meta::none() -> Self
-pub fn Meta::to_json(Self) -> Json
 pub impl Eq for Meta
-pub impl Show for Meta
-pub impl ToJson for Meta
 
 pub(all) struct NextLineFn[A]((A) -> LineSpan?)
 
 pub(all) enum NextLineResult {
   ThisLine(Int)
   NextLine(LineSpan, Int)
-} derive(Show, ToJson)
+} derive(@debug.Debug)
 
 pub(all) struct Span {
   start : Int
   span : LineSpan
-} derive(Compare, Eq, Show, ToJson)
+} derive(Compare, Eq, @debug.Debug)
 
 pub(all) struct TextLoc {
   file : String
@@ -134,7 +132,7 @@ pub(all) struct TextLoc {
   last_ccode : Int
   first_line : LinePos
   last_line : LinePos
-} derive(Compare, Eq, Show, ToJson, @json.FromJson)
+} derive(Compare, Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn TextLoc::after(Self) -> Self
 pub fn TextLoc::is_empty(Self) -> Bool
 pub fn TextLoc::is_none(Self) -> Bool

--- a/src/cmark_base/raw_html_test.mbt
+++ b/src/cmark_base/raw_html_test.mbt
@@ -22,7 +22,7 @@ test "raw_html with invalid input" {
     line=line_span,
     start=0,
   )
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -41,9 +41,17 @@ test "raw_html with processing instruction" {
     line=line_span,
     start=0,
   )
-  inspect(
+  debug_inspect(
     result,
-    content="Some(({pos: LinePos(1, 0), first: 0, last: 20}, [{start: 0, span: {pos: LinePos(1, 0), first: 0, last: 20}}], 20))",
+    content=(
+      #|Some(
+      #|  (
+      #|    { pos: LinePos(1, 0), first: 0, last: 20 },
+      #|    [{ start: 0, span: { pos: LinePos(1, 0), first: 0, last: 20 } }],
+      #|    20,
+      #|  ),
+      #|)
+    ),
   )
 }
 
@@ -63,9 +71,17 @@ test "raw_html with HTML comment" {
     line=line_span,
     start=0,
   )
-  inspect(
+  debug_inspect(
     result,
-    content="Some(({pos: LinePos(1, 0), first: 0, last: 12}, [{start: 0, span: {pos: LinePos(1, 0), first: 0, last: 12}}], 12))",
+    content=(
+      #|Some(
+      #|  (
+      #|    { pos: LinePos(1, 0), first: 0, last: 12 },
+      #|    [{ start: 0, span: { pos: LinePos(1, 0), first: 0, last: 12 } }],
+      #|    12,
+      #|  ),
+      #|)
+    ),
   )
 }
 
@@ -85,9 +101,17 @@ test "raw_html with declaration" {
     line=line_span,
     start=0,
   )
-  inspect(
+  debug_inspect(
     result,
-    content="Some(({pos: LinePos(1, 0), first: 0, last: 14}, [{start: 0, span: {pos: LinePos(1, 0), first: 0, last: 14}}], 14))",
+    content=(
+      #|Some(
+      #|  (
+      #|    { pos: LinePos(1, 0), first: 0, last: 14 },
+      #|    [{ start: 0, span: { pos: LinePos(1, 0), first: 0, last: 14 } }],
+      #|    14,
+      #|  ),
+      #|)
+    ),
   )
 }
 
@@ -107,9 +131,17 @@ test "raw_html with CDATA section" {
     line=line_span,
     start=0,
   )
-  inspect(
+  debug_inspect(
     result,
-    content="Some(({pos: LinePos(1, 0), first: 0, last: 15}, [{start: 0, span: {pos: LinePos(1, 0), first: 0, last: 15}}], 15))",
+    content=(
+      #|Some(
+      #|  (
+      #|    { pos: LinePos(1, 0), first: 0, last: 15 },
+      #|    [{ start: 0, span: { pos: LinePos(1, 0), first: 0, last: 15 } }],
+      #|    15,
+      #|  ),
+      #|)
+    ),
   )
 }
 
@@ -129,7 +161,7 @@ test "raw_html with invalid char after <!" {
     line=line_span,
     start=0,
   )
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///| Additional tests for raw_html.mbt to improve coverage
@@ -150,7 +182,7 @@ test "raw_html_invalid_start" {
     line=line_span,
     start=0,
   )
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -169,9 +201,17 @@ test "raw_html_closing_tag_invalid_name" {
     line=line_span,
     start=0,
   )
-  inspect(
+  debug_inspect(
     result,
-    content="Some(({pos: LinePos(1, 0), first: 6, last: 6}, [{start: 0, span: {pos: LinePos(1, 0), first: 0, last: 6}}], 6))",
+    content=(
+      #|Some(
+      #|  (
+      #|    { pos: LinePos(1, 0), first: 6, last: 6 },
+      #|    [{ start: 0, span: { pos: LinePos(1, 0), first: 0, last: 6 } }],
+      #|    6,
+      #|  ),
+      #|)
+    ),
   )
 }
 
@@ -191,7 +231,7 @@ test "raw_html_closing_tag_no_end" {
     line=line_span,
     start=0,
   )
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -210,9 +250,17 @@ test "raw_html_open_tag_invalid" {
     line=line_span,
     start=0,
   )
-  inspect(
+  debug_inspect(
     result,
-    content="Some(({pos: LinePos(1, 0), first: 5, last: 5}, [{start: 0, span: {pos: LinePos(1, 0), first: 0, last: 5}}], 5))",
+    content=(
+      #|Some(
+      #|  (
+      #|    { pos: LinePos(1, 0), first: 5, last: 5 },
+      #|    [{ start: 0, span: { pos: LinePos(1, 0), first: 0, last: 5 } }],
+      #|    5,
+      #|  ),
+      #|)
+    ),
   )
 }
 
@@ -232,7 +280,7 @@ test "raw_html_self_closing_tag_no_end" {
     line=line_span,
     start=0,
   )
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -251,7 +299,7 @@ test "raw_html_attribute_invalid_name" {
     line=line_span,
     start=0,
   )
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -270,9 +318,17 @@ test "raw_html_attribute_no_value" {
     line=line_span,
     start=0,
   )
-  inspect(
+  debug_inspect(
     result,
-    content="Some(({pos: LinePos(1, 0), first: 14, last: 14}, [{start: 0, span: {pos: LinePos(1, 0), first: 0, last: 14}}], 14))",
+    content=(
+      #|Some(
+      #|  (
+      #|    { pos: LinePos(1, 0), first: 14, last: 14 },
+      #|    [{ start: 0, span: { pos: LinePos(1, 0), first: 0, last: 14 } }],
+      #|    14,
+      #|  ),
+      #|)
+    ),
   )
 }
 
@@ -292,9 +348,17 @@ test "raw_html_attribute_unquoted_value" {
     line=line_span,
     start=0,
   )
-  inspect(
+  debug_inspect(
     result,
-    content="Some(({pos: LinePos(1, 0), first: 20, last: 20}, [{start: 0, span: {pos: LinePos(1, 0), first: 0, last: 20}}], 20))",
+    content=(
+      #|Some(
+      #|  (
+      #|    { pos: LinePos(1, 0), first: 20, last: 20 },
+      #|    [{ start: 0, span: { pos: LinePos(1, 0), first: 0, last: 20 } }],
+      #|    20,
+      #|  ),
+      #|)
+    ),
   )
 }
 
@@ -314,7 +378,7 @@ test "raw_html_exclamation_invalid" {
     line=line_span,
     start=0,
   )
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -333,7 +397,7 @@ test "raw_html_exclamation_too_short" {
     line=line_span,
     start=0,
   )
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -352,7 +416,7 @@ test "raw_html_comment_incomplete" {
     line=line_span,
     start=0,
   )
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -371,7 +435,7 @@ test "raw_html_comment_invalid1" {
     line=line_span,
     start=0,
   )
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -390,7 +454,7 @@ test "raw_html_comment_invalid2" {
     line=line_span,
     start=0,
   )
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -409,7 +473,7 @@ test "raw_html_cdata_incomplete" {
     line=line_span,
     start=0,
   )
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -428,5 +492,5 @@ test "raw_html_cdata_wrong_format" {
     line=line_span,
     start=0,
   )
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }

--- a/src/cmark_base/raw_html_wbtest.mbt
+++ b/src/cmark_base/raw_html_wbtest.mbt
@@ -3,21 +3,21 @@
 test "tag_name with valid tag" {
   let s = "div class=\"test\">"
   let result = tag_name(s, last=16, start=0)
-  inspect(result, content="Some(2)")
+  debug_inspect(result, content="Some(2)")
 }
 
 ///|
 test "tag_name with hyphen" {
   let s = "custom-tag>"
   let result = tag_name(s, last=10, start=0)
-  inspect(result, content="Some(9)")
+  debug_inspect(result, content="Some(9)")
 }
 
 ///|
 test "tag_name with invalid start condition" {
   let s = "1div>"
   let result = tag_name(s, last=4, start=0)
-  inspect(result, content="Some(3)")
+  debug_inspect(result, content="Some(3)")
 }
 
 ///|
@@ -25,26 +25,26 @@ test "tag_name with invalid start condition" {
 test "attribute_name with valid start chars" {
   let s = "_attr:value"
   let result = attribute_name(s, last=9, start=0)
-  inspect(result, content="Some(9)")
+  debug_inspect(result, content="Some(9)")
 }
 
 ///|
 test "attribute_name with valid continuation chars" {
   let s = "attr.name-with_colons:value"
   let result = attribute_name(s, last=24, start=0)
-  inspect(result, content="Some(24)")
+  debug_inspect(result, content="Some(24)")
 }
 
 ///|
 test "attribute_name with invalid start" {
   let s = ".invalid"
   let result = attribute_name(s, last=7, start=0)
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
 test "attribute_name when start > last" {
   let s = "attr"
   let result = attribute_name(s, last=3, start=4)
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }

--- a/src/cmark_base/runs_test.mbt
+++ b/src/cmark_base/runs_test.mbt
@@ -1,6 +1,6 @@
 ///|
 test "rev_drop_spaces when start is less than first" {
-  inspect(
+  debug_inspect(
     @cmark_base.rev_drop_spaces("hello world", first=5, start=3),
     content="4",
   )
@@ -8,7 +8,7 @@ test "rev_drop_spaces when start is less than first" {
 
 ///|
 test "rev_drop_spaces with spaces" {
-  inspect(
+  debug_inspect(
     @cmark_base.rev_drop_spaces("hello   world", first=0, start=7),
     content="4",
   )
@@ -16,5 +16,8 @@ test "rev_drop_spaces with spaces" {
 
 ///|
 test "rev_drop_spaces with no spaces" {
-  inspect(@cmark_base.rev_drop_spaces("hello", first=0, start=4), content="4")
+  debug_inspect(
+    @cmark_base.rev_drop_spaces("hello", first=0, start=4),
+    content="4",
+  )
 }

--- a/src/cmark_base/text_loc.mbt
+++ b/src/cmark_base/text_loc.mbt
@@ -5,7 +5,7 @@ pub(all) struct TextLoc {
   last_ccode : CharCodePos
   first_line : LinePos
   last_line : LinePos
-} derive(Eq, Compare, Show, FromJson, ToJson)
+} derive(Eq, Compare, Debug, FromJson, ToJson)
 
 ///|
 let text_loc_none : TextLoc = {
@@ -96,7 +96,7 @@ pub let line_num_none = -1
 
 ///|
 pub(all) struct LinePos(LineNum, CharCodePos) derive (
-  Show,
+  Debug,
   Eq,
   Compare,
   FromJson,
@@ -111,14 +111,14 @@ pub(all) struct LineSpan {
   pos : LinePos
   first : CharCodePos
   last : CharCodePos
-} derive(Show, ToJson, Eq, Compare)
+} derive(Debug, Eq, Compare)
 
 ///|
 ///  A line span with the byte position on where the line starts (inside a CommonMark container).  The [line_start] is the start of line in the container, the [line_span] has the actual data. The characters in the \[[line_start];[line_span.first - 1]\] are blanks.
 pub(all) struct Span {
   start : CharCodePos
   span : LineSpan
-} derive(Show, ToJson, Eq, Compare)
+} derive(Debug, Eq, Compare)
 
 ///|
 pub(all) struct NextLineFn[A]((A) -> LineSpan?)
@@ -127,4 +127,4 @@ pub(all) struct NextLineFn[A]((A) -> LineSpan?)
 pub(all) enum NextLineResult {
   ThisLine(CharCodePos)
   NextLine(LineSpan, CharCodePos)
-} derive(Show, ToJson)
+} derive(Debug)

--- a/src/cmark_base/text_loc_test.mbt
+++ b/src/cmark_base/text_loc_test.mbt
@@ -1,41 +1,47 @@
 ///|
 test "TextLoc::is_none with none value" {
   let loc = @cmark_base.TextLoc::none()
-  inspect(loc.is_none(), content="true")
+  debug_inspect(loc.is_none(), content="true")
 }
 
 ///|
 test "TextLoc::is_empty for non-empty location" {
   let loc = @cmark_base.TextLoc::none()
   let loc = { ..loc, first_ccode: 10, last_ccode: 5 }
-  inspect(loc.is_empty(), content="true")
+  debug_inspect(loc.is_empty(), content="true")
 }
 
 ///|
 test "TextLoc::is_empty for empty location" {
   let loc = @cmark_base.TextLoc::none()
   let loc = { ..loc, first_ccode: 5, last_ccode: 10 }
-  inspect(loc.is_empty(), content="false")
+  debug_inspect(loc.is_empty(), content="false")
 }
 
 ///|
 test "TextLoc::after basic functionality" {
   let loc = @cmark_base.TextLoc::none()
   let after_loc = loc.after()
-  inspect(after_loc.first_ccode, content="0")
-  inspect(after_loc.last_ccode, content="-1")
-  inspect(after_loc.first_line, content="LinePos(-1, -1)")
-  inspect(after_loc.last_line, content="LinePos(-1, -1)")
+  debug_inspect(after_loc.first_ccode, content="0")
+  debug_inspect(after_loc.last_ccode, content="-1")
+  debug_inspect(after_loc.first_line, content="LinePos(-1, -1)")
+  debug_inspect(after_loc.last_line, content="LinePos(-1, -1)")
 }
 
 ///|
 test "test case TextLoc::reloc" {
   let loc1 = @cmark_base.TextLoc::none()
   let loc2 = @cmark_base.TextLoc::none()
-  inspect(
+  debug_inspect(
     loc1.reloc(loc2),
     content=(
-      #|{file: "-", first_ccode: -1, last_ccode: -1, first_line: LinePos(-1, -1), last_line: LinePos(-1, -1)}
+      #|{
+      #|  file: "-",
+      #|  first_ccode: -1,
+      #|  last_ccode: -1,
+      #|  first_line: LinePos(-1, -1),
+      #|  last_line: LinePos(-1, -1),
+      #|}
     ),
   )
 }
@@ -50,9 +56,9 @@ test "TextLoc to_first method test" {
     last_line: @cmark_base.LinePos(2, 20),
   }
   let modified_loc = initial_loc.to_first()
-  inspect(modified_loc.last_ccode, content="10")
-  inspect(modified_loc.last_line.0, content="1")
-  inspect(modified_loc.last_line.1, content="10")
+  debug_inspect(modified_loc.last_ccode, content="10")
+  debug_inspect(modified_loc.last_line.0, content="1")
+  debug_inspect(modified_loc.last_line.1, content="10")
 }
 
 ///|
@@ -65,6 +71,6 @@ test "TextLoc to_last method" {
     last_line: LinePos(1, 20),
   }
   let loc_transformed = loc_initial.to_last()
-  inspect(loc_transformed.first_ccode, content="20")
-  inspect(loc_transformed.first_line, content="LinePos(1, 20)")
+  debug_inspect(loc_transformed.first_ccode, content="20")
+  debug_inspect(loc_transformed.first_line, content="LinePos(1, 20)")
 }

--- a/src/cmark_html/html.mbt
+++ b/src/cmark_html/html.mbt
@@ -8,12 +8,6 @@ priv struct State {
   ids : StringSet
   mut footnote_count : Int
   footnotes : Map[LabelKey, HtmlRenderFootnote]
-} derive(Show)
-
-///|
-test {
-  // Prevent warning about unused Show
-  (fn(s : State) { s.to_string() }) |> ignore()
 }
 
 ///|
@@ -22,12 +16,6 @@ priv struct HtmlRenderFootnote {
   id : String
   mut count : Int
   footnote : @cmark.Footnote
-} derive(Show, ToJson)
-
-///|
-test {
-  // Prevent warning about unused ToJson
-  (fn(h : HtmlRenderFootnote) { h.to_json() }) |> ignore()
 }
 
 ///|

--- a/src/cmark_renderer/error.mbt
+++ b/src/cmark_renderer/error.mbt
@@ -1,4 +1,15 @@
 ///|
 pub(all) suberror RenderError {
   RenderError(String)
-} derive(Show)
+} derive(Debug)
+
+///|
+pub impl Show for RenderError with output(self, logger) {
+  match self {
+    RenderError(message) => {
+      logger.write_string("RenderError(")
+      logger.write_object(message)
+      logger.write_char(')')
+    }
+  }
+}

--- a/src/cmark_renderer/pkg.generated.mbti
+++ b/src/cmark_renderer/pkg.generated.mbti
@@ -4,6 +4,7 @@ package "moonbit-community/cmark/cmark_renderer"
 import {
   "moonbit-community/cmark/cmark",
   "moonbit-community/cmark/cmark_base",
+  "moonbitlang/core/debug",
 }
 
 // Values
@@ -11,7 +12,8 @@ import {
 // Errors
 pub(all) suberror RenderError {
   RenderError(String)
-} derive(Show)
+} derive(@debug.Debug)
+pub impl Show for RenderError
 
 // Types and methods
 pub(all) struct BlockFn((Context, @cmark.Block) -> Bool raise)


### PR DESCRIPTION
## Summary

- Replace debug-only `derive(Show)` usage with `derive(Debug)` and `debug_inspect` snapshots.
- Keep hand-written `Show` only for error display types.
- Remove standalone/debug-only `ToJson`; remaining `ToJson` derives are paired with `FromJson`.
- Regenerate MoonBit snapshots and `pkg.generated.mbti` files.

## Fresh Codex CLI Review

I ran a fresh `codex review` twice: once on the staged cleanup and once on the full branch diff against `origin/main`.

Both reviews reported the same P2 concern: removing public `ToJson` from `Doc` and the AST surface breaks downstream callers such as `@cmark.Doc::from_string(markdown).to_json()`. This is left in the PR as intentional review scope, because the requested direction was to remove debug-only JSON serialization unless a type also has `FromJson`.

## Validation

- `moon fmt`
- `moon info`
- `moon check`
- `moon test` (`366` passed)
- `moon check --target all` (passes with an unused-package warning for `myfreess/charclass/unicode` in `src/cmark/moon.pkg`)
- `moon test --target all` (`366` passed on wasm, wasm-gc, js, and native; same unused-package warning on js)
- `git diff --check`

Note: the fresh review also tried `moon -C cmarkwrap check`, which fails in `moonbitlang/x/internal/ffi` dependency code unrelated to this PR.