### PR TITLE
[codex] Use string index syntax for code units

### DIFF
--- a/src/char/text.mbt
+++ b/src/char/text.mbt
@@ -16,10 +16,10 @@ pub fn at_checked(s : StringView, idx : Int) -> Result[Char, Int] {
     ((leading.to_int() - 0xD800) * 0x400 + trailing.to_int() - 0xDC00 + 0x10000).unsafe_to_char()
   }
 
-  let c1 = s.code_unit_at(idx)
+  let c1 = s[idx]
   if is_leading_surrogate(c1) {
     guard idx + 1 < s.length() else { Err(c1.to_int()) }
-    let c2 = s.code_unit_at(idx + 1)
+    let c2 = s[idx + 1]
     Ok(code_point_of_surrogate_pair(c1, c2))
   } else if is_trailing_surrogate(c1) {
     Err(c1.to_int())
@@ -43,7 +43,7 @@ pub fn sub_includes(
   for i = first, k = 0 {
     guard i <= max_idx_s else { return false }
     guard k <= max_idx_a else { return true }
-    if s.code_unit_at(i + k) == affix.code_unit_at(k) {
+    if s[i + k] == affix[k] {
       continue i, k + 1
     }
     continue i + 1, 0
@@ -55,7 +55,7 @@ pub fn prev_char(s : StringView, first~ : Int, before~ : Int) -> Char {
   guard first < before else { ' ' }
   let k = for start = before - 1; ; start = start - 1 {
     guard first <= start else { break first }
-    if s.code_unit_at(start)
+    if s[start]
       is ('\u{0}'..='\u{7f}'
       | '\u{c2}'..='\u{df}'
       | '\u{e0}'..='\u{ef}'
@@ -98,13 +98,13 @@ pub fn utf_16_clean_raw(
         flush(last, start, k)
         break buf.to_string()
       }
-      if s.code_unit_at(k) == '\u{0}' {
+      if s[k] == '\u{0}' {
         let next = k + 1
         flush(last, start, k)
         buf.write_char(rep)
         continue next, next
       }
-      if s.code_unit_at(k).to_char() is Some(c) && c.is_ascii() {
+      if s[k].to_char() is Some(c) && c.is_ascii() {
         continue start, k + 1
       }
       match at_checked(s, k) {
@@ -126,10 +126,10 @@ pub fn utf_16_clean_raw(
     for k = k {
       break if k > last {
         s[first:last + 1].to_owned()
-      } else if s.code_unit_at(k) == '\u{0}' {
+      } else if s[k] == '\u{0}' {
         buf.reset()
         clean(last, first, k)
-      } else if s.code_unit_at(k).to_char() is Some(c) && c.is_ascii() {
+      } else if s[k].to_char() is Some(c) && c.is_ascii() {
         continue k + 1
       } else {
         match at_checked(s, k) {
@@ -214,7 +214,7 @@ fn _utf_16_clean_unesc_unref(
       if k > last || k > num_start + 6 {
         return resolve(last, start, k)
       }
-      match s.code_unit_at(k) {
+      match s[k] {
         ';' => {
           let next = k + 1
           if k == num_start {
@@ -242,7 +242,7 @@ fn _utf_16_clean_unesc_unref(
       if k > last || k > num_start + 7 {
         return resolve(last, start, k)
       }
-      match s.code_unit_at(k) {
+      match s[k] {
         ';' => {
           let next = k + 1
           if k == num_start {
@@ -271,7 +271,7 @@ fn _utf_16_clean_unesc_unref(
       if k > last {
         return resolve(last, start, k)
       }
-      match s.code_unit_at(k) {
+      match s[k] {
         ';' => {
           let name = s[name_start:k].to_owned()
           match html_named_entity(name) {
@@ -299,7 +299,7 @@ fn _utf_16_clean_unesc_unref(
         return buf.to_string()
       }
       let next = k + 1
-      match (s.code_unit_at(k), do_unesc) {
+      match (s[k], do_unesc) {
         ('\u{0}', _) => {
           flush(last, start, k)
           buf.write_char(rep)
@@ -309,7 +309,7 @@ fn _utf_16_clean_unesc_unref(
           if next > last {
             continue start, next
           }
-          let nc = s.code_unit_at(next).unsafe_to_char()
+          let nc = s[next].unsafe_to_char()
           if !is_ascii_punctuation(nc) {
             continue start, next
           }
@@ -322,10 +322,10 @@ fn _utf_16_clean_unesc_unref(
           if k + 2 > last {
             continue start, next
           }
-          match s.code_unit_at(next) {
+          match s[next] {
             '#' => {
               let next = next + 1
-              match s.code_unit_at(next) {
+              match s[next] {
                 'x' | 'X' => {
                   let next = next + 1
                   return try_entity_hex(last, start, next, next, 0)
@@ -373,7 +373,7 @@ fn _utf_16_clean_unesc_unref(
   let first = @cmp.maximum(first, 0)
   for k = first {
     guard k <= last else { break s[first:last + 1].to_owned() }
-    match (s.code_unit_at(k), do_unesc) {
+    match (s[k], do_unesc) {
       ('\\', true) | ('&', _) | ('\u{0}', _) => {
         buf.reset()
         break resolve(last, first, k)

--- a/src/cmark/block.mbt
+++ b/src/cmark/block.mbt
@@ -180,7 +180,7 @@ pub fn CodeBlock::make_fence(self : CodeBlock) -> (Char, Count) {
   for n in self.code {
     let c = n.v
     let mut k = 0
-    while k < c.length() && c.code_unit_at(k) == ch.to_int().to_uint16() {
+    while k < c.length() && c[k] == ch.to_int().to_uint16() {
       // TODO(upstream): provide UInt16 ~ Char comparison
       k += 1
     }
@@ -467,12 +467,12 @@ fn Table::parse_sep_row(
       [(Text({ v, meta }), TableCellLayout(("", ""))), .. cs] => {
         guard !v.is_empty() else { break None }
         let max = v.length() - 1
-        let first_colon = v.code_unit_at(0) == ':'
-        let last_colon = v.code_unit_at(max) == ':'
+        let first_colon = v[0] == ':'
+        let last_colon = v[max] == ':'
         let first = if first_colon { 1 } else { 0 }
         let last = if last_colon { max - 1 } else { max }
         let all_dashes = for i in first..<=last {
-          guard v.code_unit_at(i) == '-' else { break false }
+          guard v[i] == '-' else { break false }
         } nobreak {
           true
         }

--- a/src/cmark/block_struct.mbt
+++ b/src/cmark/block_struct.mbt
@@ -34,7 +34,7 @@ fn Parser::update_next_non_blank(self : Parser) -> Unit {
       self.next_non_blank = k
       self.next_non_blank_col = col
     } else {
-      match s.code_unit_at(k) {
+      match s[k] {
         ' ' => continue k + 1, col + 1
         '\t' => continue k + 1, next_tab_stop(col)
         _ => {
@@ -52,7 +52,7 @@ fn Parser::accept_cols(self : Parser, count~ : Int) -> Unit {
     break if count == 0 {
       self.curr_char = k
       self.curr_char_col = col
-    } else if self.i.code_unit_at(k) != '\t' {
+    } else if self.i[k] != '\t' {
       continue count - 1, k + 1, col + 1
     } else {
       let col1 = next_tab_stop(col)
@@ -72,7 +72,7 @@ fn Parser::accept_cols(self : Parser, count~ : Int) -> Unit {
 ///|
 /// https://spec.commonmark.org/current/#block-quote-marker
 fn Parser::match_and_accept_block_quote(self : Parser) -> Bool {
-  if self.end_of_line() || self.i.code_unit_at(self.curr_char) != '>' {
+  if self.end_of_line() || self.i[self.curr_char] != '>' {
     return false
   }
   let next_is_blank = {
@@ -307,7 +307,7 @@ fn Parser::fenced_code_block(
   }
   let opening_fence = self.curr_line_span(first=fence_first, last=layout_last)
   let fence = (
-    self.i.code_unit_at(fence_first).unsafe_to_char(),
+    self.i[fence_first].unsafe_to_char(),
     fence_last - fence_first + 1,
   )
   let fence = { indent, opening_fence, fence, info_string, closing_fence: None }
@@ -419,7 +419,7 @@ fn Parser::parse_link_ref_definition(
     None
   }
   let colon = last + 1
-  guard colon <= line.last && self.i.code_unit_at(colon) == ':' else { None }
+  guard colon <= line.last && self.i[colon] == ':' else { None }
   let label = Parser::label_of_spans(self, key~, spans[:])
   let (lines, line, label, start) = (lines, line, label, colon + 1)
   guard self.first_non_blank_over_nl(next_line~, lines, line, start~)
@@ -480,7 +480,7 @@ fn Parser::parse_link_ref_definition(
       (
         lines1,
         after_dest,
-        self.i.code_unit_at(start1).unsafe_to_char(),
+        self.i[start1].unsafe_to_char(),
         Some(t),
         after_title,
         { ..line1, last, },
@@ -703,7 +703,7 @@ fn Parser::match_line_type(
   }
   let start = self.curr_char
   let last = self.curr_line_last_char
-  match self.i.code_unit_at(start) {
+  match self.i[start] {
     // Early dispatch shaves a few ms but may not be worth doing vs 
     // testing all the cases in sequences.
     '>' => {
@@ -1331,9 +1331,7 @@ fn Parser::add_line(self : Parser, bs : Array[BlockStruct]) -> Unit {
 fn Parser::get_first_line(self : Parser) -> String {
   let max = self.i.length() - 1
   let mut k = 0
-  let last_char = while k <= max &&
-                        self.i.code_unit_at(k) != '\r' &&
-                        self.i.code_unit_at(k) != '\n' {
+  let last_char = while k <= max && self.i[k] != '\r' && self.i[k] != '\n' {
     k += 1
   } nobreak {
     // If the line is empty, we have -1
@@ -1342,11 +1340,11 @@ fn Parser::get_first_line(self : Parser) -> String {
   self.curr_line_last_char = last_char
   self.update_next_non_blank()
   // Return first used newline (or "\n" if there is none)
-  if k > max || self.i.code_unit_at(k) == '\n' {
+  if k > max || self.i[k] == '\n' {
     return "\n"
   }
   let next = k + 1
-  if next <= max && self.i.code_unit_at(next) == '\n' {
+  if next <= max && self.i[next] == '\n' {
     return "\r\n"
   }
   "\r"
@@ -1360,18 +1358,18 @@ fn Parser::get_next_line(self : Parser) -> Bool {
   }
   let first_char = {
     let nl = self.curr_line_last_char + 1
-    if self.i.code_unit_at(nl) == '\n' {
+    if self.i[nl] == '\n' {
       nl + 1
     } else {
       let mut next = nl + 1
-      if next <= max && self.i.code_unit_at(next) == '\n' {
+      if next <= max && self.i[next] == '\n' {
         next += 1
       }
       next
     }
   }
   let last_char = for k = first_char
-                      k <= max && !(self.i.code_unit_at(k) is ('\r' | '\n'))
+                      k <= max && !(self.i[k] is ('\r' | '\n'))
                       k = k + 1 {
 
   } nobreak {

--- a/src/cmark/inline.mbt
+++ b/src/cmark/inline.mbt
@@ -308,7 +308,7 @@ pub fn InlineCodeSpan::from_string(
       }
       break layout
     }
-    let sk = s.code_unit_at(k)
+    let sk = s[k]
     if sk == '`' {
       continue btc + 1, start, k + 1
     }
@@ -317,7 +317,7 @@ pub fn InlineCodeSpan::from_string(
     }
     guard sk is ('\n' | '\r') else { continue 0, start, k + 1 }
     BlockLine::flush_tight(meta~, s, start, k - 1, acc)
-    let start = if k + 1 <= max && sk == '\r' && s.code_unit_at(k + 1) == '\n' {
+    let start = if k + 1 <= max && sk == '\r' && s[k + 1] == '\n' {
       k + 2
     } else {
       k + 1

--- a/src/cmark/inline_struct.mbt
+++ b/src/cmark/inline_struct.mbt
@@ -243,8 +243,7 @@ fn Token::newline(
   // https://spec.commonmark.org/current/#hard-line-breaks
   let { first, last, .. } = prev_line
   let non_space = @cmark_base.rev_drop_spaces(s, first~, start=last)
-  let (start, break_ty) = if non_space == last &&
-    s.code_unit_at(non_space) == '\\' {
+  let (start, break_ty) = if non_space == last && s[non_space] == '\\' {
     (non_space, Hard)
   } else {
     let start = non_space + 1
@@ -275,7 +274,7 @@ fn tokens_try_add_image_link_start(
   start~ : Int,
 ) -> Int {
   let next = start + 1
-  guard next <= line.last && s.code_unit_at(next) == '[' else { next }
+  guard next <= line.last && s[next] == '[' else { next }
   toks.push(LinkStart({ start, image: true }))
   next + 1
 }
@@ -288,7 +287,7 @@ fn tokens_try_add_emphasis(
   start~ : Int,
 ) -> Int {
   let { first, last, .. } = line
-  let char = s.code_unit_at(start).unsafe_to_char()
+  let char = s[start].unsafe_to_char()
   let run_last = @cmark_base.run_of(char~, last~, s, start=start + 1)
   let count = run_last - start + 1
   let prev_char = @char.prev_char(s, first~, before=start)
@@ -320,7 +319,7 @@ fn tokens_try_add_strikethrough_marks(
   start~ : Int,
 ) -> Int {
   let { first, last, .. } = line
-  let char = s.code_unit_at(start).unsafe_to_char()
+  let char = s[start].unsafe_to_char()
   let run_last = @cmark_base.run_of(char~, s, last~, start=start + 1)
   let count = run_last - start + 1
   let next = run_last + 1
@@ -341,7 +340,7 @@ fn tokens_try_add_math_span_marks(
   start~ : Int,
 ) -> Int {
   let { first, last, .. } = line
-  let char = s.code_unit_at(start).unsafe_to_char()
+  let char = s[start].unsafe_to_char()
   let run_last = @cmark_base.run_of(char~, s, last~, start=start + 1)
   let count = run_last - start + 1
   let next = run_last + 1
@@ -378,7 +377,7 @@ fn tokenize(
         }
       }
     }
-    let next = match s.code_unit_at(k) {
+    let next = match s[k] {
       '\\' => continue lines, line, !prev_bslash, k + 1
       '`' => tokens_add_backtick(toks, s, line, prev_bslash~, start=k)
       _ if prev_bslash => k + 1
@@ -550,7 +549,7 @@ fn Parser::emphasis_token(
   emph : Inline,
 ) -> Token {
   let text_loc = self.text_loc_of_lines(first~, last~, first_line~, last_line~)
-  let delim = self.i.code_unit_at(first).unsafe_to_char()
+  let delim = self.i[first].unsafe_to_char()
   let emph = { v: { delim, inline: emph }, meta: self.meta(text_loc) }
   let inline = if strong { StrongEmphasis(emph) } else { Emphasis(emph) }
   Inline({ start: first, inline, endline: last_line, next: last + 1 })
@@ -887,7 +886,7 @@ fn Parser::try_inline_link_remainder(
             (
               line,
               after_dest,
-              self.i.code_unit_at(start).unsafe_to_char(),
+              self.i[start].unsafe_to_char(),
               Some(title),
               last + 1,
             )
@@ -903,7 +902,7 @@ fn Parser::try_inline_link_remainder(
       start~,
     )
     .unwrap_or((line, [], start))
-  if last > line.last || self.i.code_unit_at(last) != ')' {
+  if last > line.last || self.i[last] != ')' {
     return None
   }
   let layout : LinkDefinitionLayout = {
@@ -1010,7 +1009,7 @@ fn Parser::try_link_def(
   let link = if next > line.last {
     self.try_shortcut_reflink(start_rev_toks, start_line, image~, start~)
   } else {
-    match self.i.code_unit_at(next) {
+    match self.i[next] {
       '(' =>
         match
           self.try_inline_link_remainder(rev_toks, line, image~, start=next) {
@@ -1025,7 +1024,7 @@ fn Parser::try_link_def(
         }
       '[' => {
         let next1 = next + 1
-        if next1 <= line.last && self.i.code_unit_at(next1) == ']' {
+        if next1 <= line.last && self.i[next1] == ']' {
           self.try_collapsed_reflink(start_rev_toks, start_line, image~, start~)
         } else {
           let r = self.try_full_reflink_remainder(

--- a/src/cmark_base/autolink.mbt
+++ b/src/cmark_base/autolink.mbt
@@ -8,19 +8,17 @@ pub fn autolink_email(s : String, last? : Int = -1, start? : Int = 0) -> Last? {
   }
 
   fn label_seq(last : Int, k : Int) -> Int? {
-    guard k <= last &&
-      s.code_unit_at(k).to_char() is Some(c) &&
-      @char.is_ascii_alphanum(c) else {
+    guard k <= last && s[k].to_char() is Some(c) && @char.is_ascii_alphanum(c) else {
       return None
     }
     for c = 1, k = k + 1 {
       guard k <= last else { break None }
-      let sk = s.code_unit_at(k).unsafe_to_char()
+      let sk = s[k].unsafe_to_char()
       if char_is_alphanum_or_hyp(sk) && c <= 63 {
         continue c + 1, k + 1
       }
       guard c <= 63 &&
-        s.code_unit_at(k - 1).to_char() is Some(c) &&
+        s[k - 1].to_char() is Some(c) &&
         @char.is_ascii_alphanum(c) else {
         break None
       }
@@ -32,15 +30,13 @@ pub fn autolink_email(s : String, last? : Int = -1, start? : Int = 0) -> Last? {
     }
   }
 
-  guard start <= last || s.code_unit_at(start) == '<' else { None }
+  guard start <= last || s[start] == '<' else { None }
   for k in (start + 1)..<=last {
-    let sk = s.code_unit_at(k).unsafe_to_char()
+    let sk = s[k].unsafe_to_char()
     if char_is_atext_plus_dot(sk) {
       continue
     }
-    if sk == '@' &&
-      s.code_unit_at(k - 1).to_char() is Some(c) &&
-      char_is_atext_plus_dot(c) {
+    if sk == '@' && s[k - 1].to_char() is Some(c) && char_is_atext_plus_dot(c) {
       break label_seq(last, k + 1)
     }
     break None
@@ -71,7 +67,7 @@ pub fn autolink_uri(s : String, last? : Int = -1, start? : Int = 0) -> Last? {
   }
   let next = start + 1
   guard next <= last &&
-    s.code_unit_at(start) == '<' &&
+    s[start] == '<' &&
     s.get_char(next).unwrap().is_ascii_alphabetic() else {
     return None
   }

--- a/src/cmark_base/leaf_blocks.mbt
+++ b/src/cmark_base/leaf_blocks.mbt
@@ -51,7 +51,7 @@ pub fn LineType::thematic_break(
   if start > last {
     return Nomatch
   }
-  match s.code_unit_at(start) {
+  match s[start] {
     '-' | '_' | '*' =>
       for count = 1, prev = start, k = start + 1 {
         break if k > last {
@@ -60,9 +60,9 @@ pub fn LineType::thematic_break(
           } else {
             ThematicBreakLine(prev)
           }
-        } else if s.code_unit_at(k) == s.code_unit_at(prev) {
+        } else if s[k] == s[prev] {
           continue count + 1, k, k + 1
-        } else if s.code_unit_at(k) is (' ' | '\t') {
+        } else if s[k] is (' ' | '\t') {
           continue count, prev, k + 1
         } else {
           Nomatch
@@ -80,7 +80,7 @@ pub fn LineType::atx_heading(
   start~ : CharCodePos,
 ) -> LineType {
   fn skip_hashes(s : String, last, k) {
-    for k = k; k <= last && s.code_unit_at(k) == '#'; k = k + 1 {
+    for k = k; k <= last && s[k] == '#'; k = k + 1 {
 
     } nobreak {
       k
@@ -89,7 +89,7 @@ pub fn LineType::atx_heading(
 
   fn find_end(s : String, last, k) { // Blank on k, last + 1 if blank* [#+] blank*
     let after_blank = first_non_blank(s, last~, start=k + 1)
-    if after_blank > last || s.code_unit_at(after_blank) != '#' {
+    if after_blank > last || s[after_blank] != '#' {
       return after_blank
     }
     let after_hash = skip_hashes(s, last, after_blank + 1)
@@ -104,7 +104,7 @@ pub fn LineType::atx_heading(
   fn content(s : String, last, k) {
     for k = k {
       guard k <= last else { break k - 1 }
-      guard s.code_unit_at(k) is (' ' | '\t') else { continue k + 1 }
+      guard s[k] is (' ' | '\t') else { continue k + 1 }
       let end1 = find_end(s, last, k)
       guard end1 <= last else { break k - 1 }
       continue end1
@@ -115,7 +115,7 @@ pub fn LineType::atx_heading(
     if k > last {
       return AtxHeadingLine(acc, k, k, last)
     }
-    if s.code_unit_at(k) == '#' {
+    if s[k] == '#' {
       if acc < 6 {
         return level(s, last, acc + 1, k + 1)
       } else {
@@ -129,7 +129,7 @@ pub fn LineType::atx_heading(
     if first == k {
       return Nomatch // Need a blank
     }
-    let last = if s.code_unit_at(first) != '#' {
+    let last = if s[first] != '#' {
       content(s, last, first + 1)
     } else {
       let end1 = find_end(s, last, first - 1) // Start on blank
@@ -142,7 +142,7 @@ pub fn LineType::atx_heading(
     AtxHeadingLine(acc, k, first, last)
   }
 
-  if start > last || s.code_unit_at(start) != '#' {
+  if start > last || s[start] != '#' {
     return Nomatch
   }
   level(s, last, 1, start + 1)
@@ -158,21 +158,15 @@ pub fn LineType::setext_heading_underline(
   let level = fn(c) { 2 - (c == '=').to_int() }
   fn underline(s : String, last, start, k) {
     if k > last {
-      return SetextUnderlineLine(
-        level(s.code_unit_at(start).unsafe_to_char()),
-        k - 1,
-      )
+      return SetextUnderlineLine(level(s[start].unsafe_to_char()), k - 1)
     }
-    if s.code_unit_at(k) == s.code_unit_at(start) {
+    if s[k] == s[start] {
       return underline(s, last, start, k + 1)
     }
-    guard s.code_unit_at(k) is (' ' | '\t') else { return Nomatch }
+    guard s[k] is (' ' | '\t') else { return Nomatch }
     let end_blank = first_non_blank(s, last~, start=k + 1)
     if end_blank > last {
-      return SetextUnderlineLine(
-        level(s.code_unit_at(start).unsafe_to_char()),
-        k - 1,
-      )
+      return SetextUnderlineLine(level(s[start].unsafe_to_char()), k - 1)
     }
     Nomatch
   }
@@ -180,7 +174,7 @@ pub fn LineType::setext_heading_underline(
   if start > last {
     return Nomatch
   }
-  if s.code_unit_at(start) != '-' && s.code_unit_at(start) != '=' {
+  if s[start] != '-' && s[start] != '=' {
     return Nomatch
   }
   underline(s, last, start, start + 1)
@@ -193,7 +187,7 @@ pub fn LineType::fenced_code_block_start(
   start~ : CharCodePos,
 ) -> LineType {
   fn info(s : String, last, nobt, info_first, k) {
-    let sk = s.code_unit_at(k)
+    let sk = s[k]
     guard k <= last else { Some((info_first, last)) }
     guard !(nobt && sk == '`') else { None }
     guard sk is (' ' | '\t') else { info(s, last, nobt, info_first, k + 1) }
@@ -204,7 +198,7 @@ pub fn LineType::fenced_code_block_start(
 
   fn fence(s : String, last, fence_first, k) {
     for k = k {
-      if k <= last && s.code_unit_at(k) == s.code_unit_at(fence_first) {
+      if k <= last && s[k] == s[fence_first] {
         continue k + 1
       }
       let fence_last = k - 1
@@ -215,13 +209,7 @@ pub fn LineType::fenced_code_block_start(
         if after_blank > last {
           None
         } else {
-          guard info(
-              s,
-              last,
-              s.code_unit_at(fence_first) == '`',
-              after_blank,
-              after_blank,
-            )
+          guard info(s, last, s[fence_first] == '`', after_blank, after_blank)
             is Some(i) else {
             break None
           }
@@ -237,10 +225,10 @@ pub fn LineType::fenced_code_block_start(
   }
   for k = start {
     guard k <= last else { break Nomatch }
-    if k - start + 1 < 4 && s.code_unit_at(k) == ' ' {
+    if k - start + 1 < 4 && s[k] == ' ' {
       continue k + 1
     }
-    guard s.code_unit_at(k) is ('~' | '`') else { break Nomatch }
+    guard s[k] is ('~' | '`') else { break Nomatch }
     break fence(s, last, k, k + 1).unwrap_or(Nomatch)
   }
 }
@@ -268,7 +256,7 @@ pub fn FencedCodeBlockContinue::new(
   let (fc, fcount) = fence
   fn fence(s : String, last, fence_first, k) {
     for k = k {
-      if k <= last && s.code_unit_at(k).unsafe_to_char() == fc {
+      if k <= last && s[k].unsafe_to_char() == fc {
         continue k + 1
       }
       let fence_last = k - 1
@@ -281,7 +269,7 @@ pub fn FencedCodeBlockContinue::new(
 
   for k = start {
     guard k <= last else { break Code } // Short blank line
-    let sk = s.code_unit_at(k).unsafe_to_char()
+    let sk = s[k].unsafe_to_char()
     if k - start + 1 < 4 && sk == ' ' {
       continue k + 1
     }
@@ -327,7 +315,7 @@ fn LineType::html_block_start_2(
   start~ : CharCodePos,
 ) -> LineType {
   let next = start + 3 // 3 first chars checked
-  if next > last || s.code_unit_at(next) != '-' {
+  if next > last || s[next] != '-' {
     return Nomatch
   }
   HtmlBlockLine(EndStr("-->"))
@@ -380,17 +368,17 @@ pub fn LineType::html_block_start(
   start~ : CharCodePos,
 ) -> LineType {
   let next = start + 1
-  if next > last || s.code_unit_at(start) != '<' {
+  if next > last || s[start] != '<' {
     return Nomatch
   }
-  match s.code_unit_at(next).unsafe_to_char() {
+  match s[next].unsafe_to_char() {
     '?' => HtmlBlockLine(EndStr("?>")) // 3
     '!' => {
       let next = next + 1
       if next > last {
         return Nomatch
       }
-      match s.code_unit_at(next).unsafe_to_char() {
+      match s[next].unsafe_to_char() {
         '[' => LineType::html_block_start_5(s, last~, start~)
         '-' => LineType::html_block_start_2(s, last~, start~)
         c =>
@@ -405,7 +393,7 @@ pub fn LineType::html_block_start(
       guard c.is_ascii_alphabetic() || c == '/' else { return Nomatch }
       let tag_first = if c == '/' { next + 1 } else { next }
       let tag_last = for i = tag_first {
-        if i > last || !s.code_unit_at(i).unsafe_to_char().is_ascii_alphabetic() {
+        if i > last || !s[i].unsafe_to_char().is_ascii_alphabetic() {
           break i - 1
         }
         continue i + 1
@@ -414,7 +402,7 @@ pub fn LineType::html_block_start(
       let is_open_end = {
         let n = tag_last + 1
         n > last ||
-        s.code_unit_at(n)
+        s[n]
         is (32
         | 9
         // ' ' | '\t' | '>'
@@ -449,16 +437,14 @@ fn LineType::html_block_end_cond_1(
   let lower_s = s.to_lower()
   for k = start {
     guard k + 3 <= last else { break false }
-    guard s.code_unit_at(k) == '<' && s.code_unit_at(k + 1) == '/' else {
-      continue k + 1
-    }
+    guard s[k] == '<' && s[k + 1] == '/' else { continue k + 1 }
     let next = k + 2
     let is_end_tag = {
       let lower_s_sub = lower_s[next:]
-      match s.code_unit_at(next) {
+      match s[next] {
         'p' => lower_s_sub.has_prefix("pre>")
         's' =>
-          if s.code_unit_at(k + 3) == 't' {
+          if s[k + 3] == 't' {
             lower_s_sub.has_prefix("style>")
           } else {
             lower_s_sub.has_prefix("script>")
@@ -492,12 +478,12 @@ pub fn LineType::ext_table_row(
   last~ : CharCodePos,
   start~ : CharCodePos,
 ) -> LineType {
-  guard start <= last && s.code_unit_at(start) == '|' else { Nomatch }
+  guard start <= last && s[start] == '|' else { Nomatch }
   let first = start + 1
   let last_nb = last_non_blank(s, first~, start=last)
   let before = last_nb - 1
-  guard last_nb >= first && s.code_unit_at(last_nb) == '|' else { Nomatch }
-  guard before < first || s.code_unit_at(before) != '\\' else { Nomatch }
+  guard last_nb >= first && s[last_nb] == '|' else { Nomatch }
+  guard before < first || s[before] != '\\' else { Nomatch }
   ExtTableRow(last_nb)
 }
 
@@ -509,14 +495,10 @@ pub fn LineType::ext_footnote_label(
   last~ : CharCodePos,
   start~ : CharCodePos,
 ) -> LineType {
-  guard start <= last &&
-    s.code_unit_at(start) == '[' &&
-    s.code_unit_at(start + 1) == '^' else {
-    Nomatch
-  }
+  guard start <= last && s[start] == '[' && s[start + 1] == '^' else { Nomatch }
   let rbrack = first_non_escaped_char(']', s, last~, start=start + 2)
   let colon = rbrack + 1
-  guard colon <= last && s.code_unit_at(colon) == ':' && colon - start + 1 >= 5 else {
+  guard colon <= last && s[colon] == ':' && colon - start + 1 >= 5 else {
     Nomatch
   }
   // Get the normalized label
@@ -540,10 +522,10 @@ pub fn could_be_link_ref_definition(
   }
   for k = start {
     guard k <= last else { break false }
-    if k - start + 1 < 4 && s.code_unit_at(k) == ' ' {
+    if k - start + 1 < 4 && s[k] == ' ' {
       continue k + 1
     }
-    break s.code_unit_at(k) == '['
+    break s[k] == '['
   }
 }
 
@@ -559,11 +541,11 @@ pub fn LineType::list_marker(
   if start > last {
     return Nomatch
   }
-  match s.code_unit_at(start).unsafe_to_char() {
+  match s[start].unsafe_to_char() {
     '-' | '+' | '*' as c => {
       let next = start + 1
       if next > last ||
-        (s.code_unit_at(next).to_char() is Some(c) && @char.is_ascii_blank(c)) {
+        (s[next].to_char() is Some(c) && @char.is_ascii_blank(c)) {
         ListMarkerLine(Unordered(c), start)
       } else {
         Nomatch
@@ -574,16 +556,13 @@ pub fn LineType::list_marker(
         if k > last || count > 9 {
           return Nomatch
         }
-        break match s.code_unit_at(k).unsafe_to_char() {
+        break match s[k].unsafe_to_char() {
           '0'..='9' as c =>
             continue count + 1, acc * 10 + @char.ascii_digit_to_int(c), k + 1
           '.' | ')' as c => {
             let next = k + 1
             if next > last ||
-              (
-                s.code_unit_at(next).to_char() is Some(c) &&
-                @char.is_ascii_blank(c)
-              ) {
+              (s[next].to_char() is Some(c) && @char.is_ascii_blank(c)) {
               ListMarkerLine(Ordered(acc, c), k)
             } else {
               Nomatch
@@ -603,13 +582,13 @@ pub fn ext_task_marker(
   start~ : CharCodePos,
 ) -> (Char, CharCodePos)? {
   guard start < last else { None }
-  guard s.code_unit_at(start) == '[' else { None }
+  guard s[start] == '[' else { None }
   let mut next = start + 1
   guard @char.at_checked(s, next) is Ok(u) else { None }
   next += @char.length_utf16(u.to_int())
-  guard next <= last && s.code_unit_at(next) == ']' else { None }
+  guard next <= last && s[next] == ']' else { None }
   next += 1
   guard next <= last else { Some((u, last)) }
-  guard s.code_unit_at(next) == ' ' else { None }
+  guard s[next] == ' ' else { None }
   Some((u, next))
 }

--- a/src/cmark_base/link.mbt
+++ b/src/cmark_base/link.mbt
@@ -14,14 +14,14 @@ pub fn link_destination(
   if start > last {
     return None
   }
-  if s.code_unit_at(start) == '<' {
+  if s[start] == '<' {
     // delimited, i.e. start has '<'
     // https://spec.commonmark.org/current/#link-destination 1st
     for prev = '\u{0}', k = start + 1 {
       if k > last {
         break None
       }
-      let c = s.code_unit_at(k).unsafe_to_char()
+      let c = s[k].unsafe_to_char()
       match (c, prev) {
         ('\n' | '\r', _) => break None
         ('\\', '\\') => continue '\u{0}', k + 1
@@ -40,7 +40,7 @@ pub fn link_destination(
       if k > last {
         break if bal == 0 { Some((false, start, k - 1)) } else { None }
       }
-      let c = s.code_unit_at(k).unsafe_to_char()
+      let c = s[k].unsafe_to_char()
       match (c, prev) {
         ('\\', '\\') => continue '\u{0}', bal, k + 1
         ('(', '\\') => ()
@@ -84,7 +84,7 @@ pub fn[A] link_title(
   if start > line.last {
     return None
   }
-  match s.code_unit_at(start).unsafe_to_char() {
+  match s[start].unsafe_to_char() {
     '"' | '\'' as char => {
       let spans = []
       accept_upto(char~, next_line~, s, lines, line~, spans, after=start).map(span_last => {
@@ -104,15 +104,15 @@ pub fn[A] link_title(
           continue newline, prev_bslash, start, start
         }
         if !prev_bslash {
-          if s.code_unit_at(k) == '(' {
+          if s[k] == '(' {
             break None
           }
-          if s.code_unit_at(k) == ')' {
+          if s[k] == ')' {
             push_span(line~, start, k - 1, acc)
             break Some((line, acc, k))
           }
         }
-        let prev_bslash = s.code_unit_at(k) == '\\' && !prev_bslash
+        let prev_bslash = s[k] == '\\' && !prev_bslash
         continue line, prev_bslash, start, k + 1
       }
     }
@@ -134,7 +134,7 @@ pub fn[A] link_label(
   line~ : LineSpan,
   start~ : CharCodePos,
 ) -> (LineSpan, Array[Span], Last, String)? {
-  if start > line.last || s.code_unit_at(start) != '[' {
+  if start > line.last || s[start] != '[' {
     return None
   }
   let start = start + 1
@@ -158,7 +158,7 @@ pub fn[A] link_label(
     if count > 999 {
       break None
     }
-    match (s.code_unit_at(k).unsafe_to_char(), prev) {
+    match (s[k].unsafe_to_char(), prev) {
       ('\\', '\\') => {
         b.write_char('\\')
         let prev = '\u{0}'
@@ -188,7 +188,7 @@ pub fn[A] link_label(
     }
     let k1 = k + @char.length_utf8(u.to_int())
     b.write_char(@char.to_ascii_lower(u))
-    let prev = s.code_unit_at(k).unsafe_to_char()
+    let prev = s[k].unsafe_to_char()
     continue line, prev, start, count + 1, k1
   }
 }

--- a/src/cmark_base/raw_html.mbt
+++ b/src/cmark_base/raw_html.mbt
@@ -29,12 +29,11 @@ fn attribute_name(s : String, last? : Int = -1, start? : Int = 0) -> Next? {
     }
   }
 
-  if start > last ||
-    !(s.code_unit_at(start).to_char() is Some(c) && char_is_start(c)) {
+  if start > last || !(s[start].to_char() is Some(c) && char_is_start(c)) {
     return None
   }
   for k = start + 1 {
-    if k > last || !(s.code_unit_at(k).to_char() is Some(c) && char_is_cont(c)) {
+    if k > last || !(s[k].to_char() is Some(c) && char_is_cont(c)) {
       break Some(k - 1)
     }
     continue k + 1
@@ -54,7 +53,7 @@ fn[A] attribute_value(
   if start > line.last {
     return None
   }
-  let c = s.code_unit_at(start).unsafe_to_char()
+  let c = s[start].unsafe_to_char()
   // https://spec.commonmark.org/current/#double-quoted-attribute-value
   // https://spec.commonmark.org/current/#unquoted-attribute-value
   if c is ('"' | '\'') {
@@ -66,7 +65,7 @@ fn[A] attribute_value(
   }
 
   for k = start + 1 {
-    if k <= line.last && s.code_unit_at(k).to_char() is Some(c) && is_cont(c) {
+    if k <= line.last && s[k].to_char() is Some(c) && is_cont(c) {
       continue k + 1
     }
     let last = k - 1
@@ -96,7 +95,7 @@ fn[A] attribute(
     None
   }
   let nb = last_blank + 1
-  if s.code_unit_at(nb) != '=' {
+  if s[nb] != '=' {
     return Some((line, end_name)) // No value
   }
   push_span(line=line1, nb, nb, spans.val)
@@ -145,14 +144,14 @@ fn[A] open_tag(
       break None
     }
     let next = last_blank + 1
-    break match s.code_unit_at(next) {
+    break match s[next] {
       '>' => {
         push_span(line~, next, next, spans.val)
         Some((line, spans.val, next))
       }
       '/' => {
         let last = next + 1
-        if last > line.last || s.code_unit_at(last) != '>' {
+        if last > line.last || s[last] != '>' {
           None
         } else {
           push_span(line~, next, last, spans.val)
@@ -195,7 +194,7 @@ fn[A] closing_tag(
     None
   }
   let last = last_blank + 1
-  if s.code_unit_at(last) != '>' {
+  if s[last] != '>' {
     return None
   }
   push_span(line~, last, last, spans.val)
@@ -235,11 +234,11 @@ fn[A] processing_instruction(
       let start = first_non_blank_in_span(s, new_line)
       continue new_line, start, start
     }
-    if s.code_unit_at(k) != 63 { // '?' has character code 63
+    if s[k] != 63 { // '?' has character code 63
       continue line, start, k + 1
     }
     let last = k + 1
-    if last <= line.last && s.code_unit_at(last) == 62 { // '>' has character code 62
+    if last <= line.last && s[last] == 62 { // '>' has character code 62
       push_span(line~, start, last, acc)
       break Some((line, acc, last))
     }
@@ -258,15 +257,13 @@ fn[A] html_comment(
   start~ : CharCodePos,
 ) -> (LineSpan, Array[Span], CharCodePos)? {
   // Check we have at least <!-- and not <!--> or <!--->.
-  if start + 3 > line.last || s.code_unit_at(start + 3) != '-' {
+  if start + 3 > line.last || s[start + 3] != '-' {
     return None
   }
-  if start + 4 <= line.last && s.code_unit_at(start + 4) == '>' {
+  if start + 4 <= line.last && s[start + 4] == '>' {
     return None
   }
-  if start + 5 <= line.last &&
-    s.code_unit_at(start + 4) == '-' &&
-    s.code_unit_at(start + 5) == '>' {
+  if start + 5 <= line.last && s[start + 4] == '-' && s[start + 5] == '>' {
     return None
   }
   let acc = []
@@ -277,10 +274,10 @@ fn[A] html_comment(
       let start = first_non_blank_in_span(s, new_line)
       continue new_line, start, start
     }
-    if s.code_unit_at(k) == '-' && s.code_unit_at(k - 1) != '-' {
+    if s[k] == '-' && s[k - 1] != '-' {
       let last = k + 2
-      if last <= line.last && s.code_unit_at(k + 1) == '-' {
-        break if s.code_unit_at(last) == '>' { // And we do not end with -
+      if last <= line.last && s[k + 1] == '-' {
+        break if s[last] == '>' { // And we do not end with -
           push_span(line~, start, last, acc)
           Some((line, acc, last))
         } else {
@@ -316,13 +313,11 @@ fn[A] cdata_section(
       let start = first_non_blank_in_span(s, new_line)
       continue new_line, start, start
     }
-    if s.code_unit_at(k) != ']' {
+    if s[k] != ']' {
       continue line, start, k + 1
     }
     let last = k + 2
-    if last <= line.last &&
-      s.code_unit_at(k + 1) == ']' &&
-      s.code_unit_at(last) == '>' { // ]>
+    if last <= line.last && s[k + 1] == ']' && s[last] == '>' { // ]>
       push_span(line~, start, last, acc)
       break Some((line, acc, last))
     }
@@ -341,14 +336,14 @@ pub fn[A] raw_html(
 ) -> (LineSpan, Array[Span], CharCodePos)? {
   let next = start + 1
   let { last, .. } = line
-  guard next <= last && s.code_unit_at(start) == '<' else { None }
-  match s.code_unit_at(next) {
+  guard next <= last && s[start] == '<' else { None }
+  match s[next] {
     '/' => closing_tag(next_line~, s, lines, line~, start~)
     '?' => processing_instruction(next_line, s, lines, line~, start~)
     '!' => {
       let next = next + 1
       guard next <= last else { None }
-      match s.code_unit_at(next).unsafe_to_char() {
+      match s[next].unsafe_to_char() {
         '-' => html_comment(next_line~, s, lines, line~, start~)
         '[' => cdata_section(next_line~, s, lines, line~, start~)
         c => {

--- a/src/cmark_base/runs.mbt
+++ b/src/cmark_base/runs.mbt
@@ -7,7 +7,7 @@ pub fn run_of(
   last~ : CharCodePos,
   start~ : CharCodePos,
 ) -> Last {
-  if start > last || s.code_unit_at(start) != char.to_int().to_uint16() {
+  if start > last || s[start] != char.to_int().to_uint16() {
     return start - 1
   }
   run_of(char~, s, last~, start=start + 1)
@@ -22,9 +22,7 @@ pub fn first_non_blank(
   start~ : CharCodePos,
 ) -> CharCodePos {
   for k in start..<=last {
-    guard s.code_unit_at(k).to_char() is Some(c) && @char.is_ascii_blank(c) else {
-      return k
-    }
+    guard s[k].to_char() is Some(c) && @char.is_ascii_blank(c) else { return k }
   }
   last + 1
 }
@@ -46,7 +44,7 @@ pub fn last_non_blank(
   if start < first {
     return first - 1
   }
-  match s.code_unit_at(start) {
+  match s[start] {
     ' ' | '\t' => last_non_blank(s, first~, start=start - 1)
     _ => start
   }
@@ -63,7 +61,7 @@ pub fn rev_drop_spaces(
   if start < first {
     return first - 1
   }
-  match s.code_unit_at(start) {
+  match s[start] {
     ' ' => rev_drop_spaces(s, first~, start=start - 1)
     _ => start
   }
@@ -109,7 +107,7 @@ fn[A] accept_to(
       let start = first_non_blank_in_span(s, new_line)
       continue new_line, start, start
     }
-    if s.code_unit_at(k) == char.to_int().to_uint16() {
+    if s[k] == char.to_int().to_uint16() {
       push_span(line~, start, k, spans)
       break Some((line, k))
     }
@@ -140,11 +138,11 @@ fn[A] accept_upto(
       let prev_bslash = false
       continue newline, prev_bslash, start, start
     } else {
-      if s.code_unit_at(k) == char.to_int().to_uint16() && !prev_bslash {
+      if s[k] == char.to_int().to_uint16() && !prev_bslash {
         push_span(line~, start, k - 1, spans)
         break Some((line, k))
       }
-      let prev_bslash = s.code_unit_at(k) == '\\' && !prev_bslash
+      let prev_bslash = s[k] == '\\' && !prev_bslash
       continue line, prev_bslash, start, k + 1
     }
   }
@@ -209,10 +207,7 @@ pub fn first_non_escaped_char(
 ) -> CharCodePos {
   for k = start; ; k = k + 1 {
     if k > last ||
-      (
-        s.code_unit_at(k) == c.to_int().to_uint16() &&
-        (k == start || s.code_unit_at(k - 1) != '\\')
-      ) {
+      (s[k] == c.to_int().to_uint16() && (k == start || s[k - 1] != '\\')) {
       break k
     }
   }

--- a/src/cmark_html/html.mbt
+++ b/src/cmark_html/html.mbt
@@ -173,7 +173,7 @@ fn buffer_add_html_escaped_string(b : StringBuilder, s : String) -> Unit {
       break
     }
     let next = i + 1
-    match s.code_unit_at(i) {
+    match s[i] {
       '\u{0}' => {
         flush(b, start, i)
         b.write_char(@char.rep)
@@ -256,7 +256,7 @@ fn buffer_add_pct_encoded_string(b : StringBuilder, s : String) -> Unit { // Per
       break
     }
     let next = i + 1
-    match s.code_unit_at(i) {
+    match s[i] {
       c if c.to_char() is Some(c) && (@char.is_ascii_alphanum(c) || is_delim(c)) =>
         continue start, next
       '&' => {
@@ -551,7 +551,7 @@ fn code_block(c : Context, cb : @cmark.CodeBlock) -> Unit {
     c.b.write_char('\n')
   }
   if lang is Some((lang, _env)) {
-    if backend_blocks(c) && lang.code_unit_at(0) == '=' {
+    if backend_blocks(c) && lang[0] == '=' {
       if lang == "=html" && !safe(c) {
         block_lines(c, cb.code.to_array())
       }


### PR DESCRIPTION
## Summary

- Replaces `String::code_unit_at` / `StringView::code_unit_at` call-site syntax with bracket indexing (`s[i]`).
- Keeps behavior unchanged by using the documented `_[_]` alias for the same `String::at` / `StringView::at` APIs.
- Leaves public interfaces unchanged.

## Validation

- `moon check --warn-list +unnecessary_annotation`
- `moon test`
- `moon info`
- `moon test --target wasm`
- `moon test --target wasm --release`
- `moon test --target wasm-gc`
- `moon test --target wasm-gc --release`
- `moon test --target js`
- `moon test --target js --release`
- `moon test --target native`
- `moon test --target native --release`
- `moon test --enable-coverage`
- `git diff --check`