### PR TITLE
chore: bump version to 0.4.5

### DIFF
--- a/moon.mod
+++ b/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/cmark"
 
-version = "0.4.4"
+version = "0.4.5"
 
 import {
   "moonbit-community/casefold@0.1.5",

--- a/src/cmark_cli/main.mbt
+++ b/src/cmark_cli/main.mbt
@@ -11,7 +11,7 @@ fn command() -> @argparse.Command {
   @argparse.Command(
     "cmark",
     about="Render CommonMark input as HTML.",
-    version="0.4.4",
+    version="0.4.5",
     flags=[
       FlagArg("safe", about="replace unsafe raw HTML and links with comments", conflicts_with=[
         "unsafe",


### PR DESCRIPTION
Bump version from 0.4.4 to 0.4.5 to prepare for publishing after the prev_char UTF-16 fix (#141).

Generated with SeekMoon