### PR TITLE
Fix parser EOF guards

### DIFF
--- a/src/cmark/block_struct.mbt
+++ b/src/cmark/block_struct.mbt
@@ -49,7 +49,9 @@ fn Parser::update_next_non_blank(self : Parser) -> Unit {
 ///|
 fn Parser::accept_cols(self : Parser, count~ : Int) -> Unit {
   for count = count, k = self.curr_char, col = self.curr_char_col {
-    break if count == 0 {
+    // Stop at the end of the line: a list marker or other prefix can
+    // be the very last thing in the input, with nothing left to accept.
+    break if count == 0 || k > self.curr_line_last_char {
       self.curr_char = k
       self.curr_char_col = col
     } else if self.i[k] != '\t' {

--- a/src/cmark_base/autolink.mbt
+++ b/src/cmark_base/autolink.mbt
@@ -30,7 +30,7 @@ pub fn autolink_email(s : String, last? : Int = -1, start? : Int = 0) -> Last? {
     }
   }
 
-  guard start <= last || s[start] == '<' else { None }
+  guard start <= last && s[start] == '<' else { None }
   for k in (start + 1)..<=last {
     let sk = s[k].unsafe_to_char()
     if char_is_atext_plus_dot(sk) {

--- a/src/cmark_base/autolink_test.mbt
+++ b/src/cmark_base/autolink_test.mbt
@@ -14,6 +14,11 @@ test "autolink_email invalid start" {
 }
 
 ///|
+test "autolink_email start after last" {
+  debug_inspect(@cmark_base.autolink_email("", start=0), content="None")
+}
+
+///|
 test "autolink_email label sequence ending with invalid char" {
   debug_inspect(@cmark_base.autolink_email("<a@abc$>"), content="None")
 }

--- a/src/cmark_base/leaf_blocks.mbt
+++ b/src/cmark_base/leaf_blocks.mbt
@@ -187,8 +187,8 @@ pub fn LineType::fenced_code_block_start(
   start~ : CharCodePos,
 ) -> LineType {
   fn info(s : String, last, nobt, info_first, k) {
-    let sk = s[k]
     guard k <= last else { Some((info_first, last)) }
+    let sk = s[k]
     guard !(nobt && sk == '`') else { None }
     guard sk is (' ' | '\t') else { info(s, last, nobt, info_first, k + 1) }
     let after_blank = first_non_blank(s, last~, start=k)
@@ -495,7 +495,9 @@ pub fn LineType::ext_footnote_label(
   last~ : CharCodePos,
   start~ : CharCodePos,
 ) -> LineType {
-  guard start <= last && s[start] == '[' && s[start + 1] == '^' else { Nomatch }
+  guard start + 1 <= last && s[start] == '[' && s[start + 1] == '^' else {
+    Nomatch
+  }
   let rbrack = first_non_escaped_char(']', s, last~, start=start + 2)
   let colon = rbrack + 1
   guard colon <= last && s[colon] == ':' && colon - start + 1 >= 5 else {

--- a/src/cmark_html/eof_regression_test.mbt
+++ b/src/cmark_html/eof_regression_test.mbt
@@ -1,0 +1,40 @@
+// Regression tests for parser/scanner reads at end of input.
+
+///|
+/// `Parser::accept_cols` read past the end of input when a list marker
+/// was the last thing in the input, with no trailing newline.
+test "list marker at end of input" {
+  inspect(@cmark_html.render("-"), content="<ul>\n<li></li>\n</ul>\n")
+  inspect(@cmark_html.render("*"), content="<ul>\n<li></li>\n</ul>\n")
+  inspect(@cmark_html.render("+"), content="<ul>\n<li></li>\n</ul>\n")
+  inspect(@cmark_html.render("1."), content="<ol>\n<li></li>\n</ol>\n")
+  inspect(@cmark_html.render("1)"), content="<ol>\n<li></li>\n</ol>\n")
+  inspect(
+    @cmark_html.render("> -"),
+    content="<blockquote>\n<ul>\n<li></li>\n</ul>\n</blockquote>\n",
+  )
+}
+
+///|
+/// The `info` helper of `fenced_code_block_start` read the code unit at
+/// `k` before checking `k <= last`.
+test "fence info string at end of input" {
+  inspect(
+    @cmark_html.render("```#"),
+    content="<pre><code class=\"language-#\"></code></pre>\n",
+  )
+  inspect(@cmark_html.render("```"), content="<pre><code></code></pre>\n")
+}
+
+///|
+/// `ext_footnote_label` read `start + 1` guarded only by `start <= last`.
+test "bracket at end of input with extensions" {
+  inspect(@cmark_html.render(strict=false, "["), content="<p>[</p>\n")
+  inspect(@cmark_html.render(strict=false, "[^"), content="<p>[^</p>\n")
+}
+
+///|
+/// `autolink_email` used `||` instead of `&&` before checking `s[start]`.
+test "empty email autolink input" {
+  inspect(@cmark_html.render("<"), content="<p>&lt;</p>\n")
+}


### PR DESCRIPTION
## Summary

- Stop `Parser::accept_cols` at end-of-line before reading past a marker at EOF
- Guard `fenced_code_block_start` before reading the info-string cursor
- Require `start + 1 <= last` before probing extension footnote labels
- Fix `autolink_email`'s start guard from `||` to `&&`
- Add focused regressions for list markers, fences, extension brackets, and the autolink guard

## Scope

This is an independent end-of-input slice extracted from #127. It does not depend on the UTF-16 helper PR and should be reviewable/mergeable on its own.

## Validation

- `moon test src/cmark_base --target wasm-gc`
- `moon test src/cmark_html --target wasm-gc`
- `moon check --warn-list +unnecessary_annotation`
- `moon test`
- `moon info`