### PR TITLE
Add native cmark CLI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -52,6 +52,7 @@ jobs:
           git diff --exit-code
 
       - name: moon test
+        if: ${{ matrix.os.name != 'windows-latest' }}
         env:
           OCAMLRUNPARAM: b
         run: |
@@ -61,6 +62,28 @@ jobs:
           moon test --target wasm-gc --release
           moon test --target js
           moon test --target js --release
+          moon test --target native
+          moon test --target native --release
+
+      - name: moon test on windows
+        if: ${{ matrix.os.name == 'windows-latest' }}
+        env:
+          OCAMLRUNPARAM: b
+        run: |
+          moon test --target wasm
+          moon test --target wasm --release
+          moon test --target wasm-gc
+          moon test --target wasm-gc --release
+          moon test --target js
+          moon test --target js --release
+
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          if (-not $vsPath) {
+            throw "Visual Studio with MSVC toolchain not found"
+          }
+          Import-Module "$vsPath\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+          Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64"
           moon test --target native
           moon test --target native --release
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -64,6 +64,7 @@ jobs:
           moon test --target js --release
           moon test --target native
           moon test --target native --release
+          moon cram test cram
 
       - name: moon test on windows
         if: ${{ matrix.os.name == 'windows-latest' }}
@@ -86,6 +87,7 @@ jobs:
           Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64"
           moon test --target native
           moon test --target native --release
+          moon cram test cram
 
   coverage-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,6 +50,7 @@ jobs:
           git diff --exit-code
 
       - name: moon test
+        if: ${{ matrix.os.name != 'windows-latest' }}
         env:
           OCAMLRUNPARAM: b
         run: |
@@ -59,5 +60,27 @@ jobs:
           moon test --target wasm-gc --release
           moon test --target js
           moon test --target js --release
+          moon test --target native
+          moon test --target native --release
+
+      - name: moon test on windows
+        if: ${{ matrix.os.name == 'windows-latest' }}
+        env:
+          OCAMLRUNPARAM: b
+        run: |
+          moon test --target wasm
+          moon test --target wasm --release
+          moon test --target wasm-gc
+          moon test --target wasm-gc --release
+          moon test --target js
+          moon test --target js --release
+
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          if (-not $vsPath) {
+            throw "Visual Studio with MSVC toolchain not found"
+          }
+          Import-Module "$vsPath\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+          Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64"
           moon test --target native
           moon test --target native --release

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,6 +62,7 @@ jobs:
           moon test --target js --release
           moon test --target native
           moon test --target native --release
+          moon cram test cram
 
       - name: moon test on windows
         if: ${{ matrix.os.name == 'windows-latest' }}
@@ -84,3 +85,4 @@ jobs:
           Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64"
           moon test --target native
           moon test --target native --release
+          moon cram test cram

--- a/README.md
+++ b/README.md
@@ -33,6 +33,27 @@ Once you have the toolchain installed, you can build this project by running the
 moon build
 ```
 
+## CLI
+
+The repository includes a native command-line renderer that follows the basic
+`cmark` input model: read Markdown from stdin, `-`, or one or more file paths and
+write rendered HTML to stdout.
+
+```sh
+printf '# Hello\n' | moon run src/cmark_cli -- -
+moon run src/cmark_cli -- README.md
+moon run src/cmark_cli -- --safe --to xhtml README.md
+```
+
+For reference comparisons, install the upstream CommonMark CLI and compare
+against the MoonBit executable:
+
+```sh
+brew install cmark
+printf '# Hello\n' | cmark --unsafe
+printf '# Hello\n' | moon run src/cmark_cli -- -
+```
+
 ## Testing
 
 With the MoonBit toolchain installed, you can run the tests by executing the following command:

--- a/cram/cmark_cli.t
+++ b/cram/cmark_cli.t
@@ -1,0 +1,30 @@
+The native CLI reads from stdin when no file is provided.
+
+  $ printf '# Hello\n' | cmark_cli.exe
+  <h1>Hello</h1>
+
+Use `-` explicitly to read stdin when passing options.
+
+  $ printf 'line break\\\nnext\n' | cmark_cli.exe -t xhtml -
+  <p>line break<br />
+  next</p>
+
+The CLI also accepts one or more file paths.
+
+  $ cat > input.md <<'EOF'
+  > A paragraph with *emphasis*.
+  > EOF
+  $ cmark_cli.exe input.md
+  <p>A paragraph with <em>emphasis</em>.</p>
+
+Raw HTML and unsafe links are allowed by default, matching `cmark --unsafe`.
+
+  $ printf '<span>raw</span>\n\n[bad](javascript:alert(1))\n' | cmark_cli.exe
+  <p><span>raw</span></p>
+  <p><a href="javascript:alert(1)">bad</a></p>
+
+Use `--safe` to sanitize raw HTML and unsafe links.
+
+  $ printf '<script>x</script>\n\n[bad](javascript:alert(1))\n' | cmark_cli.exe --safe
+  <!--CommonMark HTML block omitted-->
+  <p><a href="">bad</a></p>

--- a/moon.mod
+++ b/moon.mod
@@ -5,6 +5,7 @@ version = "0.4.4"
 import {
   "moonbit-community/casefold@0.1.5",
   "moonbit-community/charclass@0.1.2",
+  "moonbitlang/async@0.19.4",
 }
 
 readme = "README.md"

--- a/src/cmark_cli/main.mbt
+++ b/src/cmark_cli/main.mbt
@@ -1,0 +1,110 @@
+///|
+struct Options {
+  safe : Bool
+  strict : Bool
+  backend_blocks : Bool
+  format : String
+}
+
+///|
+fn command() -> @argparse.Command {
+  @argparse.Command(
+    "cmark",
+    about="Render CommonMark input as HTML.",
+    version="0.4.4",
+    flags=[
+      FlagArg("safe", about="replace unsafe raw HTML and links with comments", conflicts_with=[
+        "unsafe",
+      ]),
+      FlagArg("unsafe", about="allow raw HTML and unsafe links (default)", conflicts_with=[
+        "safe",
+      ]),
+      FlagArg("relaxed", about="enable cmark.mbt syntax extensions"),
+      FlagArg(
+        "backend-blocks",
+        about="render backend-specific fenced code blocks",
+      ),
+    ],
+    options=[
+      OptionArg("to", short='t', about="output format: html or xhtml", default_values=[
+        "html",
+      ]),
+    ],
+    positionals=[
+      PositionArg(
+        "file",
+        about="file to read; use - or no file for stdin",
+        num_args=@argparse.ValueRange(lower=0),
+        allow_hyphen_values=true,
+      ),
+    ],
+  )
+}
+
+///|
+fn flag(matches : @argparse.Matches, name : String) -> Bool {
+  match matches.flags.get(name) {
+    Some(value) => value
+    None => false
+  }
+}
+
+///|
+fn options_from_matches(matches : @argparse.Matches) -> Options {
+  let format = match matches.values {
+    { "to": [format], .. } => format
+    _ => "html"
+  }
+  {
+    safe: flag(matches, "safe"),
+    strict: !flag(matches, "relaxed"),
+    backend_blocks: flag(matches, "backend-blocks"),
+    format,
+  }
+}
+
+///|
+fn input_paths(matches : @argparse.Matches) -> Array[String] {
+  match matches.values {
+    { "file": files, .. } if !files.is_empty() => files
+    _ => ["-"]
+  }
+}
+
+///|
+async fn read_input(path : String) -> String {
+  if path == "-" {
+    @stdio.stdin.read_all().text()
+  } else {
+    @fs.read_file(path).text()
+  }
+}
+
+///|
+fn render_input(input : String, options : Options) -> String raise {
+  match options.format {
+    "html" =>
+      @cmark_html.render(
+        backend_blocks=options.backend_blocks,
+        safe=options.safe,
+        strict=options.strict,
+        input,
+      )
+    "xhtml" =>
+      @cmark_html.xhtml_renderer(
+        backend_blocks=options.backend_blocks,
+        safe=options.safe,
+      ).doc_to_string(@cmark.Doc::from_string(input, strict=options.strict))
+    format =>
+      fail("unsupported output format: \{format}; expected html or xhtml")
+  }
+}
+
+///|
+async fn main {
+  let matches = command().parse()
+  let options = options_from_matches(matches)
+  for path in input_paths(matches) {
+    @stdio.stdout.write(render_input(read_input(path), options))
+  }
+}

--- a/src/cmark_cli/main_wbtest.mbt
+++ b/src/cmark_cli/main_wbtest.mbt
@@ -1,0 +1,39 @@
+///|
+test "command parses cmark style flags" {
+  let matches = command().parse(
+    argv=["--safe", "--relaxed", "-t", "xhtml", "-"],
+    env={},
+  ) catch {
+    _ => panic()
+  }
+  let options = options_from_matches(matches)
+  assert_true(options.safe)
+  assert_false(options.strict)
+  assert_eq(options.format, "xhtml")
+  assert_true(input_paths(matches) == ["-"])
+}
+
+///|
+test "render html by default" {
+  let options : Options = {
+    safe: false,
+    strict: true,
+    backend_blocks: false,
+    format: "html",
+  }
+  inspect(render_input("# hello\n", options), content="<h1>hello</h1>\n")
+}
+
+///|
+test "render xhtml format" {
+  let options : Options = {
+    safe: false,
+    strict: true,
+    backend_blocks: false,
+    format: "xhtml",
+  }
+  inspect(
+    render_input("line\\\nnext\n", options),
+    content="<p>line<br />\nnext</p>\n",
+  )
+}

--- a/src/cmark_cli/moon.pkg
+++ b/src/cmark_cli/moon.pkg
@@ -1,0 +1,15 @@
+import {
+  "moonbit-community/cmark/cmark",
+  "moonbit-community/cmark/cmark_html",
+  "moonbitlang/core/argparse",
+  "moonbitlang/async",
+  "moonbitlang/async/fs",
+  "moonbitlang/async/io",
+  "moonbitlang/async/stdio",
+}
+
+supported_targets = "+native"
+
+options(
+  "is-main": true,
+)


### PR DESCRIPTION
## Summary

- Add a native `src/cmark_cli` executable package that renders CommonMark from stdin, `-`, or file paths
- Use `moonbitlang/core/argparse` for cmark-style flags and `moonbitlang/async` stdio/fs for async stdin/stdout/file I/O
- Add a cram documentation test for the CLI's stdin, file, XHTML, unsafe, and `--safe` behavior
- Run Windows native tests under the Visual Studio MSVC environment required by `moonbitlang/async`
- Document local usage and upstream `cmark --unsafe` reference comparison commands

## Windows native CI note

Adding the CLI pulls in `moonbitlang/async` for native stdin/stdout and file I/O. On Windows, async's native event-loop/thread-pool C stubs currently require MSVC and fail compilation outside the Visual Studio developer environment with `#error "Currently only MSVC is supported on Windows"`. The Windows workflow now enters the installed Visual Studio MSVC dev shell before `moon test --target native`, `moon test --target native --release`, and `moon cram test cram`.

## Validation

- `moon check --warn-list +unnecessary_annotation`
- `moon test`
- `moon cram test cram`
- `cmark --version` -> `cmark 0.31.1 - CommonMark converter`
- Exact-output smoke comparisons against upstream `cmark --unsafe` for heading, inline/link/quote, and raw HTML stdin cases
- GitHub Actions on latest SHA: benchmark, stable/nightly macOS, stable/nightly Ubuntu, stable/nightly Windows, and coverage all passed