### PR TITLE
chore: apply current MoonBit formatting

### DIFF
--- a/src/cmark/block.mbt
+++ b/src/cmark/block.mbt
@@ -18,7 +18,7 @@ pub(all) enum Block {
 
 ///|
 pub fn Block::empty() -> Block {
-  Blocks({ v: [], meta: Meta::none() })
+  Blocks({ v: [], meta: Meta::none(), })
 }
 
 ///|
@@ -52,7 +52,7 @@ pub fn Block::normalize(self : Block) -> Block {
   match self {
     BlockQuote(bl) => BlockQuote(bl.map(BlockQuote::normalize_block))
     List(bl) => List(bl.map(BlockList::normalize_items))
-    Blocks({ v: Seq([.., _] as bs), meta }) => {
+    Blocks({ v: Seq([.., _] as bs), meta, }) => {
       let mut bs = bs
       let acc = [bs.pop().unwrap().normalize()]
       for ;; {
@@ -64,7 +64,7 @@ pub fn Block::normalize(self : Block) -> Block {
       }
       match acc {
         [b] => b
-        _ => Blocks({ v: bs, meta })
+        _ => Blocks({ v: bs, meta, })
       }
     }
     ExtFootnoteDefinition(bl) =>
@@ -111,7 +111,7 @@ pub(all) struct BlockQuote {
 
 ///|
 pub fn BlockQuote::new(indent? : Int = 0, block : Block) -> BlockQuote {
-  { indent, block }
+  { indent, block, }
 }
 
 ///|
@@ -119,7 +119,7 @@ pub fn BlockQuote::map_block(
   self : BlockQuote,
   f : (Block) -> Block,
 ) -> BlockQuote {
-  { ..self, block: f(self.block) }
+  { ..self, block: f(self.block), }
 }
 
 ///|
@@ -151,7 +151,7 @@ pub(all) struct CodeBlockFencedLayout {
 
 ///|
 pub fn CodeBlockFencedLayout::default() -> CodeBlockFencedLayout {
-  { indent: 0, opening_fence: layout_empty, closing_fence: Some(layout_empty) }
+  { indent: 0, opening_fence: layout_empty, closing_fence: Some(layout_empty), }
 }
 
 ///|
@@ -165,7 +165,7 @@ pub fn CodeBlock::new(
       CodeBlockLayout::Fenced(CodeBlockFencedLayout::default())
     (_, layout) => layout
   }
-  { layout, info_string, code }
+  { layout, info_string, code, }
 }
 
 ///|
@@ -239,7 +239,7 @@ pub(all) struct BlockHeadingAtxLayout {
 
 ///|
 pub fn BlockHeadingAtxLayout::default() -> BlockHeadingAtxLayout {
-  { indent: 0, after_opening: "", closing: "" }
+  { indent: 0, after_opening: "", closing: "", }
 }
 
 ///|
@@ -264,7 +264,7 @@ pub fn BlockHeading::new(
   level~ : Int,
   inline : Inline,
 ) -> BlockHeading {
-  { layout, level, inline, id }
+  { layout, level, inline, id, }
 }
 
 ///|
@@ -291,12 +291,12 @@ pub fn ListItem::new(
   ext_task_marker~ : Node[Char]?,
   block : Block,
 ) -> ListItem {
-  { before_marker, marker, after_marker, block, ext_task_marker }
+  { before_marker, marker, after_marker, block, ext_task_marker, }
 }
 
 ///|
 pub fn ListItem::map_block(self : ListItem, f : (Block) -> Block) -> ListItem {
-  { ..self, block: f(self.block) }
+  { ..self, block: f(self.block), }
 }
 
 ///|
@@ -335,7 +335,7 @@ pub fn BlockList::map_items(
   self : BlockList,
   f : (ListItem) -> ListItem,
 ) -> BlockList {
-  { ..self, items: self.items.map(fn(it) { it.map(f) }) }
+  { ..self, items: self.items.map(fn(it) { it.map(f) }), }
 }
 
 ///|
@@ -357,7 +357,7 @@ pub fn BlockParagraph::new(
   trailing_blanks? : Blanks = "",
   inline : Inline,
 ) -> BlockParagraph {
-  { leading_indent, inline, trailing_blanks }
+  { leading_indent, inline, trailing_blanks, }
 }
 
 ///|
@@ -372,7 +372,7 @@ pub fn BlockThematicBreak::new(
   indent? : Indent = 0,
   layout? : String = "---",
 ) -> BlockThematicBreak {
-  { indent, layout }
+  { indent, layout, }
 }
 
 // Extensions
@@ -393,12 +393,12 @@ pub fn Footnote::new(
   block : Block,
 ) -> Footnote {
   let defined_label = defined_label.unwrap_or(Some(label))
-  { indent, label, defined_label, block }
+  { indent, label, defined_label, block, }
 }
 
 ///|
 pub fn Footnote::map_block(self : Footnote, f : (Block) -> Block) -> Footnote {
-  { ..self, block: f(self.block) }
+  { ..self, block: f(self.block), }
 }
 
 ///|
@@ -409,7 +409,7 @@ pub fn Footnote::normalize_block(self : Footnote) -> Footnote {
 ///|
 fn Label::stub(label : Label, defined_label : Label?) -> LabelDef {
   FootnoteDef(
-    Node::new({ indent: 0, label, defined_label, block: Block::empty() }),
+    Node::new({ indent: 0, label, defined_label, block: Block::empty(), }),
   )
 }
 
@@ -453,7 +453,7 @@ pub fn Table::new(
       Sep(cols) => col_count = @cmp.maximum(col_count, cols.length())
     }
   }
-  { indent, rows, col_count }
+  { indent, rows, col_count, }
 }
 
 ///|
@@ -464,7 +464,7 @@ fn Table::parse_sep_row(
   for cs = cs {
     match cs {
       [] => break Some(acc)
-      [(Text({ v, meta }), TableCellLayout(("", ""))), .. cs] => {
+      [(Text({ v, meta, }), TableCellLayout(("", ""))), .. cs] => {
         guard !v.is_empty() else { break None }
         let max = v.length() - 1
         let first_colon = v[0] == ':'
@@ -484,7 +484,7 @@ fn Table::parse_sep_row(
           (true, false) => Some(Left)
           (false, true) => Some(Right)
         }
-        acc.push({ v: (sep, count), meta })
+        acc.push({ v: (sep, count), meta, })
         continue cs
       }
       _ => break None

--- a/src/cmark/block_line.mbt
+++ b/src/cmark/block_line.mbt
@@ -34,7 +34,7 @@ pub(all) struct Tight {
 
 ///|
 pub fn Tight::empty(meta? : Meta = Meta::none()) -> Tight {
-  { blanks: "", node: StringNode::empty(meta~) }
+  { blanks: "", node: StringNode::empty(meta~), }
 }
 
 ///|
@@ -76,12 +76,12 @@ fn BlockLine::flush_tight(
   }
   // On the first line the blanks are legit 
   if acc.is_empty() {
-    acc.push({ blanks: "", node: { meta, v: s[start:last + 1].to_owned() } })
+    acc.push({ blanks: "", node: { meta, v: s[start:last + 1].to_owned(), }, })
     return
   }
   let nb = @cmark_base.first_non_blank(s, last~, start~)
   acc.push({
     blanks: s[start:nb].to_owned(),
-    node: { meta, v: s[nb:last + 1].to_owned() },
+    node: { meta, v: s[nb:last + 1].to_owned(), },
   })
 }

--- a/src/cmark/block_line_test.mbt
+++ b/src/cmark/block_line_test.mbt
@@ -12,7 +12,7 @@ test "Tight::to_string outputs the node content" {
 ///|
 test "BlockLine::to_string extracts the string value" {
   let meta = @cmark_base.Meta::none()
-  let block_line : @cmark.BlockLine = { v: "Test string", meta }
+  let block_line : @cmark.BlockLine = { v: "Test string", meta, }
   let result = block_line.to_string()
   debug_inspect(
     result,
@@ -49,7 +49,7 @@ test "BlockLine::list_text_loc handles single element sequence" {
     last_line: LinePos(1, 5),
   }
   let meta = @cmark_base.Meta::new(loc~)
-  let single_node : @cmark.BlockLine = { v: "hello", meta }
+  let single_node : @cmark.BlockLine = { v: "hello", meta, }
   let single_seq = @cmark.Seq::from_array([single_node])
   let result = @cmark.BlockLine::list_text_loc(single_seq)
   debug_inspect(
@@ -77,7 +77,7 @@ test "BlockLine::list_text_loc handles multiple element sequence" {
     last_line: LinePos(1, 5),
   }
   let meta1 = @cmark_base.Meta::new(loc=loc1)
-  let node1 : @cmark.BlockLine = { v: "hello", meta: meta1 }
+  let node1 : @cmark.BlockLine = { v: "hello", meta: meta1, }
 
   // Second node with location at line 2
   let loc2 = @cmark_base.TextLoc::{
@@ -88,7 +88,7 @@ test "BlockLine::list_text_loc handles multiple element sequence" {
     last_line: LinePos(2, 5),
   }
   let meta2 = @cmark_base.Meta::new(loc=loc2)
-  let node2 : @cmark.BlockLine = { v: "world", meta: meta2 }
+  let node2 : @cmark.BlockLine = { v: "world", meta: meta2, }
   let multi_seq = @cmark.Seq::from_array([node1, node2])
   let result = @cmark.BlockLine::list_text_loc(multi_seq)
 
@@ -134,8 +134,8 @@ test "Tight::list_text_loc handles single element sequence" {
     last_line: LinePos(1, 5),
   }
   let meta = @cmark_base.Meta::new(loc~)
-  let node : @cmark.StringNode = { v: "hello", meta }
-  let t : @cmark.Tight = { blanks: "", node }
+  let node : @cmark.StringNode = { v: "hello", meta, }
+  let t : @cmark.Tight = { blanks: "", node, }
   let seq = @cmark.Seq::from_array([t])
   debug_inspect(
     @cmark.Tight::list_text_loc(seq),
@@ -162,8 +162,8 @@ test "Tight::list_text_loc handles multiple element sequence" {
     last_line: LinePos(1, 5),
   }
   let meta1 = @cmark_base.Meta::new(loc=loc1)
-  let node1 : @cmark.StringNode = { v: "hello", meta: meta1 }
-  let t1 : @cmark.Tight = { blanks: "", node: node1 }
+  let node1 : @cmark.StringNode = { v: "hello", meta: meta1, }
+  let t1 : @cmark.Tight = { blanks: "", node: node1, }
 
   // Second tight element
   let loc2 = @cmark_base.TextLoc::{
@@ -174,8 +174,8 @@ test "Tight::list_text_loc handles multiple element sequence" {
     last_line: LinePos(2, 5),
   }
   let meta2 = @cmark_base.Meta::new(loc=loc2)
-  let node2 : @cmark.StringNode = { v: "world", meta: meta2 }
-  let t2 : @cmark.Tight = { blanks: "  ", node: node2 }
+  let node2 : @cmark.StringNode = { v: "world", meta: meta2, }
+  let t2 : @cmark.Tight = { blanks: "  ", node: node2, }
   let seq = @cmark.Seq::from_array([t1, t2])
   debug_inspect(
     @cmark.Tight::list_text_loc(seq),

--- a/src/cmark/block_struct.mbt
+++ b/src/cmark/block_struct.mbt
@@ -266,7 +266,7 @@ fn Parser::atx_heading(
     first=last_content + 1,
     last=self.curr_line_last_char,
   )
-  Heading(Atx({ indent, level, after_open, heading, layout_after }))
+  Heading(Atx({ indent, level, after_open, heading, layout_after, }))
 }
 
 ///|
@@ -283,14 +283,14 @@ fn Parser::setext_heading(
     last=self.curr_line_last_char,
   )
   let underline = (indent, u, blanks)
-  Heading(Setext({ level, heading_lines, underline }))
+  Heading(Setext({ level, heading_lines, underline, }))
 }
 
 ///|
 fn Parser::indented_code_block(self : Parser) -> BlockStruct {
   let (pad, first) = self.accept_code_indent(count=4)
   let code = self.curr_line_span(first~, last=self.curr_line_last_char)
-  CodeBlock(Indented([{ pad, code, is_blank: false }]))
+  CodeBlock(Indented([{ pad, code, is_blank: false, }]))
 }
 
 ///|
@@ -310,8 +310,14 @@ fn Parser::fenced_code_block(
     self.i[fence_first].unsafe_to_char(),
     fence_last - fence_first + 1,
   )
-  let fence = { indent, opening_fence, fence, info_string, closing_fence: None }
-  CodeBlock(Fenced({ fence, code: [] }))
+  let fence = {
+    indent,
+    opening_fence,
+    fence,
+    info_string,
+    closing_fence: None,
+  }
+  CodeBlock(Fenced({ fence, code: [], }))
 }
 
 ///|
@@ -333,7 +339,7 @@ fn Parser::html_block(
   } else {
     Some(end_cond)
   }
-  HtmlBlock({ end_cond, html: [self.curr_line_span(first~, last~)] })
+  HtmlBlock({ end_cond, html: [self.curr_line_span(first~, last~)], })
 }
 
 ///|
@@ -345,7 +351,7 @@ fn Parser::paragraph(self : Parser, start~ : CharCodePos) -> BlockStruct {
     start~,
   )
   let lines = [self.curr_line_span(first=start, last~)]
-  Paragraph({ maybe_ref, lines })
+  Paragraph({ maybe_ref, lines, })
 }
 
 ///|
@@ -406,7 +412,7 @@ fn Parser::parse_link_ref_definition(
   guard next_line(lines) is Some(line) else { None }
   let start = self.first_non_blank_in_span(line)
   let indent = start - line.first
-  let meta_first = { ..line, first: start }
+  let meta_first = { ..line, first: start, }
   guard @cmark_base.link_label(
       self.buf,
       next_line~,
@@ -430,7 +436,7 @@ fn Parser::parse_link_ref_definition(
     is Some((angled, first, last)) else {
     None
   }
-  let dest = Parser::clean_unesc_unref_span(self, { ..line, first, last })
+  let dest = Parser::clean_unesc_unref_span(self, { ..line, first, last, })
   let next = if angled { last + 2 } else { last + 1 }
   let (angled_dest, dest, start, meta_last) = (
     angled,
@@ -468,7 +474,7 @@ fn Parser::parse_link_ref_definition(
         if nb <= line1.last {
           None
         } else {
-          Some([self.layout_clean_raw_span({ ..line1, first: start })])
+          Some([self.layout_clean_raw_span({ ..line1, first: start, })])
         }
       }
       guard after_title is Some(after_title) else {
@@ -498,7 +504,7 @@ fn Parser::parse_link_ref_definition(
   }
   let defined_label = self.def_label(label)
   let label = Some(label)
-  let ld = { v: { layout, label, defined_label, dest, title }, meta }
+  let ld = { v: { layout, label, defined_label, dest, title, }, meta, }
   if defined_label is Some(def) {
     self.set_label_def(def, LinkDef(ld))
   }
@@ -515,7 +521,7 @@ fn Parser::maybe_add_link_ref_definitions(
   while !lines.is_empty() {
     guard self.parse_link_ref_definition(lines) is Some(ld) else {
       //  Link defs can't interrupt a paragraph so we are good now.
-      prevs.push(Paragraph({ maybe_ref: false, lines }))
+      prevs.push(Paragraph({ maybe_ref: false, lines, }))
       break
     }
     prevs.push(LinkRefDef(ld))
@@ -657,10 +663,10 @@ fn Parser::end_doc_close_html(
   if html is [.., { first, last, .. } as l] && first > last {
     // Empty line
     let _ = html.pop()
-    bs..push(HtmlBlock({ end_cond: None, html })).push(BlankLine(0, l))
+    bs..push(HtmlBlock({ end_cond: None, html, })).push(BlankLine(0, l))
     return
   }
-  bs.push(HtmlBlock({ ..h, end_cond: None }))
+  bs.push(HtmlBlock({ ..h, end_cond: None, }))
 }
 
 ///|
@@ -892,7 +898,7 @@ fn Parser::list_item(
   let min = indent + marker_size + after_marker + ext_task_marker_size
   let blocks = []
   self.add_open_blocks(blocks)
-  (min, { before_marker, marker, after_marker, ext_task_marker, blocks })
+  (min, { before_marker, marker, after_marker, ext_task_marker, blocks, })
 }
 
 ///|
@@ -1040,7 +1046,7 @@ fn Parser::try_add_to_indented_code_block(
       let first = self.curr_line_last_char + 1
       let last = self.curr_line_last_char
       let code = self.curr_line_span(first~, last~)
-      let l = { pad: 0, code, is_blank: true }
+      let l = { pad: 0, code, is_blank: true, }
       ls.push(l)
       bs.push(CodeBlock(Indented(ls)))
     }
@@ -1048,7 +1054,7 @@ fn Parser::try_add_to_indented_code_block(
     let (pad, first) = self.accept_code_indent(count=4)
     let last = self.curr_line_last_char
     let is_blank = self.only_blanks()
-    let l = { pad, code: self.curr_line_span(first~, last~), is_blank }
+    let l = { pad, code: self.curr_line_span(first~, last~), is_blank, }
     ls.push(l)
     bs.push(CodeBlock(Indented(ls)))
   }
@@ -1066,7 +1072,7 @@ fn Parser::try_add_to_fenced_code_block(
       bs.push(CodeBlock(Fenced(f)))
       self.add_open_blocks(bs)
     }
-    { fence: { indent, fence, .. }, code: ls } as b => {
+    { fence: { indent, fence, .. }, code: ls, } as b => {
       let start = self.curr_char
       let last = self.curr_line_last_char
       match
@@ -1075,11 +1081,11 @@ fn Parser::try_add_to_fenced_code_block(
           let strip = @cmp.minimum(indent, self.curr_indent())
           let (pad, first) = self.accept_code_indent(count=strip)
           ls.push((pad, self.curr_line_span(first~, last~)))
-          bs.push(CodeBlock(Fenced({ ..b, code: ls })))
+          bs.push(CodeBlock(Fenced({ ..b, code: ls, })))
         }
         Close(first, _fence_last) => {
           let close = self.curr_line_span(first~, last~) // With layout
-          let fence = { ..b.fence, closing_fence: Some(close) }
+          let fence = { ..b.fence, closing_fence: Some(close), }
           bs.push(CodeBlock(Fenced({ ..b, fence, })))
         }
       }
@@ -1095,7 +1101,7 @@ fn Parser::try_add_to_html_block(
 ) -> Unit {
   match b.end_cond {
     None => {
-      bs.push(HtmlBlock({ ..b, end_cond: None }))
+      bs.push(HtmlBlock({ ..b, end_cond: None, }))
       self.add_open_blocks(bs)
     }
     Some(end_cond) => {
@@ -1105,10 +1111,12 @@ fn Parser::try_add_to_html_block(
       if LineType::html_block_end(self.i, end_cond~, last~, start~) {
         match end_cond {
           EndBlank7 | EndBlank =>
-            bs..push(HtmlBlock({ ..b, end_cond: None })).push(self.blank_line())
+            bs
+            ..push(HtmlBlock({ ..b, end_cond: None, }))
+            .push(self.blank_line())
           _ => {
             b.html.push(l)
-            bs.push(HtmlBlock({ html: b.html, end_cond: None }))
+            bs.push(HtmlBlock({ html: b.html, end_cond: None, }))
           }
         }
       } else {
@@ -1266,13 +1274,13 @@ fn Parser::try_add_to_list_item(
       let items = list.items
       guard! items.last() is Some(item)
       self.add_line(item.blocks)
-      bs.push(List({ ..list, items, last_blank: true }))
+      bs.push(List({ ..list, items, last_blank: true, }))
     }
     IndentedCodeBlockLine | ParagraphLine as ltype => {
       let items = list.items
       guard! items.last() is Some(item)
       if self.try_lazy_continuation(indent_start~, item.blocks) {
-        bs.push(List({ ..list, items, last_blank: false }))
+        bs.push(List({ ..list, items, last_blank: false, }))
       } else {
         self.close_list(list, bs)
         self.add_open_blocks_with_line_class(indent_start~, indent~, bs, ltype)
@@ -1406,7 +1414,7 @@ fn Parser::parse_block(self : Parser) -> (String, Node[Array[BlockStruct]]) {
         break
       }
     }
-    { v: bs, meta: meta() }
+    { v: bs, meta: meta(), }
   }
   (nl, blocks)
 }
@@ -1438,17 +1446,17 @@ fn Parser::block_struct_to_code_block(
         let last_line = last.pos
         let last_ccode = last.last
         let start = code[0].meta.loc
-        self.meta({ ..start, last_ccode, last_line })
+        self.meta({ ..start, last_ccode, last_line, })
       }
-      CodeBlock({ v: { layout, info_string, code }, meta })
+      CodeBlock({ v: { layout, info_string, code, }, meta, })
     }
-    Fenced({ fence, code: ls }) => {
+    Fenced({ fence, code: ls, }) => {
       let layout = {
         let opening_fence = self.layout_clean_raw_span(fence.opening_fence)
         let closing_fence = fence.closing_fence.map(fn(i) {
           self.layout_clean_raw_span(i)
         })
-        { indent: fence.indent, opening_fence, closing_fence }
+        { indent: fence.indent, opening_fence, closing_fence, }
       }
       let info_string = fence.info_string.map(fn(i) {
         self.clean_unesc_unref_span(i)
@@ -1466,11 +1474,11 @@ fn Parser::block_struct_to_code_block(
         }
         self.meta_of_spans(first~, last~)
       }
-      let cb = { layout: Fenced(layout), info_string, code }
+      let cb = { layout: Fenced(layout), info_string, code, }
       if self.exts && CodeBlock::is_math_block(info_string.map(fn(i) { i.v })) {
-        return ExtMathBlock({ v: cb, meta })
+        return ExtMathBlock({ v: cb, meta, })
       }
-      CodeBlock({ v: cb, meta })
+      CodeBlock({ v: cb, meta, })
     }
   }
 }
@@ -1478,16 +1486,16 @@ fn Parser::block_struct_to_code_block(
 ///|
 fn Parser::block_struct_to_heading(self : Parser, b : Heading) -> Block {
   match b {
-    Atx({ indent, level, after_open, heading, layout_after }) => {
+    Atx({ indent, level, after_open, heading, layout_after, }) => {
       let after_opening = {
         let first = after_open
         let last = heading.first - 1
-        self.layout_clean_raw_span1({ ..heading, first, last })
+        self.layout_clean_raw_span1({ ..heading, first, last, })
       }
       let closing = self.layout_clean_raw_span1(layout_after)
-      let layout = BlockHeadingLayout::Atx({ indent, after_opening, closing })
+      let layout = BlockHeadingLayout::Atx({ indent, after_opening, closing, })
       let meta = self.meta(
-        self.text_loc_of_span({ ..heading, first: after_open - level }),
+        self.text_loc_of_span({ ..heading, first: after_open - level, }),
       )
       let (_, inline) = self.parse_inline([heading])
       let id = if self.heading_auto_ids {
@@ -1495,9 +1503,9 @@ fn Parser::block_struct_to_heading(self : Parser, b : Heading) -> Block {
       } else {
         None
       }
-      Heading({ v: { layout, level, inline, id }, meta })
+      Heading({ v: { layout, level, inline, id, }, meta, })
     }
-    Setext({ level, heading_lines, underline }) => {
+    Setext({ level, heading_lines, underline, }) => {
       let ((leading_indent, trailing_blanks), inline) = self.parse_inline(
         heading_lines,
       )
@@ -1518,14 +1526,14 @@ fn Parser::block_struct_to_heading(self : Parser, b : Heading) -> Block {
         let last_line = u.pos
         let last_ccode = u.last
         let start = inline.meta().loc
-        self.meta({ ..start, last_ccode, last_line })
+        self.meta({ ..start, last_ccode, last_line, })
       }
       let id = if self.heading_auto_ids {
         Some(Auto(inline.id(buf=self.buf)))
       } else {
         None
       }
-      Heading({ v: { layout: Setext(layout), level, inline, id }, meta })
+      Heading({ v: { layout: Setext(layout), level, inline, id, }, meta, })
     }
   }
 }
@@ -1538,8 +1546,8 @@ fn Parser::block_struct_to_html_block(
   guard! b.html.last() is Some({ last: last_ccode, pos: last_line, .. })
   let lines = b.html.map(fn(i) { self.clean_raw_span(i) })
   let start_loc = lines.last().unwrap().meta.loc
-  let meta = self.meta({ ..start_loc, last_ccode, last_line })
-  HtmlBlock({ v: Seq::from_array(lines), meta })
+  let meta = self.meta({ ..start_loc, last_ccode, last_line, })
+  HtmlBlock({ v: Seq::from_array(lines), meta, })
 }
 
 ///|
@@ -1547,7 +1555,7 @@ fn Parser::block_struct_to_paragraph(self : Parser, par : Paragraph) -> Block {
   let (layout, inline) = self.parse_inline(par.lines)
   let (leading_indent, trailing_blanks) = layout
   let meta = inline.meta()
-  Paragraph({ v: { leading_indent, inline, trailing_blanks }, meta })
+  Paragraph({ v: { leading_indent, inline, trailing_blanks, }, meta, })
 }
 
 ///|
@@ -1556,8 +1564,8 @@ fn Parser::block_struct_to_thematic_break(
   indent : Indent,
   span : LineSpan,
 ) -> Block {
-  let { v: layout, meta } = self.clean_raw_span(span) // No layout because of loc
-  ThematicBreak({ v: { indent, layout }, meta })
+  let { v: layout, meta, } = self.clean_raw_span(span) // No layout because of loc
+  ThematicBreak({ v: { indent, layout, }, meta, })
 }
 
 ///|
@@ -1572,14 +1580,14 @@ fn Parser::block_struct_to_table(
     match rs {
       [.. rs, (row, blanks)] => {
         let meta = self.meta(self.text_loc_of_span(row))
-        let row1 = { ..row, first: row.first + 1, last: row.last }
+        let row1 = { ..row, first: row.first + 1, last: row.last, }
         let cols = self.parse_table_row(row1)
         let col_count = @cmp.maximum(col_count, cols.length())
         let (r, last_was_sep) = match Table::parse_sep_row(cols[:]) {
-          Some(seps) => ({ v: Sep(seps), meta }, true)
+          Some(seps) => ({ v: Sep(seps), meta, }, true)
           None => {
             let v = if last_was_sep { Header(cols) } else { Data(cols) }
-            ({ v, meta }, false)
+            ({ v, meta, }, false)
           }
         }
         acc.push((r, self.layout_clean_raw_span1(blanks)))
@@ -1591,7 +1599,7 @@ fn Parser::block_struct_to_table(
   }
   rows.rev_in_place()
   let meta = self.meta_of_spans(first~, last~)
-  ExtTable({ v: { indent, col_count, rows }, meta })
+  ExtTable({ v: { indent, col_count, rows, }, meta, })
 }
 
 ///|
@@ -1607,10 +1615,10 @@ fn Parser::block_struct_to_block_quote(
       let first = quote[0].meta()
       let last = quote.last().unwrap().meta()
       let meta = self.meta_of_metas(first~, last~)
-      Blocks({ v: quote, meta })
+      Blocks({ v: quote, meta, })
     }
   }
-  BlockQuote({ v: { indent, block }, meta: block.meta() })
+  BlockQuote({ v: { indent, block, }, meta: block.meta(), })
 }
 
 ///|
@@ -1628,7 +1636,7 @@ fn Parser::block_struct_to_footnote_definition(
     blocks => {
       let first = blocks[0].meta()
       let meta = self.meta_of_metas(first~, last~)
-      Blocks({ v: blocks, meta })
+      Blocks({ v: blocks, meta, })
     }
   }
   let loc = {
@@ -1636,10 +1644,10 @@ fn Parser::block_struct_to_footnote_definition(
     let lastloc = last.loc
     let loc = labelloc.span(lastloc)
     let first_ccode = loc.first_ccode - 1
-    { ..loc, first_ccode, first_line: loc.first_line }
+    { ..loc, first_ccode, first_line: loc.first_line, }
   }
   let footnote = {
-    v: { indent, label, defined_label, block },
+    v: { indent, label, defined_label, block, },
     meta: self.meta(loc),
   }
   if defined_label is Some(def) {
@@ -1704,7 +1712,7 @@ fn Parser::block_struct_to_list_item(
     [i] => i
     blocks => {
       let first = blocks[0].meta()
-      Blocks({ v: blocks, meta: self.meta_of_metas(first~, last=last_meta) })
+      Blocks({ v: blocks, meta: self.meta_of_metas(first~, last=last_meta), })
     }
   }
   let before_marker = i.before_marker
@@ -1714,9 +1722,9 @@ fn Parser::block_struct_to_list_item(
     v: v_span.0,
     meta: self.meta(self.text_loc_of_span(v_span.1)),
   })
-  let v = { before_marker, marker, after_marker, block, ext_task_marker }
+  let v = { before_marker, marker, after_marker, block, ext_task_marker, }
   let meta = self.meta_of_metas(first=marker.meta, last=last_meta)
-  ({ v, meta }, tight)
+  ({ v, meta, }, tight)
 }
 
 ///|
@@ -1735,7 +1743,7 @@ fn Parser::block_struct_to_list(self : Parser, list : ListBlockStruct) -> Block 
     }
   }
   let meta = self.meta_of_metas(first=first.meta, last=acc.last().unwrap().meta)
-  List({ v: { ty: list.list_type, tight, items: acc }, meta })
+  List({ v: { ty: list.list_type, tight, items: acc, }, meta, })
 }
 
 ///|
@@ -1762,9 +1770,9 @@ fn Parser::block_struct_to_doc(
   self : Parser,
   doc : Node[Array[BlockStruct]],
 ) -> Block {
-  let { v: doc, meta } = doc
+  let { v: doc, meta, } = doc
   match doc.map(fn(b) { self.block_struct_to_block(b) }) {
     [b] => b
-    bs => Blocks({ v: bs, meta })
+    bs => Blocks({ v: bs, meta, })
   }
 }

--- a/src/cmark/block_test.mbt
+++ b/src/cmark/block_test.mbt
@@ -199,7 +199,7 @@ test "block normalize with block quote" {
 /// Test Block::normalize for List with Seq.empty()
 test "block normalize with list using Seq.empty" {
   let items = @cmark.Seq::empty()
-  let list = @cmark.BlockList::{ ty: Unordered('*'), tight: true, items }
+  let list = @cmark.BlockList::{ ty: Unordered('*'), tight: true, items, }
   let normalized = @cmark.Block::List(@cmark.Node::new(list)).normalize()
   debug_inspect(
     normalized,

--- a/src/cmark/doc.mbt
+++ b/src/cmark/doc.mbt
@@ -12,7 +12,7 @@ pub fn Doc::new(
   defs? : LabelDefs = Map([]),
   block : Block,
 ) -> Doc {
-  { nl, block, defs }
+  { nl, block, defs, }
 }
 
 ///|

--- a/src/cmark/folder.mbt
+++ b/src/cmark/folder.mbt
@@ -63,7 +63,7 @@ pub fn[A] Folder::new(
   inline? : FolderFn[Inline, A] = Folder::none,
   block? : FolderFn[Block, A] = Folder::none,
 ) -> Folder[A] {
-  { inline_ext_default, block_ext_default, inline, block }
+  { inline_ext_default, block_ext_default, inline, block, }
 }
 
 ///|

--- a/src/cmark/inline.mbt
+++ b/src/cmark/inline.mbt
@@ -19,7 +19,7 @@ pub(all) enum Inline {
 
 ///|
 pub fn Inline::empty() -> Inline {
-  Inlines({ v: [], meta: Meta::none() })
+  Inlines({ v: [], meta: Meta::none(), })
 }
 
 ///|
@@ -73,18 +73,18 @@ pub fn Inline::normalize(self : Inline) -> Inline {
     | Text(_)
     | Inlines({ v: Seq([]), .. })
     | ExtMathSpan(_) as i => i
-    Image({ v: raw, meta }) =>
-      Image({ v: { ..raw, text: raw.text.normalize() }, meta })
-    Link({ v: raw, meta }) =>
-      Link({ v: { ..raw, text: raw.text.normalize() }, meta })
-    Emphasis({ v: raw, meta }) =>
-      Emphasis({ v: { ..raw, inline: raw.inline.normalize() }, meta })
-    StrongEmphasis({ v: raw, meta }) =>
-      StrongEmphasis({ v: { ..raw, inline: raw.inline.normalize() }, meta })
-    ExtStrikethrough({ v: raw, meta }) =>
-      ExtStrikethrough({ v: raw.0.normalize(), meta })
+    Image({ v: raw, meta, }) =>
+      Image({ v: { ..raw, text: raw.text.normalize(), }, meta, })
+    Link({ v: raw, meta, }) =>
+      Link({ v: { ..raw, text: raw.text.normalize(), }, meta, })
+    Emphasis({ v: raw, meta, }) =>
+      Emphasis({ v: { ..raw, inline: raw.inline.normalize(), }, meta, })
+    StrongEmphasis({ v: raw, meta, }) =>
+      StrongEmphasis({ v: { ..raw, inline: raw.inline.normalize(), }, meta, })
+    ExtStrikethrough({ v: raw, meta, }) =>
+      ExtStrikethrough({ v: raw.0.normalize(), meta, })
     Inlines({ v: Seq([i]), .. }) => i
-    Inlines({ v: Seq([i, .. is_]), meta }) => {
+    Inlines({ v: Seq([i, .. is_]), meta, }) => {
       let acc = [i.normalize()]
       let is_ = Array::from_iter(is_.iter())
       for ;; {
@@ -94,12 +94,12 @@ pub fn Inline::normalize(self : Inline) -> Inline {
             for i1 in is1.0.rev() {
               is_.push(i1)
             }
-          Text({ v: t1, meta: meta1 }) as i1 =>
+          Text({ v: t1, meta: meta1, }) as i1 =>
             match acc {
-              [.., Text({ v: t, meta })] =>
+              [.., Text({ v: t, meta, })] =>
                 acc[acc.length() - 1] = Text({
                   v: t + t1,
-                  meta: { ..meta, loc: meta.loc.span(meta1.loc) },
+                  meta: { ..meta, loc: meta.loc.span(meta1.loc), },
                 })
               _ => acc.push(i1.normalize())
             }
@@ -108,7 +108,7 @@ pub fn Inline::normalize(self : Inline) -> Inline {
       }
       match acc {
         [i] => i
-        is_ => Inlines({ v: is_, meta })
+        is_ => Inlines({ v: is_, meta, })
       }
     }
   }
@@ -221,7 +221,7 @@ pub(all) struct InlineAutolink {
 ///|
 pub fn InlineAutolink::new(link : StringNode) -> InlineAutolink {
   let raw_link = "<{$link.raw}>"
-  { is_email: !(@cmark_base.autolink_email(raw_link) is None), link }
+  { is_email: !(@cmark_base.autolink_email(raw_link) is None), link, }
 }
 
 ///|
@@ -237,7 +237,7 @@ pub fn InlineBreak::new(
   layout_after? : BlanksNode = layout_empty,
   ty : InlineBreakType,
 ) -> InlineBreak {
-  { layout_before, ty, layout_after }
+  { layout_before, ty, layout_after, }
 }
 
 ///|
@@ -258,7 +258,7 @@ pub fn InlineCodeSpan::new(
   backticks~ : Count,
   code_layout : Seq[Tight],
 ) -> InlineCodeSpan {
-  { backticks, code_layout }
+  { backticks, code_layout, }
 }
 
 ///|
@@ -287,7 +287,7 @@ pub fn InlineCodeSpan::from_string(
   s : String,
 ) -> InlineCodeSpan {
   if s.is_empty() {
-    return { backticks: 1, code_layout: [Tight::empty(meta~)] }
+    return { backticks: 1, code_layout: [Tight::empty(meta~)], }
   }
   // This finds out the needed backtick count, whether spaces are needed,
   // and treats blanks after newline as layout 
@@ -300,7 +300,7 @@ pub fn InlineCodeSpan::from_string(
     if k > max {
       // assert (btc = 0) because of [need_sp]
       let layout = if acc.is_empty() {
-        [{ blanks: "", node: { v: s, meta } }]
+        [{ blanks: "", node: { v: s, meta, }, }]
       } else {
         BlockLine::flush_tight(meta~, s, start, max, acc)
         acc
@@ -323,7 +323,7 @@ pub fn InlineCodeSpan::from_string(
     }
     continue 0, start, start
   }
-  { code_layout, backticks: InlineCodeSpan::min_backticks(min=1, bt_counts) }
+  { code_layout, backticks: InlineCodeSpan::min_backticks(min=1, bt_counts), }
 }
 
 ///|
@@ -350,7 +350,7 @@ pub fn InlineEmphasis::new(
   delim? : Char = '*',
   inline : Inline,
 ) -> InlineEmphasis {
-  { delim, inline }
+  { delim, inline, }
 }
 
 ///|
@@ -381,7 +381,7 @@ pub(all) enum ReferenceLayout {
 
 ///|
 pub fn InlineLink::new(text : Inline, reference : ReferenceKind) -> InlineLink {
-  { text, reference }
+  { text, reference, }
 }
 
 ///|

--- a/src/cmark/inline_struct.mbt
+++ b/src/cmark/inline_struct.mbt
@@ -157,8 +157,8 @@ fn make_closer_index(toks : Tokens) -> CloserIndex {
   toks.0.retain(fn(curr) {
     match curr {
       Backticks({ count, start, .. }) => cidx.add(Backticks(count), start)
-      RightBrack({ start }) => cidx.add(RightBrack, start)
-      RightParen({ start }) => {
+      RightBrack({ start, }) => cidx.add(RightBrack, start)
+      RightParen({ start, }) => {
         cidx.add(RightParen, start)
         return false // Discard the token since it's not used for parsing
       }
@@ -182,11 +182,11 @@ fn tokens_shorten_last_line(to_last~ : Int, toks : Tokens) -> Unit {
   for i = toks.0.length() - 1; i >= 0; i = i - 1 {
     match toks.0[i] {
       Newline({ newline, .. } as nl) => {
-        toks.0[i] = Newline({ ..nl, newline: { ..newline, last, } })
+        toks.0[i] = Newline({ ..nl, newline: { ..newline, last, }, })
         break
       }
       Inline({ endline, .. } as il) => {
-        toks.0[i] = Inline({ ..il, endline: { ..endline, last, } })
+        toks.0[i] = Inline({ ..il, endline: { ..endline, last, }, })
         break
       }
       _ => ()
@@ -249,7 +249,7 @@ fn Token::newline(
     let start = non_space + 1
     (start, if last - start + 1 >= 2 { Hard } else { Soft })
   }
-  Newline({ start, break_ty, newline })
+  Newline({ start, break_ty, newline, })
 }
 
 ///|
@@ -262,7 +262,7 @@ fn tokens_add_backtick(
 ) -> Int {
   let last = @cmark_base.run_of(char='`', s, last=line.last, start=start + 1)
   let count = last - start + 1
-  toks.push(Backticks({ start, count, escaped: prev_bslash }))
+  toks.push(Backticks({ start, count, escaped: prev_bslash, }))
   last + 1
 }
 
@@ -275,7 +275,7 @@ fn tokens_try_add_image_link_start(
 ) -> Int {
   let next = start + 1
   guard next <= line.last && s[next] == '[' else { next }
-  toks.push(LinkStart({ start, image: true }))
+  toks.push(LinkStart({ start, image: true, }))
   next + 1
 }
 
@@ -307,7 +307,7 @@ fn tokens_try_add_emphasis(
   let may_close = (char == '*' && is_right_flanking) ||
     (char == '_' && is_right_flanking && (!is_left_flanking || is_next_punct))
   guard may_open || may_close else { next }
-  toks.push(EmphasisMarks({ start, char, count, may_open, may_close }))
+  toks.push(EmphasisMarks({ start, char, count, may_open, may_close, }))
   next
 }
 
@@ -328,7 +328,7 @@ fn tokens_try_add_strikethrough_marks(
   let next_char = @char.next_char(s, last~, after=run_last)
   let may_open = !@char.is_ascii_whitespace(next_char)
   let may_close = !@char.is_ascii_whitespace(prev_char)
-  toks.push(StrikethroughMarks({ start, may_open, may_close }))
+  toks.push(StrikethroughMarks({ start, may_open, may_close, }))
   next
 }
 
@@ -354,7 +354,7 @@ fn tokens_try_add_math_span_marks(
     may_close = !@char.is_ascii_whitespace(prev_char)
   }
   guard may_open || may_close else { next }
-  toks.push(MathSpanMarks({ start, count, may_open, may_close }))
+  toks.push(MathSpanMarks({ start, count, may_open, may_close, }))
   next
 }
 
@@ -383,20 +383,20 @@ fn tokenize(
       _ if prev_bslash => k + 1
       '*' | '_' => tokens_try_add_emphasis(toks, s, line, start=k)
       ']' => {
-        toks.push(RightBrack({ start: k }))
+        toks.push(RightBrack({ start: k, }))
         k + 1
       }
       '[' => {
-        toks.push(LinkStart({ start: k, image: false }))
+        toks.push(LinkStart({ start: k, image: false, }))
         k + 1
       }
       '!' => tokens_try_add_image_link_start(toks, s, line, start=k)
       '<' => {
-        toks.push(AutolinkOrHtmlStart({ start: k }))
+        toks.push(AutolinkOrHtmlStart({ start: k, }))
         k + 1
       }
       ')' => {
-        toks.push(RightParen({ start: k }))
+        toks.push(RightParen({ start: k, }))
         k + 1
       }
       '~' if exts => tokens_try_add_strikethrough_marks(toks, s, line, start=k)
@@ -418,15 +418,15 @@ fn Parser::break_inline(
   break_ty~ : InlineBreakType,
   newline~ : LineSpan,
 ) -> Inline {
-  let layout_before = { ..line, first: start }
+  let layout_before = { ..line, first: start, }
   let layout_after = {
     let non_blank = self.first_non_blank_in_span(newline)
-    { ..newline, last: non_blank - 1 }
+    { ..newline, last: non_blank - 1, }
   }
   let m = self.meta_of_spans(first=layout_before, last=layout_after)
   let layout_before = self.layout_clean_raw_span(layout_before)
   let layout_after = self.layout_clean_raw_span(layout_after)
-  Break({ v: { ty: break_ty, layout_before, layout_after }, meta: m })
+  Break({ v: { ty: break_ty, layout_before, layout_after, }, meta: m, })
 }
 
 ///|
@@ -444,7 +444,7 @@ fn Parser::try_add_text_inline(
   if first == line.first {
     first = self.first_non_blank_in_span(line) // Strip leading blanks
   }
-  acc.push(Text(self.clean_unesc_unref_span({ ..line, first, last })))
+  acc.push(Text(self.clean_unesc_unref_span({ ..line, first, last, })))
 }
 
 ///|
@@ -465,7 +465,7 @@ fn Parser::inlines_inline(
         first_line~,
         last_line~,
       )
-      Inlines({ v: is_, meta: self.meta(text_loc) })
+      Inlines({ v: is_, meta: self.meta(text_loc), })
     }
   }
 }
@@ -483,8 +483,8 @@ fn Parser::code_span_token(
   let text_loc = self.text_loc_of_lines(first~, last~, first_line~, last_line~)
   let code_layout = self.raw_tight_block_lines(spans~)
   let meta = self.meta(text_loc)
-  let cs = CodeSpan({ v: { backticks: count, code_layout }, meta })
-  Inline({ start: first, inline: cs, endline: last_line, next: last + 1 })
+  let cs = CodeSpan({ v: { backticks: count, code_layout, }, meta, })
+  Inline({ start: first, inline: cs, endline: last_line, next: last + 1, })
 }
 
 ///|
@@ -495,11 +495,11 @@ fn Parser::autolink_token(
   last~ : Int,
   is_email~ : Bool,
 ) -> Token {
-  let meta = self.meta(self.text_loc_of_span({ ..line, first, last }))
-  let link = { ..line, first: first + 1, last: last - 1 }
+  let meta = self.meta(self.text_loc_of_span({ ..line, first, last, }))
+  let link = { ..line, first: first + 1, last: last - 1, }
   let link = self.clean_unref_span(link)
-  let inline = Autolink({ v: { link, is_email }, meta })
-  Inline({ start: first, inline, endline: line, next: last + 1 })
+  let inline = Autolink({ v: { link, is_email, }, meta, })
+  Inline({ start: first, inline, endline: line, next: last + 1, })
 }
 
 ///|
@@ -516,10 +516,10 @@ fn Parser::raw_html_token(
   let text_loc = {
     let first = raw[0].node.meta.loc
     let { last: last_ccode, pos: last_line, .. } = spans[spans.length() - 1].span
-    { ..first, last_ccode, last_line }
+    { ..first, last_ccode, last_line, }
   }
-  let inline = RawHtml({ v: raw, meta: self.meta(text_loc) })
-  Inline({ start: first, inline, endline: last_line, next: last + 1 })
+  let inline = RawHtml({ v: raw, meta: self.meta(text_loc), })
+  Inline({ start: first, inline, endline: last_line, next: last + 1, })
 }
 
 ///|
@@ -533,9 +533,9 @@ fn Parser::link_token(
   link : InlineLink,
 ) -> Token {
   let text_loc = self.text_loc_of_lines(first~, last~, first_line~, last_line~)
-  let link = { v: link, meta: self.meta(text_loc) }
+  let link = { v: link, meta: self.meta(text_loc), }
   let inline : Inline = if image { Image(link) } else { Link(link) }
-  Inline({ start: first, inline, endline: last_line, next: last + 1 })
+  Inline({ start: first, inline, endline: last_line, next: last + 1, })
 }
 
 ///|
@@ -550,9 +550,9 @@ fn Parser::emphasis_token(
 ) -> Token {
   let text_loc = self.text_loc_of_lines(first~, last~, first_line~, last_line~)
   let delim = self.i[first].unsafe_to_char()
-  let emph = { v: { delim, inline: emph }, meta: self.meta(text_loc) }
+  let emph = { v: { delim, inline: emph, }, meta: self.meta(text_loc), }
   let inline = if strong { StrongEmphasis(emph) } else { Emphasis(emph) }
-  Inline({ start: first, inline, endline: last_line, next: last + 1 })
+  Inline({ start: first, inline, endline: last_line, next: last + 1, })
 }
 
 ///|
@@ -565,8 +565,8 @@ fn Parser::ext_strikethough_token(
   s : Inline,
 ) -> Token {
   let text_loc = self.text_loc_of_lines(first~, last~, first_line~, last_line~)
-  let inline = ExtStrikethrough({ v: s, meta: self.meta(text_loc) })
-  Inline({ start: first, inline, endline: last_line, next: last + 1 })
+  let inline = ExtStrikethrough({ v: s, meta: self.meta(text_loc), })
+  Inline({ start: first, inline, endline: last_line, next: last + 1, })
 }
 
 ///|
@@ -582,9 +582,9 @@ fn Parser::ext_math_span_token(
   let textloc = self.text_loc_of_lines(first~, last~, first_line~, last_line~)
   let tex_layout = self.raw_tight_block_lines(spans~)
   let meta = self.meta(textloc)
-  let ms = { display: count == 2, tex_layout }
-  let inline = ExtMathSpan({ v: ms, meta })
-  Inline({ start: first, inline, endline: last_line, next: last + 1 })
+  let ms = { display: count == 2, tex_layout, }
+  let inline = ExtMathSpan({ v: ms, meta, })
+  Inline({ start: first, inline, endline: last_line, next: last + 1, })
 }
 
 // Parsers
@@ -615,7 +615,7 @@ fn Parser::try_code(
         guard c == count else { continue }
         let span : Span = {
           start: line.first,
-          span: { ..line, first: k, last: start - 1 },
+          span: { ..line, first: k, last: start - 1, },
         }
         spans.push(span)
         let t = self.code_span_token(
@@ -629,7 +629,7 @@ fn Parser::try_code(
         return Some((line, t))
       }
       Some(Newline({ newline, .. })) => {
-        let span : Span = { start: line.first, span: { ..line, first: k } }
+        let span : Span = { start: line.first, span: { ..line, first: k, }, }
         spans.push(span)
         k = self.first_non_blank_in_span(newline)
         line = newline
@@ -665,7 +665,7 @@ fn Parser::try_math_span(
         guard c == count && may_close else { continue }
         let span : Span = {
           start: line.first,
-          span: { ..line, first: k, last: start - 1 },
+          span: { ..line, first: k, last: start - 1, },
         }
         spans.push(span)
         let t = self.ext_math_span_token(
@@ -679,7 +679,7 @@ fn Parser::try_math_span(
         return Some((line, t))
       }
       Some(Newline({ newline, .. })) => {
-        let span : Span = { start: line.first, span: { ..line, first: k } }
+        let span : Span = { start: line.first, span: { ..line, first: k, }, }
         spans.push(span)
         k = self.first_non_blank_in_span(newline)
         line = newline
@@ -740,7 +740,7 @@ fn Parser::label_of_spans(
     self.meta_of_spans(first=spans[0].span, last=spans[spans.length() - 1].span)
   }
   let text = self.tight_block_lines(spans~)
-  { meta, key, text }
+  { meta, key, text, }
 }
 
 ///|
@@ -854,7 +854,7 @@ fn Parser::try_inline_link_remainder(
     @cmark_base.link_destination(self.i, last=line.last, start~) {
     None => (line, false, None, start)
     Some((angled, first, last)) => {
-      let dest = self.clean_unesc_unref_span({ ..line, first, last })
+      let dest = self.clean_unesc_unref_span({ ..line, first, last, })
       let next = last + 1 + angled.to_int()
       (line, angled, Some(dest), next)
     }
@@ -915,14 +915,14 @@ fn Parser::try_inline_link_remainder(
   }
   let label = None
   let defined_label = None
-  let ld : LinkDefinition = { layout, label, defined_label, dest, title }
+  let ld : LinkDefinition = { layout, label, defined_label, dest, title, }
   let textloc = self.text_loc_of_lines(
     first=st,
     last=start,
     first_line=start_line,
     last_line=line,
   )
-  let ld = { v: ld, meta: self.meta(textloc) }
+  let ld = { v: ld, meta: self.meta(textloc), }
   tokens_pop_until(start=last + 1, rev_toks.val)
   Some((line, Inline(ld), last))
 }
@@ -944,11 +944,11 @@ fn Parser::find_link_text_tokens(
   let old_rev_toks = rev_toks.val.0.copy()
   for ;; {
     match (rev_toks.val.pop(), nest) {
-      (Some(RightBrack({ start: last })), 0) => {
+      (Some(RightBrack({ start: last, })), 0) => {
         tokens_shorten_last_line(to_last=last - 1, acc)
         return Some((line, acc, last))
       }
-      (Some(Backticks({ start, count, escaped })), _) =>
+      (Some(Backticks({ start, count, escaped, })), _) =>
         if self.try_code(rev_toks, line, start~, count~, escaped~)
           is Some((line_, t)) {
           line = line_
@@ -962,7 +962,7 @@ fn Parser::find_link_text_tokens(
         line = line_
         acc.push(t)
       }
-      (Some(AutolinkOrHtmlStart({ start })), _) => {
+      (Some(AutolinkOrHtmlStart({ start, })), _) => {
         guard self.try_autolink_or_html(rev_toks, line, start~)
           is Some((line_, t)) else {
           continue
@@ -1061,7 +1061,7 @@ fn Parser::try_link_def(
     last_line=line,
     text,
   )
-  let link : InlineLink = { text, reference }
+  let link : InlineLink = { text, reference, }
   let t = self.link_token(
     first~,
     last~,
@@ -1108,7 +1108,7 @@ fn Parser::try_link(
       } else {
         start_line.last
       }
-      { ..start_line, first, last }
+      { ..start_line, first, last, }
     },
   )
   if had_link && !image {
@@ -1145,7 +1145,7 @@ fn Parser::first_pass(
   let rev_toks : Ref[RevTokens] = Ref(toks.val.0)
   while rev_toks.val.pop() is Some(t) {
     match t {
-      Backticks({ start, count, escaped }) =>
+      Backticks({ start, count, escaped, }) =>
         if self.try_code(rev_toks, line, start~, count~, escaped~)
           is Some((line_, t)) {
           line = line_
@@ -1159,12 +1159,12 @@ fn Parser::first_pass(
         line = line_
         acc.push(t)
       }
-      AutolinkOrHtmlStart({ start }) =>
+      AutolinkOrHtmlStart({ start, }) =>
         if self.try_autolink_or_html(rev_toks, line, start~) is Some((line_, t)) {
           line = line_
           acc.push(t)
         }
-      LinkStart({ start, image }) =>
+      LinkStart({ start, image, }) =>
         if self.try_link(rev_toks, line, image~, start~)
           is Some((l, t, had_link_)) {
           acc.push(t)
@@ -1271,7 +1271,7 @@ fn Parser::try_emphasis(
   let last_line = line
   let emph = {
     let last = if start_line == line { text_last } else { start_line.last }
-    let text_start = { ..start_line, first: text_first, last }
+    let text_start = { ..start_line, first: text_first, last, }
     let emph_toks : Ref[Tokens] = Ref(emph_toks)
     self.second_pass(emph_toks, text_start)
     let text = self.last_pass(emph_toks.val, text_start)
@@ -1279,7 +1279,7 @@ fn Parser::try_emphasis(
   }
   let count = closer.count - used
   if count != 0 {
-    rev_toks.val.push(EmphasisMarks({ ..closer, start: last + 1, count }))
+    rev_toks.val.push(EmphasisMarks({ ..closer, start: last + 1, count, }))
   }
   let emph = self.emphasis_token(
     first~,
@@ -1357,7 +1357,7 @@ fn Parser::try_strikethrough(
     let last = closer.start - 1
     let text_start = {
       let last = if start_line == line { last } else { start_line.last }
-      { ..start_line, first, last }
+      { ..start_line, first, last, }
     }
     let emph_toks : Ref[Tokens] = Ref(stricken_toks)
     self.second_pass(emph_toks, text_start)
@@ -1424,14 +1424,14 @@ fn Parser::last_pass(
   let mut k = line.first
   for tok in toks.0 {
     match tok {
-      Newline({ start, break_ty, newline }) => {
+      Newline({ start, break_ty, newline, }) => {
         self.try_add_text_inline(line, first=k, last=start - 1, acc)
         let break_ = self.break_inline(line, start~, break_ty~, newline~)
         line = newline
         acc.push(break_)
         k = newline.first
       }
-      Inline({ start, inline, endline, next }) => {
+      Inline({ start, inline, endline, next, }) => {
         self.try_add_text_inline(line, first=k, last=start - 1, acc)
         match inline {
           Inlines({ v: is_, .. }) => acc.push_iter(is_.iter())
@@ -1469,7 +1469,7 @@ fn Parser::strip_paragraph(
     guard! lines.pop() is Some(line)
     let { first, last: start, .. } = line
     let non_blank = @cmark_base.last_non_blank(self.i, first~, start~)
-    let last = { ..line, last: non_blank }
+    let last = { ..line, last: non_blank, }
     let trailing_blanks = self.layout_clean_raw_span1({
       ..line,
       first: non_blank + 1,
@@ -1480,7 +1480,7 @@ fn Parser::strip_paragraph(
   let (first, leading_indent) = {
     let line = lines[0]
     let non_blank = self.first_non_blank_in_span(line)
-    let first = { ..line, first: non_blank }
+    let first = { ..line, first: non_blank, }
     let leading_indent = non_blank - line.first
     (first, leading_indent)
   }
@@ -1499,7 +1499,7 @@ fn Parser::parse_inline(
   let (is_, _) = self.parse_tokens(toks, first_line)
   let inline = match is_ {
     [i] => i
-    _ => Inlines({ v: is_, meta })
+    _ => Inlines({ v: is_, meta, })
   }
   (layout, inline)
 }
@@ -1514,7 +1514,7 @@ fn Parser::get_blanks(
   k : CharCodePos,
 ) -> (String, CharCodePos) {
   let nb = @cmark_base.first_non_blank(self.i, last=before - 1, start=k)
-  let line = { ..line, first: k, last: nb - 1 }
+  let line = { ..line, first: k, last: nb - 1, }
   (self.layout_clean_raw_span1(line), nb)
 }
 
@@ -1527,7 +1527,7 @@ fn Parser::make_col(self : Parser, is_ : Array[Inline]) -> Inline {
       let first = is_[0].meta()
       let last = is_[is_.length() - 1].meta()
       let meta = self.meta_of_metas(first~, last~)
-      Inlines({ v: is_, meta })
+      Inlines({ v: is_, meta, })
     }
   }
 }
@@ -1540,7 +1540,7 @@ fn Parser::find_pipe(
   k : CharCodePos,
 ) -> Result[(Inline?, String, Col), Inline] {
   fn text(first, last) {
-    let line = { ..line, first, last }
+    let line = { ..line, first, last, }
     Text(self.clean_unesc_unref_span(line))
   }
 
@@ -1554,7 +1554,11 @@ fn Parser::find_pipe(
     return Err(text(k, n - 1))
   }
   let nb = @cmark_base.last_non_blank(self.i, first=k, start=n - 1)
-  let after = self.layout_clean_raw_span1({ ..line, first: nb + 1, last: n - 1 })
+  let after = self.layout_clean_raw_span1({
+    ..line,
+    first: nb + 1,
+    last: n - 1,
+  })
   let text = if nb < k { None } else { Some(text(k, nb)) }
   Ok((text, after, n + 1))
 }
@@ -1574,8 +1578,8 @@ fn Parser::start_col(
     Err(text) => Start(bbefore, [text])
     Ok((text, bafter, k)) => {
       let text = text.unwrap_or_else(fn() {
-        let l = self.text_loc_of_span({ ..line, first: k, last: k - 1 })
-        Inlines({ v: [], meta: self.meta(l) })
+        let l = self.text_loc_of_span({ ..line, first: k, last: k - 1, })
+        Inlines({ v: [], meta: self.meta(l), })
       })
       Col((text, (bbefore, bafter)), k)
     }

--- a/src/cmark/inline_test.mbt
+++ b/src/cmark/inline_test.mbt
@@ -17,7 +17,7 @@ test "Inline::is_empty checks if inline content is empty" {
   let meta = @cmark_base.Meta::none()
 
   // Test empty inlines list
-  let empty_inlines = @cmark.Inline::Inlines({ v: @cmark.Seq::empty(), meta })
+  let empty_inlines = @cmark.Inline::Inlines({ v: @cmark.Seq::empty(), meta, })
   debug_inspect(empty_inlines.is_empty(), content="true")
 
   // Test non-empty inlines list
@@ -99,7 +99,7 @@ test "inline id with text containing backticks" {
     @cmark.Node::new({
       backticks: 1,
       code_layout: @cmark.Seq::from_array([
-        { blanks: "", node: @cmark.Node::new("`text`") },
+        { blanks: "", node: @cmark.Node::new("`text`"), },
       ]),
     }),
   )
@@ -154,7 +154,7 @@ test "Inline::normalize with Emphasis type" {
   // Create a nested Text inside Emphasis
   let text = @cmark.Inline::Text(@cmark.Node::new("emphasized text", meta~))
   let emphasis = @cmark.Inline::Emphasis(
-    @cmark.Node::new({ delim: '*', inline: text }, meta~),
+    @cmark.Node::new({ delim: '*', inline: text, }, meta~),
   )
 
   // Normalize and check result
@@ -207,7 +207,7 @@ test "Inline::normalize with StrongEmphasis type" {
   // Create a nested Text inside StrongEmphasis
   let text = @cmark.Inline::Text(@cmark.Node::new("strong text", meta~))
   let strong = @cmark.Inline::StrongEmphasis(
-    @cmark.Node::new({ delim: '*', inline: text }, meta~),
+    @cmark.Node::new({ delim: '*', inline: text, }, meta~),
   )
 
   // Normalize and check result
@@ -304,7 +304,7 @@ test "Inline::normalize with Link type" {
   let text = @cmark.Inline::Text(@cmark.Node::new("link text", meta~))
   let link_def = @cmark.Node::new(@cmark.LinkDefinition::new(), meta~)
   let reference = @cmark.ReferenceKind::Inline(link_def)
-  let link = @cmark.Inline::Link(@cmark.Node::new({ text, reference }, meta~))
+  let link = @cmark.Inline::Link(@cmark.Node::new({ text, reference, }, meta~))
 
   // Normalize should recursively normalize the link's text
   let normalized = link.normalize()
@@ -639,14 +639,14 @@ test "Inline::to_plain_text with emphasis and strong emphasis" {
 
   // Test with Emphasis
   let emphasis = @cmark.Inline::Emphasis(
-    @cmark.Node::new({ delim: '*', inline: text }, meta~),
+    @cmark.Node::new({ delim: '*', inline: text, }, meta~),
   )
   let emphasis_result = emphasis.to_plain_text(break_on_soft=false)
   debug_inspect(emphasis_result.length(), content="1")
 
   // Test with StrongEmphasis
   let strong = @cmark.Inline::StrongEmphasis(
-    @cmark.Node::new({ delim: '*', inline: text }, meta~),
+    @cmark.Node::new({ delim: '*', inline: text, }, meta~),
   )
   let strong_result = strong.to_plain_text(break_on_soft=false)
   debug_inspect(strong_result.length(), content="1")
@@ -669,7 +669,7 @@ test "Inline::to_plain_text with inlines and link" {
   let link_def = @cmark.Node::new(@cmark.LinkDefinition::new(), meta~)
   let reference = @cmark.ReferenceKind::Inline(link_def)
   let link = @cmark.Inline::Link(
-    @cmark.Node::new({ text: text1, reference }, meta~),
+    @cmark.Node::new({ text: text1, reference, }, meta~),
   )
   let link_result = link.to_plain_text(break_on_soft=false)
   debug_inspect(link_result.length(), content="1")
@@ -699,10 +699,13 @@ test "Inline::to_plain_text with math span" {
   let meta = @cmark_base.Meta::none()
 
   // Test with MathSpan
-  let tight = @cmark.Tight::{ blanks: "", node: @cmark.Node::new("x^2", meta~) }
+  let tight = @cmark.Tight::{
+    blanks: "",
+    node: @cmark.Node::new("x^2", meta~),
+  }
   let tex_layout = @cmark.Seq::from_array([tight])
   let math_span = @cmark.Inline::ExtMathSpan(
-    @cmark.Node::new({ display: false, tex_layout }, meta~),
+    @cmark.Node::new({ display: false, tex_layout, }, meta~),
   )
   let math_result = math_span.to_plain_text(break_on_soft=false)
   debug_inspect(math_result.length(), content="1")
@@ -717,14 +720,14 @@ test "Inline::to_plain_text with image" {
   let link_def = @cmark.Node::new(@cmark.LinkDefinition::new(), meta~)
   let reference = @cmark.ReferenceKind::Inline(link_def)
   let image = @cmark.Inline::Image(
-    @cmark.Node::new({ text: badge, reference }, meta~),
+    @cmark.Node::new({ text: badge, reference, }, meta~),
   )
   let image_result = image.to_plain_text(break_on_soft=false)
   debug_inspect(image_result[0][0], content="\"badge\"")
 
   // Test with image nested in a link: `[![badge](badge.svg)](target)`
   let link = @cmark.Inline::Link(
-    @cmark.Node::new({ text: image, reference }, meta~),
+    @cmark.Node::new({ text: image, reference, }, meta~),
   )
   let link_result = link.to_plain_text(break_on_soft=false)
   debug_inspect(link_result[0][0], content="\"badge\"")

--- a/src/cmark/label.mbt
+++ b/src/cmark/label.mbt
@@ -24,7 +24,7 @@ pub fn Label::new(
   key~ : String,
   text : Seq[Tight],
 ) -> Label {
-  { meta, key, text }
+  { meta, key, text, }
 }
 
 ///|

--- a/src/cmark/layout.mbt
+++ b/src/cmark/layout.mbt
@@ -1,6 +1,6 @@
 ///|
 pub fn layout_of_string(meta? : Meta = Meta::none(), s : String) -> StringNode {
-  { meta, v: s }
+  { meta, v: s, }
 }
 
 ///|

--- a/src/cmark/link_definition.mbt
+++ b/src/cmark/link_definition.mbt
@@ -19,7 +19,7 @@ pub fn LinkDefinition::new(
   dest? : StringNode? = None,
   title? : Seq[Tight]? = None,
 ) -> LinkDefinition {
-  { layout, label, defined_label, dest, title }
+  { layout, label, defined_label, dest, title, }
 }
 
 ///|

--- a/src/cmark/mapper.mbt
+++ b/src/cmark/mapper.mbt
@@ -75,7 +75,7 @@ pub fn Mapper::new(
   inline? : MapperFn[Inline] = Mapper::none,
   block? : MapperFn[Block] = Mapper::none,
 ) -> Mapper {
-  { inline_ext_default, block_ext_default, inline, block }
+  { inline_ext_default, block_ext_default, inline, block, }
 }
 
 ///|
@@ -90,30 +90,30 @@ pub fn Mapper::map_inline(self : Mapper, i : Inline) -> Inline? {
     | RawHtml(_)
     | Text(_)
     | ExtMathSpan(_) => Some(i)
-    Image({ v, meta }) => {
+    Image({ v, meta, }) => {
       let text = self.map_inline(v.text).unwrap_or(Inline::empty())
-      Some(Image({ v: { ..v, text, }, meta }))
+      Some(Image({ v: { ..v, text, }, meta, }))
     }
-    Link({ v, meta }) => {
+    Link({ v, meta, }) => {
       guard self.map_inline(v.text) is Some(text) else { None }
-      Some(Link({ v: { ..v, text, }, meta }))
+      Some(Link({ v: { ..v, text, }, meta, }))
     }
-    Emphasis({ v, meta }) => {
+    Emphasis({ v, meta, }) => {
       guard self.map_inline(v.inline) is Some(inline) else { None }
-      Some(Emphasis({ v: { ..v, inline, }, meta }))
+      Some(Emphasis({ v: { ..v, inline, }, meta, }))
     }
-    StrongEmphasis({ v, meta }) => {
+    StrongEmphasis({ v, meta, }) => {
       guard self.map_inline(v.inline) is Some(inline) else { None }
-      Some(StrongEmphasis({ v: { ..v, inline, }, meta }))
+      Some(StrongEmphasis({ v: { ..v, inline, }, meta, }))
     }
-    Inlines({ v, meta }) => {
+    Inlines({ v, meta, }) => {
       let v = v.0.filter_map(fn(x) { self.map_inline(x) })
       guard !v.is_empty() else { None }
-      Some(Inlines({ v, meta }))
+      Some(Inlines({ v, meta, }))
     }
-    ExtStrikethrough({ v, meta }) => {
+    ExtStrikethrough({ v, meta, }) => {
       guard self.map_inline(v.0) is Some(v) else { None }
-      Some(ExtStrikethrough({ v, meta }))
+      Some(ExtStrikethrough({ v, meta, }))
     }
     // ext => (self.inline_ext_default)(self, ext)
   }
@@ -131,66 +131,66 @@ pub fn Mapper::map_block(self : Mapper, b : Block) -> Block? {
     | LinkRefDefinition(_)
     | ThematicBreak(_)
     | ExtMathBlock(_) as b => Some(b)
-    Heading({ v, meta }) => {
+    Heading({ v, meta, }) => {
       let inline = self
         .map_inline(v.inline)
-        .unwrap_or(Inlines({ v: [], meta: Meta::none() }))
-      Some(Heading({ v: { ..v, inline, }, meta }))
+        .unwrap_or(Inlines({ v: [], meta: Meta::none(), }))
+      Some(Heading({ v: { ..v, inline, }, meta, }))
     }
-    BlockQuote({ v, meta }) => {
+    BlockQuote({ v, meta, }) => {
       let block = self
         .map_block(v.block)
-        .unwrap_or(Blocks({ v: [], meta: Meta::none() }))
-      Some(BlockQuote({ v: { ..v, block, }, meta }))
+        .unwrap_or(Blocks({ v: [], meta: Meta::none(), }))
+      Some(BlockQuote({ v: { ..v, block, }, meta, }))
     }
-    Blocks({ v, meta }) =>
+    Blocks({ v, meta, }) =>
       match v.0.filter_map(fn(x) { self.map_block(x) }) {
         [] => None
-        v => Some(Blocks({ v, meta }))
+        v => Some(Blocks({ v, meta, }))
       }
-    List({ v, meta }) => {
+    List({ v, meta, }) => {
       fn map_list_item(i : Node[ListItem]) {
-        let { v, meta } = i
+        let { v, meta, } = i
         guard self.map_block(i.v.block) is Some(block) else { None }
-        Some({ v: { ..v, block, }, meta })
+        Some({ v: { ..v, block, }, meta, })
       }
 
       match v.items.0.filter_map(map_list_item) {
         [] => None
-        items => Some(List({ v: { ..v, items, }, meta }))
+        items => Some(List({ v: { ..v, items, }, meta, }))
       }
     }
-    Paragraph({ v, meta }) => {
+    Paragraph({ v, meta, }) => {
       guard self.map_inline(v.inline) is Some(inline) else { None }
-      Some(Paragraph({ v: { ..v, inline, }, meta }))
+      Some(Paragraph({ v: { ..v, inline, }, meta, }))
     }
-    ExtFootnoteDefinition({ v, meta }) => {
+    ExtFootnoteDefinition({ v, meta, }) => {
       let block = self
         .map_block(v.block)
         .unwrap_or_else(fn() { Blocks(Node::new([])) }) // Can be empty
-      Some(ExtFootnoteDefinition({ v: { ..v, block, }, meta }))
+      Some(ExtFootnoteDefinition({ v: { ..v, block, }, meta, }))
     }
-    ExtTable({ v, meta }) => {
+    ExtTable({ v, meta, }) => {
       fn map_col(i, layout) {
         self.map_inline(i).map(fn(i) { (i, layout) })
       }
 
       fn map_row(row) {
-        let ({ v, meta }, blanks) = row
+        let ({ v, meta, }, blanks) = row
         match v {
           Header(is_) => {
             let is_ = is_.0.filter_map(fn(i) { map_col(i.0, i.1) })
-            ({ v: Header(is_), meta }, blanks)
+            ({ v: Header(is_), meta, }, blanks)
           }
           Sep(_) => row
           Data(is_) => {
             let is_ = is_.0.filter_map(fn(i) { map_col(i.0, i.1) })
-            ({ v: Data(is_), meta }, blanks)
+            ({ v: Data(is_), meta, }, blanks)
           }
         }
       }
 
-      Some(ExtTable({ v: { ..v, rows: v.rows.map(map_row) }, meta }))
+      Some(ExtTable({ v: { ..v, rows: v.rows.map(map_row), }, meta, }))
     }
     // ext => (self.block_ext_default)(self, ext)
   }
@@ -200,14 +200,14 @@ pub fn Mapper::map_block(self : Mapper, b : Block) -> Block? {
 pub fn Mapper::map_doc(self : Mapper, d : Doc) -> Doc {
   let map_block = fn(b) { self.map_block(b).unwrap_or(Block::empty()) }
   let map_def = fn(b : LabelDef) {
-    guard b is FootnoteDef({ v, meta }) else { b }
+    guard b is FootnoteDef({ v, meta, }) else { b }
     let block = map_block(v.block)
-    FootnoteDef({ v: { ..v, block, }, meta })
+    FootnoteDef({ v: { ..v, block, }, meta, })
   }
   let block = map_block(d.block)
   let defs = Map::Map([])
   for k, d in d.defs {
     defs[k] = map_def(d)
   }
-  { ..d, block, defs }
+  { ..d, block, defs, }
 }

--- a/src/cmark/mapper_test.mbt
+++ b/src/cmark/mapper_test.mbt
@@ -56,7 +56,7 @@ test "map_inline with StrongEmphasis" {
   let mapper = @cmark.Mapper::new()
   let text = @cmark.Inline::Text(@cmark.Node::new("strongly emphasized text"))
   let strong = @cmark.Inline::StrongEmphasis(
-    @cmark.Node::new({ delim: '*', inline: text }),
+    @cmark.Node::new({ delim: '*', inline: text, }),
   )
   let result = mapper.map_inline(strong)
   debug_inspect(
@@ -114,7 +114,7 @@ test "map_inline with StrongEmphasis returns None when inner inline is None" {
   let mapper = @cmark.Mapper::new(inline=inline_fn)
   let text = @cmark.Inline::Text(@cmark.Node::new("strongly emphasized text"))
   let strong = @cmark.Inline::StrongEmphasis(
-    @cmark.Node::new({ delim: '*', inline: text }),
+    @cmark.Node::new({ delim: '*', inline: text, }),
   )
   let result = mapper.map_inline(strong)
   debug_inspect(result, content="None")
@@ -126,7 +126,7 @@ test "map_inline with Emphasis" {
   let text = @cmark.Inline::Text(@cmark.Node::new("emphasized text"))
   // Create Emphasis with the correct structure
   let emphasis = @cmark.Inline::Emphasis(
-    @cmark.Node::new({ delim: '*', inline: text }),
+    @cmark.Node::new({ delim: '*', inline: text, }),
   )
   let result = mapper.map_inline(emphasis)
   debug_inspect(
@@ -184,7 +184,7 @@ test "map_inline with Emphasis returns None when inner text is None" {
   let mapper = @cmark.Mapper::new(inline=inline_fn)
   let text = @cmark.Inline::Text(@cmark.Node::new("emphasized text"))
   let emphasis = @cmark.Inline::Emphasis(
-    @cmark.Node::new({ delim: '*', inline: text }),
+    @cmark.Node::new({ delim: '*', inline: text, }),
   )
   let result = mapper.map_inline(emphasis)
   debug_inspect(result, content="None")
@@ -654,7 +654,7 @@ test "map_inline with Emphasis (2)" {
   let text = @cmark.Inline::Text(@cmark.Node::new("emphasized text"))
   // Create Emphasis with the correct structure
   let emphasis = @cmark.Inline::Emphasis(
-    @cmark.Node::new({ delim: '*', inline: text }),
+    @cmark.Node::new({ delim: '*', inline: text, }),
   )
   let result = mapper.map_inline(emphasis)
   debug_inspect(
@@ -950,7 +950,7 @@ test "map_block with BlockQuote" {
     }),
   )
   let blockquote = @cmark.Block::BlockQuote(
-    @cmark.Node::new({ indent: 0, block: para }),
+    @cmark.Node::new({ indent: 0, block: para, }),
   )
   let result = mapper.map_block(blockquote)
   debug_inspect(

--- a/src/cmark/node.mbt
+++ b/src/cmark/node.mbt
@@ -6,12 +6,12 @@ pub(all) struct Node[A] {
 
 ///|
 pub fn[A] Node::new(v : A, meta? : Meta = Meta::none()) -> Node[A] {
-  { v, meta }
+  { v, meta, }
 }
 
 ///|
 pub fn[A, B] Node::map(self : Node[A], f : (A) -> B) -> Node[B] {
-  { v: f(self.v), meta: self.meta }
+  { v: f(self.v), meta: self.meta, }
 }
 
 ///|
@@ -22,5 +22,5 @@ pub type BlanksNode = Node[Blanks]
 
 ///|
 pub fn StringNode::empty(meta? : Meta = Meta::none()) -> StringNode {
-  { v: "", meta }
+  { v: "", meta, }
 }

--- a/src/cmark/parser.mbt
+++ b/src/cmark/parser.mbt
@@ -111,7 +111,7 @@ fn Parser::curr_line_span(
   first~ : CharCodePos,
   last~ : CharCodePos,
 ) -> LineSpan {
-  { first, last, pos: self.curr_line_pos }
+  { first, last, pos: self.curr_line_pos, }
 }
 
 // Making metas and text locations. This is centralized here to be able
@@ -293,8 +293,8 @@ fn Parser::_tight_block_lines(
   for i, span in spans {
     match (span, i) {
       ({ span: fst_ln, .. }, 0) =>
-        acc.push({ blanks: "", node: f(self, fst_ln) })
-      ({ start: line_start, span }, _) => {
+        acc.push({ blanks: "", node: f(self, fst_ln), })
+      ({ start: line_start, span, }, _) => {
         let layout = if self.no_layouts || span.first <= line_start {
           ""
         } else {
@@ -305,7 +305,7 @@ fn Parser::_tight_block_lines(
             last=span.first - 1,
           )
         }
-        acc.push({ blanks: layout, node: f(self, span) })
+        acc.push({ blanks: layout, node: f(self, span), })
       }
     }
   }
@@ -341,13 +341,13 @@ fn[A] Parser::first_non_blank_over_nl(
       let layout = if nb == start {
         []
       } else {
-        [self.clean_raw_span({ ..line, first: start, last: nb - 1 })]
+        [self.clean_raw_span({ ..line, first: start, last: nb - 1, })]
       }
       Some((line, layout, nb))
     }
     Some(NextLine(newline, nb)) => {
-      let first_layout = self.clean_raw_span({ ..line, first: start })
-      let next_layout = self.clean_raw_span({ ..newline, last: nb - 1 })
+      let first_layout = self.clean_raw_span({ ..line, first: start, })
+      let next_layout = self.clean_raw_span({ ..newline, last: nb - 1, })
       let layout = [first_layout, next_layout]
       Some((newline, layout, nb))
     }

--- a/src/cmark_base/leaf_blocks.mbt
+++ b/src/cmark_base/leaf_blocks.mbt
@@ -328,7 +328,7 @@ fn LineType::html_block_start_7_open_tag(
   start~ : CharCodePos,
 ) -> LineType {
   // Has to be on the same line we fake one and use the inline parser
-  let line = { pos: line_pos_none, first: start, last }
+  let line = { pos: line_pos_none, first: start, last, }
   guard open_tag(next_line=fn(_x) { None }, s, (), line~, start~)
     is Some((_, _, tag_end)) else {
     Nomatch
@@ -347,7 +347,7 @@ fn LineType::html_block_start_7_close_tag(
   last~ : CharCodePos,
   start~ : CharCodePos,
 ) -> LineType {
-  let line = { pos: line_pos_none, first: start, last }
+  let line = { pos: line_pos_none, first: start, last, }
   guard closing_tag(next_line=fn(_x) { None }, s, (), line~, start~)
     is Some((_, _, tag_end)) else {
     Nomatch
@@ -502,7 +502,7 @@ pub fn LineType::ext_footnote_label(
     Nomatch
   }
   // Get the normalized label
-  let line = { pos: line_pos, first: start, last }
+  let line = { pos: line_pos, first: start, last, }
   guard link_label(buf, next_line=fn(_x) { None }, s, (), line~, start~)
     is Some((_, spans, _, key)) else {
     Nomatch

--- a/src/cmark_base/meta.mbt
+++ b/src/cmark_base/meta.mbt
@@ -13,7 +13,7 @@ let curr_id : Ref[MetaId] = Ref(0)
 
 ///|
 pub fn Meta::new(loc? : TextLoc = text_loc_none) -> Meta {
-  let res = { loc, id: curr_id.val, extra: None }
+  let res = { loc, id: curr_id.val, extra: None, }
   curr_id.val += 1
   res
 }

--- a/src/cmark_base/raw_html.mbt
+++ b/src/cmark_base/raw_html.mbt
@@ -129,8 +129,8 @@ fn[A] open_tag(
     None
   }
   let start = tag_name_end + 1
-  let span = { ..line, first: tag_start, last: tag_name_end }
-  let spans = Ref([{ start: tag_start, span }])
+  let span = { ..line, first: tag_start, last: tag_name_end, }
+  let spans = Ref([{ start: tag_start, span, }])
   for line = line, start = start {
     guard first_non_blank_over_nl1(
         next_line~,
@@ -186,8 +186,8 @@ fn[A] closing_tag(
   guard tag_name(s, last=line.last, start=start + 2) is Some(tag_name_end) else {
     return None
   }
-  let span = { ..line, first: start, last: tag_name_end }
-  let spans = Ref([{ start: tag_start, span }])
+  let span = { ..line, first: start, last: tag_name_end, }
+  let spans = Ref([{ start: tag_start, span, }])
   let start = tag_name_end + 1
   guard first_non_blank_over_nl1(next_line~, s, lines, line~, spans.val, start~)
     is Some((line, last_blank)) else {

--- a/src/cmark_base/runs.mbt
+++ b/src/cmark_base/runs.mbt
@@ -77,16 +77,19 @@ fn push_span(
   let first1 = first
   let last1 = last
   // Merge if on the same line
-  if spans is [.., { start, span: { pos, first, .. } }] {
+  if spans is [.., { start, span: { pos, first, .. }, }] {
     if line.pos.0 == pos.0 {
       spans[spans.length() - 1] = {
         start,
-        span: { ..line, first, last: last1 },
+        span: { ..line, first, last: last1, },
       }
       return
     }
   }
-  spans.push({ start: line.first, span: { ..line, first: first1, last: last1 } })
+  spans.push({
+    start: line.first,
+    span: { ..line, first: first1, last: last1, },
+  })
 }
 
 ///|
@@ -184,12 +187,12 @@ fn[A] first_non_blank_over_nl1(
   match first_non_blank_over_nl(next_line~, s, lines, line~, start~) {
     None => None
     Some(ThisLine(nb)) => {
-      let line = { ..line, first: start } // No layout
+      let line = { ..line, first: start, } // No layout
       push_span(line~, start, nb - 1, spans)
       Some((line, nb - 1))
     }
     Some(NextLine(new_line, nb)) => {
-      let line = { ..line, first: start } // No layout
+      let line = { ..line, first: start, } // No layout
       push_span(line~, start, line.last, spans)
       Some((new_line, nb - 1))
     }

--- a/src/cmark_base/text_loc.mbt
+++ b/src/cmark_base/text_loc.mbt
@@ -33,12 +33,12 @@ pub fn TextLoc::is_empty(self : TextLoc) -> Bool {
 
 ///|
 pub fn TextLoc::to_first(self : TextLoc) -> TextLoc {
-  { ..self, last_ccode: self.first_ccode, last_line: self.first_line }
+  { ..self, last_ccode: self.first_ccode, last_line: self.first_line, }
 }
 
 ///|
 pub fn TextLoc::to_last(self : TextLoc) -> TextLoc {
-  { ..self, first_ccode: self.last_ccode, first_line: self.last_line }
+  { ..self, first_ccode: self.last_ccode, first_line: self.last_line, }
 }
 
 ///|
@@ -64,14 +64,14 @@ pub fn TextLoc::span(self : TextLoc, other : TextLoc) -> TextLoc {
   ) {
     it.last_ccode
   })
-  { file, first_ccode, last_ccode, first_line, last_line }
+  { file, first_ccode, last_ccode, first_line, last_line, }
 }
 
 ///|
 pub fn TextLoc::reloc(self : TextLoc, other : TextLoc) -> TextLoc {
   let { first_ccode, first_line, .. } = self
   let { file, last_ccode, last_line, .. } = other
-  { file, first_ccode, last_ccode, first_line, last_line }
+  { file, first_ccode, last_ccode, first_line, last_line, }
 }
 
 // TODO: Formatters unimplemented

--- a/src/cmark_base/text_loc_test.mbt
+++ b/src/cmark_base/text_loc_test.mbt
@@ -7,14 +7,14 @@ test "TextLoc::is_none with none value" {
 ///|
 test "TextLoc::is_empty for non-empty location" {
   let loc = @cmark_base.TextLoc::none()
-  let loc = { ..loc, first_ccode: 10, last_ccode: 5 }
+  let loc = { ..loc, first_ccode: 10, last_ccode: 5, }
   debug_inspect(loc.is_empty(), content="true")
 }
 
 ///|
 test "TextLoc::is_empty for empty location" {
   let loc = @cmark_base.TextLoc::none()
-  let loc = { ..loc, first_ccode: 5, last_ccode: 10 }
+  let loc = { ..loc, first_ccode: 5, last_ccode: 10, }
   debug_inspect(loc.is_empty(), content="false")
 }
 

--- a/src/cmark_html/html.mbt
+++ b/src/cmark_html/html.mbt
@@ -118,7 +118,7 @@ fn make_footnote_ref_ids(
     st.footnote_count = footnote_count
     let text = "[\{footnote_count}]"
     let id = footnote_id(label)
-    footnotes[label] = { text, id, count: 1, footnote: f }
+    footnotes[label] = { text, id, count: 1, footnote: f, }
     (text, id, footnote_ref_id(id, 1))
   }
   rf.count += 1
@@ -382,7 +382,7 @@ fn link_dest_and_title(
       }
   }
   let title = ld.title.map(fn(title) {
-    { iter: title.iter().map(fn(t) { t.node.v }), sep: "\n" }
+    { iter: title.iter().map(fn(t) { t.node.v }), sep: "\n", }
   })
   (dest, title)
 }
@@ -397,7 +397,7 @@ fn image(c : Context, i : @cmark.InlineLink, close? : String = " >") -> Unit {
       c.b.write_string("\" alt=\"")
       let lines = i.text.to_plain_text(break_on_soft=false)
       for line in lines {
-        let joined = { iter: line.iter(), sep: "\n" }
+        let joined = { iter: line.iter(), sep: "\n", }
         joined_string(c, joined)
       }
       c.b.write_char('"')

--- a/src/cmark_renderer/renderer.mbt
+++ b/src/cmark_renderer/renderer.mbt
@@ -16,7 +16,7 @@ pub fn Renderer::new(
   block? : BlockFn = fn(_c, _b) { false },
   doc? : DocFn = fn(_c, _d) { false },
 ) -> Renderer {
-  { init_context, inline, block, doc }
+  { init_context, inline, block, doc, }
 }
 
 ///|
@@ -28,7 +28,7 @@ pub fn Renderer::compose(self : Renderer, other : Renderer) -> Renderer {
   let block = fn(c, b) raise { (other.block)(c, b) || (self.block)(c, b) }
   let inline = fn(c, i) raise { (other.inline)(c, i) || (self.inline)(c, i) }
   let doc = fn(c, d) raise { (other.doc)(c, d) || (self.doc)(c, d) }
-  { init_context, inline, block, doc }
+  { init_context, inline, block, doc, }
 }
 
 ///|
@@ -45,7 +45,7 @@ pub(all) struct Context {
 
 ///|
 pub fn Context::new(renderer : Renderer, b : StringBuilder) -> Context {
-  { renderer, state: None, b, doc: Doc::empty() }
+  { renderer, state: None, b, doc: Doc::empty(), }
 }
 
 ///|


### PR DESCRIPTION
## Summary

- format the repository with the current `moon fmt`
- establish a clean formatting baseline before rebasing #129

This PR is intentionally formatting-only. The previous CloserIndex optimization has been removed so the performance work and formatter churn can be reviewed independently.

## Validation

- `moon check --warn-list +73` — 0 errors
- `moon test` — 368 passed, 0 failed
- `moon info` — no generated interface changes
- `moon fmt` — clean after a second run
- `git diff --check`
