### PR TITLE
fix: handle Image in Inline::to_plain_text to avoid infinite loop

### DIFF
--- a/src/cmark/inline.mbt
+++ b/src/cmark/inline.mbt
@@ -145,12 +145,11 @@ pub fn Inline::to_plain_text(
         for i in is1.0.rev() {
           st.push(i)
         }
-      Link(l) => st.push(l.v.text)
+      Link(l) | Image(l) => st.push(l.v.text)
       RawHtml(_) => ()
       Text(t) => push(t.v)
       ExtStrikethrough(i) => st.push(i.v.0)
       ExtMathSpan(m) => push(m.v.tex())
-      i => st.push(i)
     }
   }
   acc

--- a/src/cmark/inline_test.mbt
+++ b/src/cmark/inline_test.mbt
@@ -709,6 +709,41 @@ test "Inline::to_plain_text with math span" {
 }
 
 ///|
+test "Inline::to_plain_text with image" {
+  let meta = @cmark_base.Meta::none()
+
+  // Test with Image: plain text should be its alt text
+  let badge = @cmark.Inline::Text(@cmark.Node::new("badge", meta~))
+  let link_def = @cmark.Node::new(@cmark.LinkDefinition::new(), meta~)
+  let reference = @cmark.ReferenceKind::Inline(link_def)
+  let image = @cmark.Inline::Image(
+    @cmark.Node::new({ text: badge, reference }, meta~),
+  )
+  let image_result = image.to_plain_text(break_on_soft=false)
+  debug_inspect(image_result[0][0], content="\"badge\"")
+
+  // Test with image nested in a link: `[![badge](badge.svg)](target)`
+  let link = @cmark.Inline::Link(
+    @cmark.Node::new({ text: image, reference }, meta~),
+  )
+  let link_result = link.to_plain_text(break_on_soft=false)
+  debug_inspect(link_result[0][0], content="\"badge\"")
+}
+
+///|
+test "Inline::to_plain_text with image in heading auto id (issue #138)" {
+  let doc = @cmark.Doc::from_string(
+    "# Title [![badge](badge.svg)](target)",
+    heading_auto_ids=true,
+  )
+  guard doc.block is Heading({ v, .. }) else { abort("expected heading") }
+  guard v.id is Some(@cmark.BlockHeadingId::Auto(id)) else {
+    abort("expected auto id")
+  }
+  debug_inspect(id, content="\"title-badge\"")
+}
+
+///|
 test "Inline::normalize with singleton list" {
   let meta = @cmark_base.Meta::none()
 


### PR DESCRIPTION
## Problem

`Inline::to_plain_text` loops forever when it reaches an `Image` node. Since there is no `Image` match case, it falls through to the catch-all `i => st.push(i)`, which re-pushes the *same* node back onto the work stack. The traversal only terminates when the stack empties, so this spins at 100% CPU indefinitely.

Minimal input:

```
# Title [![badge](badge.svg)](target)
```

When `heading_auto_ids=true`, parsing computes the heading id via `Inline::id()` → `to_plain_text()` and hangs before `Doc::from_string` even returns. This is exactly what happened on mooncakes.io for a README heading containing a linked badge image.

## Root cause

This is a porting regression from the upstream OCaml [`cmarkit`](https://github.com/dbuenzli/cmarkit) library, combined with a broken fallback branch.

Upstream cmarkit handles `Image` together with `Link` — both traverse their text (the alt text for images):

```ocaml
| Link (l, _) :: is | Image (l, _) :: is ->
    loop ~break_on_soft acc (l.text :: is)
```

The MoonBit port dropped the `Image` case. The catch-all `i => st.push(i)` is itself a leftover of the upstream `ext` hook dispatch (`| i :: is -> loop ~break_on_soft acc (ext ~break_on_soft i :: is)`), whose default hook **raises an error** on unknown nodes. When the port removed the `ext` machinery, it replaced the hook with an identity push, turning what should be an explicit error into a silent infinite loop — the node is pushed back unchanged, no progress is made, and the stack never empties.

## Solution

Follow the upstream behavior:

- Handle `Image` exactly like `Link`: `Link(l) | Image(l) => st.push(l.v.text)`, so an image contributes its alt text.
- Remove the catch-all. The `Inline` enum is closed with 12 variants and the match is now exhaustive; any future variant will be caught at compile time instead of hanging at runtime.

## Tests

- `Inline::to_plain_text with image` — image alone and image nested in a link, asserting the alt text is extracted.
- `Inline::to_plain_text with image in heading auto id (issue #138)` — end-to-end repro of the issue input with `heading_auto_ids=true`, asserting the generated id is `title-badge`.

All 368 tests pass.

Fixes #138
