### PR TITLE
fix: include image alt text in plain text

### DIFF
--- a/src/cmark/inline.mbt
+++ b/src/cmark/inline.mbt
@@ -145,6 +145,7 @@ pub fn Inline::to_plain_text(
         for i in is1.0.rev() {
           st.push(i)
         }
+      Image(l) => st.push(l.v.text)
       Link(l) => st.push(l.v.text)
       RawHtml(_) => ()
       Text(t) => push(t.v)

--- a/src/cmark/inline_test.mbt
+++ b/src/cmark/inline_test.mbt
@@ -673,6 +673,13 @@ test "Inline::to_plain_text with inlines and link" {
   )
   let link_result = link.to_plain_text(break_on_soft=false)
   debug_inspect(link_result.length(), content="1")
+
+  // Image alt text follows the same plain-text traversal as link text.
+  let image = @cmark.Inline::Image(
+    @cmark.Node::new({ text: text2, reference }, meta~),
+  )
+  let image_result = image.to_plain_text(break_on_soft=false)
+  debug_inspect(image_result.length(), content="1")
 }
 
 ///|


### PR DESCRIPTION
Fixes #138\n\n## Summary\n- handle Image nodes explicitly in Inline::to_plain_text\n- emit the image's alt text so traversal advances instead of repeatedly visiting the Image node\n- add a regression assertion alongside the existing link plain-text coverage\n\n## Validation\n- git diff --check\n- MoonBit validation was not available locally because the moon tool is not installed; repository CI can run moon test